### PR TITLE
Add screaming-frog-mcp to Browser Automation & Web Scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Servers using tools for browser control, automation, and extracting content from
 - [sungithubid/mcp-url2markdown](https://github.com/sungithubid/mcp-url2markdown): Transforms web page content from a given URL into clean, formatted markdown using MCP server capabilities.
 - [NexusX-MCP/data-mcp-server](https://github.com/NexusX-MCP/data-mcp-server): Facilitates web scraping, data extraction, and browser automation with integration for agents like OpenAI's CUA and Anthropic's Claude.
 - [korwabs/playwright-trace-mcp](https://github.com/korwabs/playwright-trace-mcp): Enhances browser automation with Playwright by adding trace viewer and video recording capabilities, enabling LLMs to interact with web pages through structured data.
+- [bzsasson/screaming-frog-mcp](https://github.com/bzsasson/screaming-frog-mcp): Screaming Frog SEO Spider integration for crawling websites, exporting SEO data, and managing crawl storage through AI assistants.
 
 ## 🏗️ Build & Deployment Tools
 

--- a/docs/browser-automation--web-scraping.md
+++ b/docs/browser-automation--web-scraping.md
@@ -259,4 +259,5 @@ Servers using tools for browser control, automation, and extracting content from
 - [jakedahn/deno2-playwright-mcp-server](https://github.com/jakedahn/deno2-playwright-mcp-server): Facilitates browser automation through Playwright and Deno 2, enabling LLMs to interact with web pages in a real browser environment.
 - [Sunwood-ai-labs/duckduckgo-web-search](https://github.com/Sunwood-ai-labs/duckduckgo-web-search): A TypeScript-based MCP server for Claude Desktop that implements a simple notes system using DuckDuckGo API.
 - [blazickjp/web-browser-mcp-server](https://github.com/blazickjp/web-browser-mcp-server): Empower AI models to navigate and extract data from websites using a streamlined MCP interface with advanced content targeting and error management.
+- [bzsasson/screaming-frog-mcp](https://github.com/bzsasson/screaming-frog-mcp): Screaming Frog SEO Spider integration for crawling websites, exporting SEO data, and managing crawl storage through AI assistants.
 


### PR DESCRIPTION
## Summary

- Add [screaming-frog-mcp](https://github.com/bzsasson/screaming-frog-mcp) to the **Browser Automation & Web Scraping** category
- Screaming Frog SEO Spider integration for crawling websites, exporting SEO data, and managing crawl storage through AI assistants
- Language: Python

## Changes

- Added entry to `README.md` under Browser Automation & Web Scraping
- Added entry to `docs/browser-automation--web-scraping.md`