### PR TITLE
Add TrainingPeaks MCP to Sports section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1132,6 +1132,7 @@ Servers interacting with social networks, content platforms, or feed aggregators
 Servers providing access to sports-related APIs and analysis.
 
 - [dhrbtjr0331/nba-stats-predictor-mcp](https://github.com/dhrbtjr0331/nba-stats-predictor-mcp): Generates NBA player performance forecasts using real-time data analysis and advanced statistical modeling.
+- [JamsusMaximus/trainingpeaks-mcp](https://github.com/JamsusMaximus/trainingpeaks-mcp): Accesses TrainingPeaks training data including fitness metrics (CTL/ATL/TSB), workout history, and power/pace personal records for endurance athletes.
 - [henryco23/NBA](https://github.com/henryco23/NBA): A Python server utilizing MCP to provide comprehensive access to NBA statistics and live game data through the NBA API.
 - [yeonupark/mcp-soccer-data](https://github.com/yeonupark/mcp-soccer-data): Delivers real-time football match data through natural language interactions using the SoccerDataAPI.
 - [guillochon/mlb-api-mcp](https://github.com/guillochon/mlb-api-mcp): A Python MCP server that acts as a proxy to the freely available MLB API, which provides player info, stats, and game information.

--- a/docs/sport.md
+++ b/docs/sport.md
@@ -3,6 +3,7 @@
 Servers providing access to sports-related APIs and analysis.
 
 - [dhrbtjr0331/nba-stats-predictor-mcp](https://github.com/dhrbtjr0331/nba-stats-predictor-mcp): Generates NBA player performance forecasts using real-time data analysis and advanced statistical modeling.
+- [JamsusMaximus/trainingpeaks-mcp](https://github.com/JamsusMaximus/trainingpeaks-mcp): Accesses TrainingPeaks training data including fitness metrics (CTL/ATL/TSB), workout history, and power/pace personal records for endurance athletes.
 - [henryco23/NBA](https://github.com/henryco23/NBA): A Python server utilizing MCP to provide comprehensive access to NBA statistics and live game data through the NBA API.
 - [yeonupark/mcp-soccer-data](https://github.com/yeonupark/mcp-soccer-data): Delivers real-time football match data through natural language interactions using the SoccerDataAPI.
 - [guillochon/mlb-api-mcp](https://github.com/guillochon/mlb-api-mcp): A Python MCP server that acts as a proxy to the freely available MLB API, which provides player info, stats, and game information.


### PR DESCRIPTION
## Summary

Adds [TrainingPeaks MCP](https://github.com/JamsusMaximus/trainingpeaks-mcp) to the Sports section.

**TrainingPeaks MCP** enables AI assistants to access endurance athlete training data:
- Training data and workout history (up to 90 days)
- Fitness metrics: CTL (Chronic Training Load), ATL (Acute Training Load), TSB (Training Stress Balance)
- Historical fitness data for any date range
- Power and pace personal records across all-time training history

This complements existing sports servers (NBA, soccer, MLB) with endurance training analytics.

## Links

- Repository: https://github.com/JamsusMaximus/trainingpeaks-mcp
- MIT licensed
- Python-based with full MCP 1.0 support