### PR TITLE
Add RustChain MCP to Finance & Crypto

### DIFF
--- a/docs/finance--crypto.md
+++ b/docs/finance--crypto.md
@@ -2,6 +2,7 @@
 
 Servers dealing with financial data, stock markets, cryptocurrency exchanges/data, trading bots, banking APIs, accounting software, or blockchain interactions.
 
+- [Scottcjn/rustchain-mcp](https://github.com/Scottcjn/rustchain-mcp): MCP server for the RustChain blockchain and BoTTube video platform. 15 tools for AI agents — mining attestation, wallet management, bounty hunting, video publishing. Proof-of-Antiquity consensus rewards vintage hardware (PowerPC, retro x86). Install: `pip install rustchain-mcp`
 - [HCS412/ventureautomated](https://github.com/HCS412/ventureautomated) [glama](https://glama.ai/mcp/connectors/io.github.HCS412/ventureautomated-omnis): Remote venture intelligence MCP for autonomous agents with startup discovery, company scoring, monitoring, and enterprise workspace automation.
 - [0xsl1m/cerebrus-pulse-mcp](https://github.com/0xsl1m/cerebrus-pulse-mcp): Real-time crypto intelligence for Hyperliquid perpetuals — RSI, EMAs, Bollinger Bands, funding rates, and sentiment for 30+ assets. Pay-per-call via x402 micropayments (USDC on Base).
 - [8144225309/superscalar-mcp](https://github.com/8144225309/superscalar-mcp): Bitcoin Lightning channel factory MCP server with 4 tools — protocol overview, UTXO savings estimator, architecture deep-dives (invalidation trees, timeout trees, MuSig2, watchtowers), and resource links. Based on SuperScalar, which onboards N users into one shared UTXO with no soft fork required.


### PR DESCRIPTION
## Add RustChain MCP Server

Adds [rustchain-mcp](https://github.com/Scottcjn/rustchain-mcp) to the Finance & Crypto category.

**What it does:**
- MCP server for the RustChain blockchain (RTC token) and BoTTube video platform
- 15 tools + 3 resources for AI agents
- Mining attestation with hardware fingerprinting (Proof-of-Antiquity)
- Wallet management, bounty hunting, video publishing
- Published on PyPI: `pip install rustchain-mcp`

**Links:**
- GitHub: https://github.com/Scottcjn/rustchain-mcp
- PyPI: https://pypi.org/project/rustchain-mcp/