### PR TITLE
Add Unmarkdown MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ Servers for interacting with email, chat platforms, SMS, or notification service
 
 Servers specifically designed to interact with CMS platforms.
 
+- [UnMarkdown/mcp-server](https://github.com/UnMarkdown/mcp-server): Converts markdown to formatted documents for Google Docs, Word, Slack, OneNote, Email, and Plain Text with 62 templates, plus document management and publishing via 7 MCP tools.
 - [edgarrmondragon/limesurvey-mcp](https://github.com/edgarrmondragon/limesurvey-mcp): Facilitates seamless management of LimeSurvey surveys and responses through a dedicated MCP server.
 - [thoy-le-duc/mcp-woocommerce-thoy](https://github.com/thoy-le-duc/mcp-woocommerce-thoy): Facilitates seamless WooCommerce store management via JSON-RPC 2.0, integrating with WordPress REST API across multiple platforms.
 - [aguaitech/Elementor-MCP](https://github.com/aguaitech/Elementor-MCP): Facilitates CRUD operations on Elementor data within WordPress using a simple MCP server.

--- a/docs/content-management-systems-cms.md
+++ b/docs/content-management-systems-cms.md
@@ -2,6 +2,7 @@
 
 Servers specifically designed to interact with CMS platforms.
 
+- [UnMarkdown/mcp-server](https://github.com/UnMarkdown/mcp-server): Converts markdown to formatted documents for Google Docs, Word, Slack, OneNote, Email, and Plain Text with 62 templates, plus document management and publishing via 7 MCP tools.
 - [edgarrmondragon/limesurvey-mcp](https://github.com/edgarrmondragon/limesurvey-mcp): Facilitates seamless management of LimeSurvey surveys and responses through a dedicated MCP server.
 - [thoy-le-duc/mcp-woocommerce-thoy](https://github.com/thoy-le-duc/mcp-woocommerce-thoy): Facilitates seamless WooCommerce store management via JSON-RPC 2.0, integrating with WordPress REST API across multiple platforms.
 - [aguaitech/Elementor-MCP](https://github.com/aguaitech/Elementor-MCP): Facilitates CRUD operations on Elementor data within WordPress using a simple MCP server.


### PR DESCRIPTION
Adds [Unmarkdown MCP Server](https://github.com/UnMarkdown/mcp-server) to the Content Management Systems category.

- **What it does:** Converts markdown to formatted documents for 6 destinations (Google Docs, Word, Slack, OneNote, Email, Plain Text) with 62 templates. Also manages documents and publishes pages.
- **7 MCP tools:** convert_markdown, create_document, list_documents, get_document, update_document, publish_document, get_usage
- **Published on npm:** [@un-markdown/mcp-server](https://www.npmjs.com/package/@un-markdown/mcp-server)