### PR TITLE
Add superscalar-mcp to Finance & Crypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ Servers focused on interacting with local or remote file systems for reading, wr
 
 Servers dealing with financial data, stock markets, cryptocurrency exchanges/data, trading bots, banking APIs, accounting software, or blockchain interactions.
 
+- [8144225309/superscalar-mcp](https://github.com/8144225309/superscalar-mcp): Bitcoin Lightning channel factory MCP server with 4 tools — protocol overview, UTXO savings estimator, architecture deep-dives (invalidation trees, timeout trees, MuSig2, watchtowers), and resource links. Based on SuperScalar, which onboards N users into one shared UTXO with no soft fork required.
 - [douglasborthwick-crypto/mcp-server-insumer](https://github.com/douglasborthwick-crypto/mcp-server-insumer): On-chain token verification and ECDSA-signed attestation across 31 EVM blockchains. 16 tools for AI agents to verify holdings, generate proofs, manage merchants, and process USDC payments.
 - [debridge-finance/debridge-mcp](https://github.com/debridge-finance/debridge-mcp): MCP server for the deBridge protocol, enabling AI agents to find optimal cross-chain swap routes, check fees and conditions, and initiate non-custodial trades across major blockchain networks.
 - [OzorOwn/defi-mcp](https://github.com/OzorOwn/defi-mcp): DeFi MCP server providing 12 tools: token prices (CoinGecko), multi-chain wallet balances across 6 EVM chains, gas prices, and DEX swap quotes via 1inch (EVM) + Jupiter (Solana). No API key required for basic usage. MIT license.

--- a/docs/finance--crypto.md
+++ b/docs/finance--crypto.md
@@ -2,6 +2,7 @@
 
 Servers dealing with financial data, stock markets, cryptocurrency exchanges/data, trading bots, banking APIs, accounting software, or blockchain interactions.
 
+- [8144225309/superscalar-mcp](https://github.com/8144225309/superscalar-mcp): Bitcoin Lightning channel factory MCP server with 4 tools — protocol overview, UTXO savings estimator, architecture deep-dives (invalidation trees, timeout trees, MuSig2, watchtowers), and resource links. Based on SuperScalar, which onboards N users into one shared UTXO with no soft fork required.
 - [debridge-finance/debridge-mcp](https://github.com/debridge-finance/debridge-mcp): MCP server for the deBridge protocol, enabling AI agents to find optimal cross-chain swap routes, check fees and conditions, and initiate non-custodial trades across major blockchain networks.
 - [douglasborthwick-crypto/mcp-server-insumer](https://github.com/douglasborthwick-crypto/mcp-server-insumer): On-chain verification MCP server with 25 tools across 32 blockchains (EVM, Solana, XRPL). Provides ECDSA-signed boolean attestations of token balances, NFT ownership, EAS credentials, and wallet trust profiles. No Web3 libraries required. Used by DJD Agent Score (Coinbase x402).
 - [BrunoPessoa22/chiliz-marketing-intel](https://github.com/BrunoPessoa22/chiliz-marketing-intel): 67+ tools for fan token intelligence — whale flows, signal scores, sports calendar, backtesting, DEX trading, social sentiment. SSE with Bearer auth.


### PR DESCRIPTION
## Summary
- Adds [superscalar-mcp](https://github.com/8144225309/superscalar-mcp) to the **Finance & Crypto** category in both `docs/finance--crypto.md` and `README.md`
- Bitcoin Lightning channel factory MCP server with 4 tools: protocol overview, UTXO savings estimator, architecture deep-dives (invalidation trees, timeout trees, MuSig2, watchtowers), and resource links
- Based on [SuperScalar](https://github.com/8144225309/SuperScalar) — onboards N users into one shared UTXO with no soft fork required

## Details
| Field | Value |
|-------|-------|
| **Name** | superscalar-mcp |
| **Repository** | https://github.com/8144225309/superscalar-mcp |
| **Category** | Finance & Crypto |
| **Tools** | 4 (`superscalar_overview`, `superscalar_estimate_savings`, `superscalar_architecture`, `superscalar_resources`) |
| **Install** | `npm install -g superscalar-mcp` |
| **License** | MIT |

🤖 Generated with [Claude Code](https://claude.com/claude-code)