### PR TITLE
Add Commune MCP to Communication & Messaging section

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ Servers for interacting with email, chat platforms, SMS, or notification service
 - [futuyu/Discord-webhook-MCP](https://github.com/futuyu/Discord-webhook-MCP): Facilitates message delivery to Discord using webhooks through the Model Context Protocol, with integration support for Claude Desktop.
 - [beylessai/hiworks-mcp](https://github.com/beylessai/hiworks-mcp): Facilitates email retrieval and sending through Hiworks Mail integration using MCP.
 - [team-telnyx/telnyx-mcp-server](https://github.com/team-telnyx/telnyx-mcp-server): Facilitates interaction with telephony, messaging, and AI assistant APIs, enabling MCP clients to manage communications and create AI-driven solutions.
+- [commune-sh/commune-mcp](https://github.com/commune-sh/commune-mcp): Provides email infrastructure for AI agents, enabling programmatic inbox creation, send/receive email, thread management across concurrent conversations, custom domains, structured extraction on inbound mail, and SMS.
 
 ## 📝 Content Management Systems
 


### PR DESCRIPTION
Adding Commune MCP — it fits the 'email, chat platforms, SMS' scope of this section.

The difference from the other email entries here: the others are mostly about reading a user's personal inbox or sending transactional emails via Gmail/SMTP. Commune is infrastructure for the agent itself — you create an inbox from the API, it's yours to program, and it handles both directions (send and receive) with proper thread isolation.

Practical example of where this matters: an agent handling customer support needs a separate email context per customer. With Gmail-based tools, threads bleed into each other. Commune provisions isolated inboxes and tracks threads natively, so the agent always knows which reply belongs to which conversation.

Also has SMS from the same server, which pairs well with email for escalation workflows.