### PR TITLE
Add PraisonAI to Frameworks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,8 @@ Servers dealing with financial data, stock markets, cryptocurrency exchanges/dat
 
 ## 🧰 Frameworks
 
+- [MervinPraison/praisonai-mcp](https://github.com/MervinPraison/praisonai-mcp): An AI Agents framework providing 64+ built-in MCP tools for search, memory management, workflow orchestration, code execution, and file operations. Install via uvx praisonai-mcp.
+
 Toolkits, SDKs, starter templates, or code frameworks designed to help developers easily build MCP-compliant servers or applications.
 
 - [johnhenry/hackernews-mcp](https://github.com/johnhenry/hackernews-mcp): A template for creating new MCP servers with features like sandboxed JavaScript execution and debug logging.
@@ -1241,5 +1243,6 @@ Servers interacting with version control systems and platforms for repository ma
 - [KarakuriAgent/karakuri_git_mcp](https://github.com/KarakuriAgent/karakuri_git_mcp): Facilitates Git repository interaction and automation through a Model Context Protocol server, enabling operations like reading, searching, and manipulating repositories via Large Language Models.
 - [kwanLeeFrmVi/mcp-git](https://github.com/kwanLeeFrmVi/mcp-git): Facilitates Git repository interaction and automation through a Model Context Protocol server, enabling operations like reading, searching, and manipulating repositories via Large Language Models.
 - [rahul-roy-glean/github-mcp-server](https://github.com/rahul-roy-glean/github-mcp-server): Facilitates seamless integration with GitHub's API for file operations, repository management, and search functionalities within CI workflows.
+
 
 


### PR DESCRIPTION
## Summary
Add PraisonAI MCP Server to the Frameworks section.

## About PraisonAI
- **GitHub**: https://github.com/MervinPraison/praisonai-mcp
- **PyPI**: https://pypi.org/project/praisonai-mcp/

## Features
PraisonAI MCP Server provides 64+ built-in tools including:
- Agent execution tools (run_agent, run_research, run_auto_agents)
- Web search tools (Tavily, DuckDuckGo, Wikipedia, arXiv)  
- Memory management (add, search, auto-extract)
- Code execution (Python, shell, git)
- File operations (read, write, directory listing)

## Installation
```bash
uvx praisonai-mcp
```