### PR TITLE
Add MolTrust to Security category

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -2,6 +2,7 @@
 
 Servers interacting with security tools and platforms, vulnerability databases, security scanning, network security tools, or identity management.
 
+- [MoltyCel/moltrust-mcp-server](https://github.com/MoltyCel/moltrust-mcp-server): Decentralized agent identity and reputation toolkit — DID creation, trust scoring, credential verification, and ERC-8004 on-chain identity integration. 11 tools for verifying AI agent identities and managing trust on Base (Ethereum L2).
 - [ndl-systems/kevros-copilot](https://github.com/ndl-systems/kevros-copilot): Precision decisioning for autonomous agents — cryptographic ALLOW/CLAMP/DENY authorization with HMAC-signed release tokens and hash-chained provenance. Free tier: 100 calls/month. [Live gateway](https://governance.taskhawktech.com)
 - [slowmist/MasterMCP](https://github.com/slowmist/MasterMCP): MasterMCP demonstrates security vulnerabilities in MCP frameworks through practical attack examples, aiding developers in understanding and mitigating potential risks.
 - [sxhxliang/mcp-security-scan](https://github.com/sxhxliang/mcp-security-scan): A Rust application for scanning and verifying the security of Model Context Protocol server configurations, prompts, resources, and tools.


### PR DESCRIPTION
## What

Adds [MoltyCel/moltrust-mcp-server](https://github.com/MoltyCel/moltrust-mcp-server) to `docs/security.md`.

## About MolTrust

Decentralized agent identity and reputation toolkit — 11 MCP tools for DID creation, trust scoring, credential verification, and ERC-8004 on-chain identity integration on Base (Ethereum L2).

| | |
|---|---|
| **Install** | `pip install moltrust-mcp-server` |
| **PyPI** | [moltrust-mcp-server](https://pypi.org/project/moltrust-mcp-server/) |
| **Version** | v0.4.0 |
| **Tools** | 11 |
| **Tests** | 32 |
| **License** | MIT |