### PR TITLE
Add mcp-tool-search to Utilities & Helpers

### DIFF
--- a/docs/utilities--helpers.md
+++ b/docs/utilities--helpers.md
@@ -350,4 +350,5 @@ Servers providing simple, general-purpose tools like time/date information, calc
 - [Sunwood-ai-labs/mcp-weather-service-server](https://github.com/Sunwood-ai-labs/mcp-weather-service-server): A weather service MCP server that manages and summarizes notes using a custom URI scheme.
 - [anaisbetts/mcp-installer](https://github.com/anaisbetts/mcp-installer): Facilitates the installation of MCP servers from npm or PyPi using Claude, streamlining server setup and deployment.
 - [hide-org/hide-mcp](https://github.com/hide-org/hide-mcp): A headless IDE MCP server featuring a text editor and persistent bash shell for file management and command execution.
+- [KGT24k/mcp-tool-search](https://github.com/KGT24k/mcp-tool-search): MCP proxy that reduces context token usage by 85-96% via lazy tool loading, replacing 50-200+ tool schemas with 4 lightweight proxy tools. Compatible with Claude Code, Claude Desktop, Cursor, and Windsurf.
 


### PR DESCRIPTION
## What is mcp-tool-search?

[mcp-tool-search](https://github.com/KGT24k/mcp-tool-search) is an MCP proxy server that dramatically reduces context token usage (85-96% reduction) by replacing 50-200+ tool schemas with just 4 lightweight proxy tools via lazy tool loading.

**Key features:**
- **4 proxy tools** (`search_tools`, `get_tool_schema`, `call_tool`, `list_servers`) replace all upstream tool definitions
- **Lazy connection pool** with 5-minute idle timeout — only connects to upstream servers on demand
- **Fuzzy search** with Levenshtein distance for typo-tolerant tool discovery
- **Works with** Claude Code, Claude Desktop, Cursor, Windsurf, and any MCP-compatible client
- **Published on npm:** `npm install -g mcp-tool-search` ([v1.1.3](https://www.npmjs.com/package/mcp-tool-search))

## Placement

Added to **Utilities & Helpers** (`docs/utilities--helpers.md`) — appended at the end following the existing convention.

## Format

Matches the existing entry format:
```
- [KGT24k/mcp-tool-search](https://github.com/KGT24k/mcp-tool-search): MCP proxy that reduces context token usage by 85-96% via lazy tool loading, replacing 50-200+ tool schemas with 4 lightweight proxy tools. Compatible with Claude Code, Claude Desktop, Cursor, and Windsurf.
```