### PR TITLE
Add sports-betting-mcp to Sports section

### DIFF
--- a/docs/sport.md
+++ b/docs/sport.md
@@ -7,3 +7,4 @@ Servers providing access to sports-related APIs and analysis.
 - [henryco23/NBA](https://github.com/henryco23/NBA): A Python server utilizing MCP to provide comprehensive access to NBA statistics and live game data through the NBA API.
 - [yeonupark/mcp-soccer-data](https://github.com/yeonupark/mcp-soccer-data): Delivers real-time football match data through natural language interactions using the SoccerDataAPI.
 - [guillochon/mlb-api-mcp](https://github.com/guillochon/mlb-api-mcp): A Python MCP server that acts as a proxy to the freely available MLB API, which provides player info, stats, and game information.
+- [seang1121/sports-betting-mcp](https://github.com/seang1121/sports-betting-mcp): AI-powered sports betting intelligence for NBA, NHL, and NCAAB. Provides live odds, injury reports, line movement, daily picks with confidence scores, and visual bet slip cards — backed by 1,353+ resolved picks with 59.6% documented win rate.


### PR DESCRIPTION
## Description

Adds [seang1121/sports-betting-mcp](https://github.com/seang1121/sports-betting-mcp) to the Sports section.

An MCP server for AI-powered sports betting intelligence with 7 tools: live odds, injury reports, line movement, daily picks with confidence scores, visual bet slip cards, win rate metrics, and pending picks. Backed by 1,353+ resolved picks with 59.6% documented win rate across NBA, NHL, and NCAAB. Installable via `pip install sports-betting-mcp`.