### PR TITLE
Add AgentFund to Finance & Crypto

### DIFF
--- a/docs/finance--crypto.md
+++ b/docs/finance--crypto.md
@@ -2,6 +2,7 @@
 
 Servers dealing with financial data, stock markets, cryptocurrency exchanges/data, trading bots, banking APIs, accounting software, or blockchain interactions.
 
+- [RioTheGreat-ai/agentfund-mcp](https://github.com/RioTheGreat-ai/agentfund-mcp): Crowdfunding for AI agents with milestone-based escrow on Base chain. Create funding proposals, track projects, receive payments.
 - [trayders/trayd-mcp](https://github.com/trayders/trayd-mcp): Trade Robinhood stocks through natural language in Claude Code, with portfolio analysis, real-time quotes, and order execution.
 - [ccassini/DEVNADS-Monad-TESNET-MCP-Tools](https://github.com/ccassini/DEVNADS-Monad-TESNET-MCP-Tools): Interact with the Monad blockchain testnet using a Model Context Protocol server for wallet management, network insights, and token operations.
 - [SheriffOladejo/mcp-monad](https://github.com/SheriffOladejo/mcp-monad): Facilitates querying MON token balances on the Monad testnet via an MCP server.


### PR DESCRIPTION
## Added

AgentFund - Crowdfunding platform for AI agents with milestone-based escrow on Base chain.

## Why Finance & Crypto

AgentFund enables:
- AI agents to create crowdfunding proposals
- Milestone-based payment releases
- On-chain escrow via smart contract

First MCP server for agent crowdfunding!

## Links

- **GitHub**: https://github.com/RioTheGreat-ai/agentfund-mcp
- **Contract**: https://basescan.org/address/0x6a4420f696c9ba6997f41dddc15b938b54aa009a