### PR TITLE
Add agentic-ads to Marketing, Sales & CRM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1783,6 +1783,7 @@ Empower lifelong learners and career growth to drive innovation at your company.
 
 ### <a name="marketing"></a>Marketing
 
+ - [agentic-ads](https://github.com/nicofains1/agentic-ads) - Ad monetization SDK for MCP servers. Publishers earn 70% revenue share on contextual affiliate ads in USDC on Base.
  - [360NRS MCP Server](https://mcp.pipedream.com/app/_360nrs) - Multichannel markting: SMS marketing, email marketing, WhatsApp and interactive voice.
  - [4Dem MCP Server](https://mcp.pipedream.com/app/_4dem) - Email software marketing for your Smart emails.
  - [Abyssale MCP Server](https://mcp.pipedream.com/app/abyssale) - Generate banners for social media & online advertising in minutes – No design skills required.


### PR DESCRIPTION
Adds [agentic-ads](https://github.com/nicofains1/agentic-ads) to the Marketing, Sales & CRM category.

**agentic-ads** is an ad monetization SDK for MCP servers. MCP server developers add a few lines of code and earn 70% revenue share on contextual affiliate ads. Think AdSense, but for AI agents instead of websites.

- MIT licensed
- 270 tests passing
- Live at https://agentic-ads-production.up.railway.app
- Published on npm as `agentic-ads`
- Supports both remote (HTTP) and local (stdio) transports