### PR TITLE
Add FinBrain MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,7 @@ Servers focused on interacting with local or remote file systems for reading, wr
 
 Servers dealing with financial data, stock markets, cryptocurrency exchanges/data, trading bots, banking APIs, accounting software, or blockchain interactions.
 
+- [ahmetsbilgin/finbrain-mcp](https://github.com/ahmetsbilgin/finbrain-mcp): Access institutional-grade alternative financial data directly in your LLM workflows.
 - [ccassini/DEVNADS-Monad-TESNET-MCP-Tools](https://github.com/ccassini/DEVNADS-Monad-TESNET-MCP-Tools): Interact with the Monad blockchain testnet using a Model Context Protocol server for wallet management, network insights, and token operations.
 - [SheriffOladejo/mcp-monad](https://github.com/SheriffOladejo/mcp-monad): Facilitates querying MON token balances on the Monad testnet via an MCP server.
 - [letsbonk-ai/bonk-mcp](https://github.com/letsbonk-ai/bonk-mcp): Facilitates token launching and trading on the LetsBonk platform using Solana blockchain capabilities.


### PR DESCRIPTION
## Description

Adding FinBrain MCP Server - access institutional-grade alternative financial data directly in LLM workflows.

## Server Details

- **Name:** FinBrain MCP
- **GitHub Repo:** https://github.com/ahmetsbilgin/finbrain-mcp
- **Docs:** https://finbrain.tech/integrations/mcp/
- **Category:** Finance & Crypto

## Features

- AI-powered price predictions with daily (10-day) and monthly (12-month) horizons
- News sentiment analysis for any ticker
- Congressional trading data (House & Senate disclosures)
- Insider transactions (SEC Form 4 filings)
- Analyst ratings and price target changes
- Alternative data: LinkedIn metrics, app store ratings, options put/call ratios

## Tools Provided

- `predictions_by_market`, `predictions_by_ticker` - ML price forecasts with 95% confidence intervals
- `news_sentiment_by_ticker` - Aggregated sentiment scores from financial news
- `house_trades_by_ticker`, `senate_trades_by_ticker` - Congressional stock transactions
- `insider_transactions_by_ticker` - Executive buys and sells
- `analyst_ratings_by_ticker` - Wall Street coverage and ratings
- `linkedin_metrics_by_ticker` - Employee and follower trends
- `app_ratings_by_ticker` - Mobile app performance data
- `options_put_call` - Put/call ratios and volume
- `available_markets`, `available_tickers` - Discovery endpoints
- `health` - Server status check
