### PR TITLE
Add brainstorm-mcp to AI & LLM Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ For more, please click the category name in the next section.
 Servers integrating with other AI models, AI platforms, RAG tools, prompt management, or agent frameworks.
 
 - [bh-rat/context-awesome](https://github.com/bh-rat/context-awesome) - MCP server for querying 8,500+ curated awesome lists (1M+ items) and fetching the best resources for your agent.
+- [spranab/brainstorm-mcp](https://github.com/spranab/brainstorm-mcp) - Multi-round AI brainstorming debates between multiple models (GPT, DeepSeek, Groq, Ollama, etc.). Pit different LLMs against each other to explore ideas from diverse perspectives.
 - [comitest22/linear-mcp](https://github.com/comitest22/linear-mcp): Facilitates interaction with the Linear API through a Model Context Protocol server, offering tools for ticket management and prioritization.
 - [stephenlb/pubnub-mcp-server](https://github.com/stephenlb/pubnub-mcp-server): Facilitates access to PubNub SDK and Functions documentation within Cursor IDE using a CLI-based MCP server.
 - [Ankit2533/research](https://github.com/Ankit2533/research): A multi-agent deep researcher leveraging MCP to perform comprehensive web searches with Linkup and CrewAI orchestration.

--- a/docs/ai--llm-integration.md
+++ b/docs/ai--llm-integration.md
@@ -3,6 +3,7 @@
 Servers integrating with other AI models, AI platforms, RAG tools, prompt management, or agent frameworks.
 
 - [bh-rat/context-awesome](https://github.com/bh-rat/context-awesome) - MCP server for querying 8,500+ curated awesome lists (1M+ items) and fetching the best resources for your agent.
+- [spranab/brainstorm-mcp](https://github.com/spranab/brainstorm-mcp) - Multi-round AI brainstorming debates between multiple models (GPT, DeepSeek, Groq, Ollama, etc.). Pit different LLMs against each other to explore ideas from diverse perspectives.
 - [comitest22/linear-mcp](https://github.com/comitest22/linear-mcp): Facilitates interaction with the Linear API through a Model Context Protocol server, offering tools for ticket management and prioritization.
 - [stephenlb/pubnub-mcp-server](https://github.com/stephenlb/pubnub-mcp-server): Facilitates access to PubNub SDK and Functions documentation within Cursor IDE using a CLI-based MCP server.
 - [Ankit2533/research](https://github.com/Ankit2533/research): A multi-agent deep researcher leveraging MCP to perform comprehensive web searches with Linkup and CrewAI orchestration.


### PR DESCRIPTION
## New Server

**Name:** [brainstorm-mcp](https://github.com/spranab/brainstorm-mcp)
**Category:** AI & LLM Integration
**Language:** TypeScript
**Scope:** Local

An MCP server for multi-round AI brainstorming debates between multiple models (GPT, DeepSeek, Groq, Ollama, etc.). Enables Claude or any MCP client to orchestrate structured debates where different LLMs argue different perspectives on a topic.

- **npm:** `npx brainstorm-mcp`
- **Repository:** https://github.com/spranab/brainstorm-mcp
- **License:** MIT