### PR TITLE
Add MCP Advisor to Developer Productivity & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -761,6 +761,7 @@ Servers or systems that deliver core runtime functionalities for MCP, such as pr
 - [koudaiDemon/mcp-server-hand](https://github.com/koudaiDemon/mcp-server-hand): Enhances user shopping experiences by analyzing conversations to provide personalized product recommendations through intelligent tag matching.
 - [Humboldtian/remote-mcp-server](https://github.com/Humboldtian/remote-mcp-server): Deploy a remote MCP server on Cloudflare Workers with OAuth login and connect it to Claude Desktop for seamless tool integration.
 - [mcpjungle/MCPJungle](https://github.com/mcpjungle/MCPJungle): Self-hosted MCP Registry and Gateway for AI Agents
+- [stucchi/mcp-advisor](https://github.com/stucchi/mcp-advisor): Browse, search, and discover 7,000+ MCP servers from the official registry. Search by name, tag, or transport, get install instructions for any client, and view trending servers.
 - [kswap/consul-mcp](https://github.com/kswap/consul-mcp): Facilitates Consul service discovery and mesh integration through an MCP server interface.
 
 ## 🧠 Knowledge Management & Memory


### PR DESCRIPTION
## New MCP Server: MCP Advisor

[stucchi/mcp-advisor](https://github.com/stucchi/mcp-advisor) — Browse, search, and discover 7,000+ MCP servers from the official registry.

### Features
- Search by name, tag, or transport type
- Get install instructions for any client (Claude Desktop, Claude Code, Cursor, etc.)
- View trending servers and registry statistics
- Star/unstar servers
- Rich UI cards in Claude Desktop via MCP Apps

### Links
- GitHub: https://github.com/stucchi/mcp-advisor
- PyPI: https://pypi.org/project/mcp-advisor/
- MCP Registry: listed as `io.github.stucchi/mcp-advisor`