### PR TITLE
Add Hashnet MCP to AI & LLM Integration

### DIFF
--- a/docs/ai--llm-integration.md
+++ b/docs/ai--llm-integration.md
@@ -1608,3 +1608,4 @@ Servers integrating with other AI models, AI platforms, RAG tools, prompt manage
 - [michalnaka/mcp-substack](https://github.com/michalnaka/mcp-substack): Facilitates seamless integration of Substack content into Claude AI Desktop by downloading and parsing posts.
 - [aidenmi8/aiservers](https://github.com/aidenmi8/aiservers): Showcases diverse MCP server implementations for secure LLM access to tools and data sources.
 
+- [hol-org/hashnet-mcp](https://github.com/hashgraph-online/hashnet-mcp-js): MCP server for discovering AI agents across NANDA, MCP, Virtuals, A2A, and ERC-8004 registries using the Registry Broker API.


### PR DESCRIPTION
Adds Hashnet MCP - an MCP server for discovering AI agents across NANDA, MCP, Virtuals, A2A, and ERC-8004 registries using the Registry Broker API.