### PR TITLE
Adding consul mcp server

### DIFF
--- a/README.md
+++ b/README.md
@@ -730,6 +730,7 @@ Servers or systems that deliver core runtime functionalities for MCP, such as pr
 - [koudaiDemon/mcp-server-hand](https://github.com/koudaiDemon/mcp-server-hand): Enhances user shopping experiences by analyzing conversations to provide personalized product recommendations through intelligent tag matching.
 - [Humboldtian/remote-mcp-server](https://github.com/Humboldtian/remote-mcp-server): Deploy a remote MCP server on Cloudflare Workers with OAuth login and connect it to Claude Desktop for seamless tool integration.
 - [mcpjungle/MCPJungle](https://github.com/mcpjungle/MCPJungle): Self-hosted MCP Registry and Gateway for AI Agents
+- [kswap/consul-mcp](https://github.com/kswap/consul-mcp): Facilitates Consul service discovery and mesh integration through an MCP server interface.
 
 ## 🧠 Knowledge Management & Memory
 

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -152,4 +152,5 @@ Servers or systems that deliver core runtime functionalities for MCP, such as pr
 - [metoro-io/metoro-mcp-server](https://github.com/metoro-io/metoro-mcp-server): Facilitates interaction with Kubernetes clusters via the Claude Desktop App, leveraging eBPF-based telemetry for deep observability.
 - [Flux159/mcp-server-kubernetes](https://github.com/Flux159/mcp-server-kubernetes): Facilitates Kubernetes cluster management through a robust MCP server, enabling seamless interaction with Kubernetes resources and Helm charts.
 - [netcaster1/e2b-mcp](https://github.com/netcaster1/e2b-mcp): A secure sandbox environment for executing code using the Model Context Protocol, tailored for integration with Claude Desktop.
+- [kswap/consul-mcp](https://github.com/kswap/consul-mcp): Facilitates Consul service discovery and mesh integration through an MCP server interface.
 


### PR DESCRIPTION
Adding mcp server server support for interacting with HashiCorp Consul service discovery and service mesh. This implementation follows Anthropic's MCP specification and connects AI agents to your Consul infrastructure, allowing you to manage and analyze your services using natural language.