### PR TITLE
Add IndieStack to Search category

### DIFF
--- a/README.md
+++ b/README.md
@@ -1106,6 +1106,7 @@ Servers providing web search capabilities or interfacing with specialized search
 - [isnow890/naver-search-mcp](https://github.com/isnow890/naver-search-mcp): Facilitates comprehensive search and data trend analysis across Naver services using the Naver Search and DataLab APIs.
 - [uju777/coupang-mcp](https://github.com/uju777/coupang-mcp): MCP server for Coupang (Korea's largest e-commerce) product search with Rocket Delivery filtering and affiliate link generation.
 - [uju777/mcp-server-naver-search](https://github.com/uju777/mcp-server-naver-search): MCP server for Naver Search (Shopping, Cafe, News). Essential for Korean users.
+- [Pattyboi101/indiestack](https://github.com/Pattyboi101/indiestack): Open-source supply chain for AI agents — search and discover 3,000+ indie creations across 25 categories. 15 MCP tools including find_tools, build_stack, scan_project, compare_tools, and analyze_dependencies. Install via `uvx --from indiestack indiestack-mcp`.
 
 ## 🔒 Security
 

--- a/docs/search.md
+++ b/docs/search.md
@@ -156,3 +156,4 @@ Servers providing web search capabilities or interfacing with specialized search
 - [fatwang2/search1api-mcp](https://github.com/fatwang2/search1api-mcp): Facilitates search and crawl operations using Search1API, offering seamless integration with various MCP clients.
 
 - [pranciskus/newsmcp](https://github.com/pranciskus/newsmcp): Real-time world news for AI agents — events clustered from hundreds of sources, classified by 12 topics and 30+ geographic regions, ranked by importance. Free, no API key required.
+- [Pattyboi101/indiestack](https://github.com/Pattyboi101/indiestack): Open-source supply chain for AI agents — search and discover 3,000+ indie creations across 25 categories. 15 MCP tools including find_tools, build_stack, scan_project, compare_tools, and analyze_dependencies. Install via `uvx --from indiestack indiestack-mcp`.


### PR DESCRIPTION
## Summary

Adds [IndieStack](https://github.com/Pattyboi101/indiestack) to the Search category.

**IndieStack** is an open-source supply chain for AI agents. It lets you search and discover 3,000+ indie creations across 25 categories through 15 MCP tools including `find_tools`, `build_stack`, `scan_project`, `compare_tools`, and `analyze_dependencies`.

- **GitHub**: https://github.com/Pattyboi101/indiestack
- **PyPI**: https://pypi.org/project/indiestack/
- **Install**: `uvx --from indiestack indiestack-mcp`

Added to both `docs/search.md` and the Search section in `README.md`.