### PR TITLE
Add Speech AI MCP server to Multimedia Processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -924,6 +924,7 @@ Servers focused on generating or manipulating images, processing video, audio tr
 - [sandst1/mcp-server-midi](https://github.com/sandst1/mcp-server-midi): Facilitates the transmission of MIDI sequences from an LLM to any MIDI-compatible software, enabling seamless integration with digital audio workstations and hardware synthesizers.
 - [falahgs/image-gen3-google-mcp-server](https://github.com/falahgs/image-gen3-google-mcp-server): Harness Google's Imagen 3.0 model via the Gemini API for high-quality image generation, seamlessly integrating with Claude Desktop and other MCP-compatible hosts.
 - [transloadit/node-sdk](https://github.com/transloadit/node-sdk/tree/main/packages/mcp-server): Agent-native media processing via Transloadit's 86+ Robots, supporting video encoding, image manipulation, document conversion, OCR, and speech transcription. Hosted or self-hosted via npx.
+- [fasuizu-br/speech-ai-examples](https://github.com/fasuizu-br/speech-ai-examples): Speech AI MCP server with pronunciation assessment (phoneme-level scoring, 17MB model, <300ms), text-to-speech, and speech-to-text. 8 tools for AI agents building language learning, accessibility, and voice applications.
 
 ## 🖥️ Operating System & Command Line
 


### PR DESCRIPTION
## Summary

Adds [fasuizu-br/speech-ai-examples](https://github.com/fasuizu-br/speech-ai-examples) to the **Multimedia Processing** section.

Speech AI is an MCP server providing:
- **Pronunciation assessment** with phoneme-level scoring (17MB model, <300ms latency)
- **Text-to-speech** synthesis
- **Speech-to-text** transcription
- 8 MCP tools for AI agents building language learning, accessibility, and voice applications

## Checklist
- [x] Entry added to the Multimedia Processing section
- [x] Description follows the existing format (repo link + description)
- [x] Link points to a public GitHub repository