### PR TITLE
Add mcp-server-insumer to Finance & Crypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,7 @@ Servers focused on interacting with local or remote file systems for reading, wr
 
 Servers dealing with financial data, stock markets, cryptocurrency exchanges/data, trading bots, banking APIs, accounting software, or blockchain interactions.
 
+- [douglasborthwick-crypto/mcp-server-insumer](https://github.com/douglasborthwick-crypto/mcp-server-insumer): On-chain token verification and ECDSA-signed attestation across 31 EVM blockchains. 16 tools for AI agents to verify holdings, generate proofs, manage merchants, and process USDC payments.
 - [debridge-finance/debridge-mcp](https://github.com/debridge-finance/debridge-mcp): MCP server for the deBridge protocol, enabling AI agents to find optimal cross-chain swap routes, check fees and conditions, and initiate non-custodial trades across major blockchain networks.
 - [BrunoPessoa22/chiliz-marketing-intel](https://github.com/BrunoPessoa22/chiliz-marketing-intel): 67+ tools for fan token intelligence — whale flows, signal scores, sports calendar, backtesting, DEX trading, social sentiment. SSE with Bearer auth.
 - [decidefyi/decide](https://github.com/decidefyi/decide) – Deterministic MCP notary suite for subscription policies: refund, cancellation, return, and trial terms. Stateless, read-only rules engine with auditable verdicts.


### PR DESCRIPTION
## Summary

- Adds [mcp-server-insumer](https://github.com/douglasborthwick-crypto/mcp-server-insumer) to the **Finance & Crypto** section
- On-chain token verification and ECDSA-signed attestation across 31 EVM blockchains
- 16 tools for AI agents to verify holdings, generate proofs, manage merchants, and process USDC payments
- Published on npm (`mcp-server-insumer`) and the official MCP Registry

## Details

mcp-server-insumer connects AI agents to the InsumerAPI for privacy-preserving on-chain verification. Agents can autonomously verify token holdings, generate ECDSA-signed attestation proofs, onboard merchants, and process payments, all without exposing wallet balances or requiring human intervention.

- **npm**: https://www.npmjs.com/package/mcp-server-insumer
- **MCP Registry**: https://github.com/modelcontextprotocol/servers (listed under `io.github.douglasborthwick-crypto/insumer`)
- **Transport**: stdio
- **License**: MIT