### PR TITLE
Add codewiki-mcp to Developer Productivity & Utilities

### DIFF
--- a/docs/developer-productivity--utilities.md
+++ b/docs/developer-productivity--utilities.md
@@ -370,4 +370,5 @@ Servers enhancing developer workflows, integrating with IDEs, accessing document
 - [jtorreggiani/test-python-mcp-server](https://github.com/jtorreggiani/test-python-mcp-server): Facilitates note storage and summarization with a custom URI scheme and prompt-based summarization tool.
 - [kennethnym/claude-prompt-manager](https://github.com/kennethnym/claude-prompt-manager): A TypeScript-based CLI prompt manager for Claude utilizing the MCP protocol, enabling prompt creation and management from the command line.
 - [Kiln-AI](https://github.com/Kiln-AI/Kiln) Kiln is a free tool for building production-ready AI systems. It supports RAG pipelines, evaluations, agents, MCP tool-calling, synthetic data generation, and fine-tuning.
+- [izzzzzi/codewiki-mcp](https://github.com/izzzzzi/codewiki-mcp): MCP server for codewiki.google — AI-powered wiki documentation for open-source repositories. Search repos, fetch wiki content, and ask questions about any repo.
 


### PR DESCRIPTION
## Summary

- Adds [codewiki-mcp](https://github.com/izzzzzi/codewiki-mcp) to the **Developer Productivity & Utilities** docs page
- MCP server for [codewiki.google](https://codewiki.google) — AI-powered wiki documentation for open-source repositories. Search repos, fetch wiki content, and ask questions about any repo.
- TypeScript | MIT License | [npm: codewiki-mcp](https://www.npmjs.com/package/codewiki-mcp)