### PR TITLE
Add BGPT MCP API to Science & Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -1001,6 +1001,7 @@ Servers integrating with project management and task tracking tools.
 
 Servers accessing scientific databases, research platforms, or providing tools for scientific computation/simulation.
 
+- [connerlambden/bgpt-mcp](https://github.com/connerlambden/bgpt-mcp): Search scientific papers with structured experimental data extracted from full-text studies, returning 25+ fields per paper including methods, results, sample sizes, and quality scores.
 - [GreatApo/concrete-properties-mcp](https://github.com/GreatApo/concrete-properties-mcp): Facilitates AI-driven analysis of reinforced concrete sections by providing a unified API interface for calculating geometric and material properties.
 - [GooTec/NCBI-MCP](https://github.com/GooTec/NCBI-MCP): Facilitates access to NCBI Datasets through a modular MCP server with OpenAPI-driven endpoints for genome, gene, and taxonomy data.
 - [leelasd/molecule_mcp](https://github.com/leelasd/molecule_mcp): Facilitates chemistry-focused applications by visualizing molecules and retrieving molecular properties using SMILES codes, integrated with LLMs like Claude Desktop.

--- a/docs/science--research.md
+++ b/docs/science--research.md
@@ -2,6 +2,7 @@
 
 Servers accessing scientific databases, research platforms, or providing tools for scientific computation/simulation.
 
+- [connerlambden/bgpt-mcp](https://github.com/connerlambden/bgpt-mcp): Search scientific papers with structured experimental data extracted from full-text studies, returning 25+ fields per paper including methods, results, sample sizes, and quality scores.
 - [GreatApo/concrete-properties-mcp](https://github.com/GreatApo/concrete-properties-mcp): Facilitates AI-driven analysis of reinforced concrete sections by providing a unified API interface for calculating geometric and material properties.
 - [GooTec/NCBI-MCP](https://github.com/GooTec/NCBI-MCP): Facilitates access to NCBI Datasets through a modular MCP server with OpenAPI-driven endpoints for genome, gene, and taxonomy data.
 - [leelasd/molecule_mcp](https://github.com/leelasd/molecule_mcp): Facilitates chemistry-focused applications by visualizing molecules and retrieving molecular properties using SMILES codes, integrated with LLMs like Claude Desktop.


### PR DESCRIPTION
## Summary
- Adds [BGPT MCP API](https://github.com/connerlambden/bgpt-mcp) to the Science & Research category
- Search scientific papers with structured experimental data extracted from full-text studies
- Returns 25+ fields per paper (methods, results, sample sizes, limitations, conflicts of interest, quality scores)
- SSE transport, 50 free searches then $0.01/result
- Website: https://bgpt.pro/mcp
- Official MCP Registry: `io.github.connerlambden/bgpt-mcp`

## Changes
- `docs/science--research.md`: Added entry at the top of the list
- `README.md`: Added entry to the Science & Research section