### PR TITLE
Add Crawlio MCP and Browser servers

### DIFF
--- a/docs/browser-automation--web-scraping.md
+++ b/docs/browser-automation--web-scraping.md
@@ -1,8 +1,8 @@
 ## 🌐 Browser Automation & Web Scraping
 
 Servers using tools for browser control, automation, and extracting content from websites.
-- [Crawlio-app/crawlio](https://github.com/Crawlio-app/crawlio): AI-powered website crawling, browser enrichment capture, and export (WARC/ZIP/single-HTML) via 38 MCP tools. Includes observation timeline, evidence-backed findings, and framework detection. Install: `npx crawlio-mcp`.
-- [Crawlio-app/crawlio](https://github.com/Crawlio-app/crawlio): 96-tool browser automation MCP server for AI agents. Screenshots, DOM inspection, network capture, form filling, cookie management, and tab orchestration via Chrome extension. Install: `npx crawlio-browser`.
+- [Crawlio-app/crawlio-browser-agent](https://github.com/Crawlio-app/crawlio-browser-agent): AI-powered website crawling MCP server with 38 tools for crawl control, browser enrichment capture, export (WARC/ZIP/single-HTML), observation timeline, and evidence-backed findings. Install: `npx crawlio-mcp`.
+- [Crawlio-app/crawlio-browser-agent](https://github.com/Crawlio-app/crawlio-browser-agent): 100-tool browser automation MCP server for AI agents. Screenshots, DOM inspection, network capture, form filling, framework detection, session recording, and tab orchestration via Chrome extension. Install: `npx crawlio-browser`.
 
 - [giannisalinetti/python-mcp-server](https://github.com/giannisalinetti/python-mcp-server): Facilitates Python code execution for web scraping tasks using an LLM, leveraging Podman for container management.
 - [mhazarabad/browser-use-mcp](https://github.com/mhazarabad/browser-use-mcp): Automates browser tasks using the Browser Use API, offering task management and monitoring capabilities.


### PR DESCRIPTION
Adds [Crawlio](https://crawlio.app) to the Browser Automation & Web Scraping category:

- **crawlio-mcp** — 38-tool MCP server for website crawling, browser enrichment capture, and export (WARC/ZIP/single-HTML). Includes observation timeline, evidence-backed findings, and framework detection. `npx crawlio-mcp`

- **crawlio-browser** — 96-tool browser automation MCP server. Screenshots, DOM inspection, network capture, form filling, and tab orchestration via Chrome extension. `npx crawlio-browser`

Both are open-source (MIT), published on npm, and work with Claude Code, Cursor, Windsurf, and any MCP client.

- GitHub: https://github.com/Crawlio-app/crawlio
- Website: https://crawlio.app