### PR TITLE
Add Agent OS MCP server to Security category

### DIFF
--- a/README.md
+++ b/README.md
@@ -1098,6 +1098,7 @@ Servers interacting with security tools and platforms, vulnerability databases, 
 - [stoyky/mitre-attack-mcp](https://github.com/stoyky/mitre-attack-mcp): Facilitates querying and visualizing the MITRE ATT&CK knowledge base, enabling threat actor and malware attribution through a Model-Context Protocol server.
 - [stevenyu113228/BloodHound-MCP](https://github.com/stevenyu113228/BloodHound-MCP): BloodHound MCP enables LLMs to interact with and analyze Active Directory environments using natural language queries, enhancing the BloodHound tool's capabilities.
 - [Ludok-4/Ghidra](https://github.com/Ludok-4/Ghidra): ghidraMCP enables LLMs to autonomously reverse engineer applications by integrating Ghidra's decompilation and analysis tools with MCP clients.
+- [imran-siddique/agent-os](https://github.com/imran-siddique/agent-os): Kernel-level governance MCP server for AI agents — enforces deterministic policies (tool filtering, budget caps, rate limits, audit logging) instead of prompt-based guardrails. Part of microsoft/agent-lightning (14k★). Run via `npx agentos-mcp-server`.
 
 ## 📱 Social Media & Content Platforms
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -99,4 +99,5 @@ Servers interacting with security tools and platforms, vulnerability databases, 
 - [alexgoller/illumio-mcp-server](https://github.com/alexgoller/illumio-mcp-server): Enables programmatic interaction with Illumio PCE for workload management, label operations, and traffic flow analysis.
 - [Sladey01/github-snyk-server](https://github.com/Sladey01/github-snyk-server): Integrates GitHub repository access with Snyk security scanning for enhanced vulnerability analysis in Claude.
 - [fr0gger/MCP_Security](https://github.com/fr0gger/MCP_Security): A Model Context Protocol server for querying the ORKL API, providing tools for threat intelligence analysis and integration with MCP-compatible applications.
+- [imran-siddique/agent-os](https://github.com/imran-siddique/agent-os): Kernel-level governance MCP server for AI agents — enforces deterministic policies (tool filtering, budget caps, rate limits, audit logging) instead of prompt-based guardrails. Part of microsoft/agent-lightning (14k★). Run via `npx agentos-mcp-server`.
 


### PR DESCRIPTION
## What is Agent OS?

[Agent OS](https://github.com/imran-siddique/agent-os) provides a **kernel-level governance MCP server for AI agents** — enforces deterministic policies (tool filtering, budget caps, rate limits, audit logging) instead of prompt-based guardrails.

### Why it belongs in Security

Agent OS is an MCP server that provides **agent governance and security** — hard constraints on agent behavior at the protocol level. It fits naturally in the Security category alongside tools like \mcp-guardrail\ and \Secure-Coding-MCP\.

### Key facts

- **GitHub:** [imran-siddique/agent-os](https://github.com/imran-siddique/agent-os) (40+ ⭐, MIT license)
- **MCP server:** \
px agentos-mcp-server\
- **PyPI:** \pip install agent-os-kernel\
- **Merged into [microsoft/agent-lightning](https://github.com/microsoft/agent-lightning/pull/478)** (14k★)
- **Featured in [awesome-llm-apps](https://github.com/Shubhamsaboo/awesome-llm-apps)** (92k★)

### Changes

- Added entry to \docs/security.md\ (full list)
- Added entry to \README.md\ Security section (recent 30)