### PR TITLE
Add MKP Server to Cloud Platforms & Services section

### DIFF
--- a/docs/cloud-platforms--services.md
+++ b/docs/cloud-platforms--services.md
@@ -48,6 +48,7 @@ Servers integrating with major cloud providers or specific cloud services.
 - [CefBoud/kafka-mcp-server](https://github.com/CefBoud/kafka-mcp-server): Integrates Apache Kafka with natural language processing capabilities via the Model Context Protocol, enabling seamless interaction with Kafka clusters.
 - [ArchBlizzard/mcp-server](https://github.com/ArchBlizzard/mcp-server): Connects Claude AI with ElevenLabs for seamless voice-enabled conversations.
 - [yamanoku/baseline-mcp-server](https://github.com/yamanoku/baseline-mcp-server): Provides the baseline status of Web Platform API features using the Web Platform Dashboard API, facilitating integration with various AI models.
+- [StacklokLabs/mkp](https://github.com/StacklokLabs/mkp): Model Kontext Protocol Server for Kubernetes that allows LLM-powered applications to interact with Kubernetes clusters through native Go implementation with direct API integration and comprehensive resource management.
 - [kunwu/aliyun-manager-mcp](https://github.com/kunwu/aliyun-manager-mcp): Manage and monitor Alibaba Cloud resources with tools for ECS instance tracking and billing analysis via the MCP interface.
 - [Chenastron/remote-mcp-server](https://github.com/Chenastron/remote-mcp-server): Deploy a remote MCP server on Cloudflare Workers with OAuth login, enabling seamless integration with Claude Desktop and MCP Inspector.
 - [devilMing/yapi-mcp-server](https://github.com/devilMing/yapi-mcp-server): Facilitates access to YAPI interface details through a Model Context Protocol server.


### PR DESCRIPTION
Add MKP (Model Kontext Protocol Server for Kubernetes) to the Cloud Platforms & Services section.

MKP is a native Go implementation that allows LLM-powered applications to interact with Kubernetes clusters through direct API integration, providing comprehensive resource management capabilities including:

- List resources supported by the Kubernetes API server
- List clustered and namespaced resources  
- Get resources and their subresources (including status, scale, logs, etc.)
- Apply (create or update) clustered and namespaced resources
- Execute commands in pods with timeout control
- Generic and pluggable implementation using API Machinery's unstructured client
- Built-in rate limiting for protection against excessive API calls

Repository: https://github.com/StacklokLabs/mkp