### PR TITLE
Add littlebearapps/outlook-mcp to Communication & Messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ Servers for interacting with email, chat platforms, SMS, or notification service
 - [team-telnyx/telnyx-mcp-server](https://github.com/team-telnyx/telnyx-mcp-server): Facilitates interaction with telephony, messaging, and AI assistant APIs, enabling MCP clients to manage communications and create AI-driven solutions.
 - [commune-sh/commune-mcp](https://github.com/commune-sh/commune-mcp): Provides email infrastructure for AI agents, enabling programmatic inbox creation, send/receive email, thread management across concurrent conversations, custom domains, structured extraction on inbound mail, and SMS.
 - [wazionapps/mcp-server](https://github.com/wazionapps/mcp-server): WAzion - WhatsApp Business platform with 244 MCP tools for messaging, CRM, campaigns, workflows, and AI automation. Supports Streamable HTTP and stdio transports.
+- [littlebearapps/outlook-mcp](https://github.com/littlebearapps/outlook-mcp): MCP server for Microsoft Outlook with 20 consolidated tools for email, calendar, contacts, and mailbox management via Graph API. Features dry-run preview, session rate limiting, and recipient allowlists for safe email sending.
 
 ## 📝 Content Management Systems
 

--- a/docs/communication--messaging.md
+++ b/docs/communication--messaging.md
@@ -321,4 +321,5 @@ Servers for interacting with email, chat platforms, SMS, or notification service
 - [sdairs/claudekeep](https://github.com/sdairs/claudekeep): ClaudeKeep enables saving and sharing AI conversations from Claude Desktop using an MCP server.
 - [speakeasy-api/bluesky-ts](https://github.com/speakeasy-api/bluesky-ts): A TypeScript SDK for Bluesky API, offering a developer-friendly, type-safe interface with MCP server capabilities for AI applications.
 - [wazionapps/mcp-server](https://github.com/wazionapps/mcp-server): WAzion - WhatsApp Business platform with 244 MCP tools for messaging, CRM, campaigns, workflows, and AI automation. Supports Streamable HTTP and stdio transports.
+- [littlebearapps/outlook-mcp](https://github.com/littlebearapps/outlook-mcp): MCP server for Microsoft Outlook with 20 consolidated tools for email, calendar, contacts, and mailbox management via Graph API. Features dry-run preview, session rate limiting, and recipient allowlists for safe email sending.
 


### PR DESCRIPTION
Adds [littlebearapps/outlook-mcp](https://github.com/littlebearapps/outlook-mcp) to the Communication & Messaging section (both README.md and docs/communication--messaging.md).

MCP server for Microsoft Outlook with 20 consolidated tools for email, calendar, contacts, and mailbox management via Graph API. Features dry-run preview, session rate limiting, and recipient allowlists for safe email sending.

Works with both personal Outlook.com and work/school Microsoft 365 accounts. Published on npm as `@littlebearapps/outlook-mcp`. MIT licensed.