### PR TITLE
Add LightCMS to Content Management Systems category

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ Servers specifically designed to interact with CMS platforms.
 - [rakeshgangwar/freshrss-server](https://github.com/rakeshgangwar/freshrss-server): Facilitates AI interaction with FreshRSS feeds via the Fever API, enabling feed management and item retrieval.
 - [sdi2200262/eclass-mcp-server](https://github.com/sdi2200262/eclass-mcp-server): Facilitates AI agents' interaction with Open eClass by enabling authentication, course retrieval, and session management.
 - [mrwyndham/pocketbase-mcp](https://github.com/mrwyndham/pocketbase-mcp): Facilitates rapid development of PocketBase applications with advanced database operations and schema management.
+- [jonradoff/lightcms](https://github.com/jonradoff/lightcms): AI-native CMS with 41 MCP tools for managing websites through natural language. Create pages, templates, assets, themes, collections, redirects, and more with full content versioning.
 
 ## 📊 Data Analysis & Business Intelligence
 

--- a/docs/content-management-systems-cms.md
+++ b/docs/content-management-systems-cms.md
@@ -60,4 +60,5 @@ Servers specifically designed to interact with CMS platforms.
 - [r-huijts/canvas-mcp](https://github.com/r-huijts/canvas-mcp): Facilitates AI-driven management of Canvas LMS through a Model Context Protocol server, enabling seamless interaction with course data and student information.
 - [Omedia/mcp-server-drupal](https://github.com/Omedia/mcp-server-drupal): A TypeScript-based MCP server designed to integrate with the Drupal MCP module using STDIO transport.
 - [ivo-toby/contentful-mcp](https://github.com/ivo-toby/contentful-mcp): Integrates with Contentful's API to manage content, spaces, and environments with full CRUD operations and bulk processing capabilities.
+- [jonradoff/lightcms](https://github.com/jonradoff/lightcms): AI-native CMS with 41 MCP tools for managing websites through natural language. Create pages, templates, assets, themes, collections, redirects, and more with full content versioning.
 


### PR DESCRIPTION
## Summary
- Adds [LightCMS](https://github.com/jonradoff/lightcms) to the Content Management Systems (CMS) category
- Updated both `README.md` and `docs/content-management-systems-cms.md`
- LightCMS is an AI-native CMS with 41 MCP tools for managing websites through natural language — pages, templates, assets, themes, collections, redirects, and more with full content versioning

## Author
Jon Radoff — [github.com/jonradoff](https://github.com/jonradoff)