### PR TITLE
Add SuperLocalMemory V2 to Knowledge Management & Memory

### DIFF
--- a/docs/knowledge-management--memory.md
+++ b/docs/knowledge-management--memory.md
@@ -2,6 +2,7 @@
 
 Servers connecting to personal knowledge bases, flashcard apps, building/querying knowledge graphs, or providing persistent memory for LLMs.
 
+- [varun369/SuperLocalMemoryV2](https://github.com/varun369/SuperLocalMemoryV2): A local-first AI memory system providing persistent memory across 17+ AI tools via MCP, featuring knowledge graphs, hybrid search, and pattern learning with zero cloud dependency.
 - [gdcc/mcp-dataverse](https://github.com/gdcc/mcp-dataverse): Facilitates multilingual data integration and exploration in Dataverse using Croissant ML.
 - [digila/linear-mcp](https://github.com/digila/linear-mcp): A TypeScript-based MCP server for managing and summarizing text notes with URI-based access and LLM integration.
 - [xsp52Hz/cognigraph-mcp-server](https://github.com/xsp52Hz/cognigraph-mcp-server): CogniGraph MCP Server generates mind maps, relationship graphs, and knowledge graphs using CLI tools and AI analysis, compatible with various local MCP clients.


### PR DESCRIPTION
Closes #77

Adding SuperLocalMemory V2 to the Knowledge Management & Memory category, as requested by the maintainer in Issue #77.

**What:** Local-first AI memory system with knowledge graphs, hybrid search, and pattern learning
**MCP:** 6 tools, 4 resources, 2 prompts
**Install:** `npm install -g superlocalmemory`
**Compatibility:** 17+ AI tools (Claude Desktop, Claude Code, Cursor, Windsurf, VS Code, ChatGPT, and more)
**License:** MIT
**Website:** https://superlocalmemory.com
**Official MCP Registry:** `io.github.varun369/superlocalmemory`