### PR TITLE
Add ark-forge/arkforge-mcp to Security category

### DIFF
--- a/README.md
+++ b/README.md
@@ -1112,6 +1112,7 @@ Servers providing web search capabilities or interfacing with specialized search
 Servers interacting with security tools and platforms, vulnerability databases, security scanning, network security tools, or identity management.
 - [ark-forge/mcp-eu-ai-act](https://github.com/ark-forge/mcp-eu-ai-act): Scans codebases for AI framework usage (16 frameworks) and checks compliance against EU AI Act requirements. Features 4-tier risk categorization, GDPR compliance checking, report generation, and compliance document templates.
 
+- [ark-forge/arkforge-mcp](https://github.com/ark-forge/arkforge-mcp): Certifying proxy for AI agent API calls. Every tool call becomes a signed, timestamped Agent Action Receipt (AAR). Model-agnostic and vendor-independent — works across any LLM provider or infrastructure.
 - [ndl-systems/kevros-copilot](https://github.com/ndl-systems/kevros-copilot): Precision decisioning for autonomous agents — cryptographic ALLOW/CLAMP/DENY authorization with HMAC-signed release tokens and hash-chained provenance. Free tier: 100 calls/month. [Live gateway](https://governance.taskhawktech.com)
 - [slowmist/MasterMCP](https://github.com/slowmist/MasterMCP): MasterMCP demonstrates security vulnerabilities in MCP frameworks through practical attack examples, aiding developers in understanding and mitigating potential risks.
 - [sxhxliang/mcp-security-scan](https://github.com/sxhxliang/mcp-security-scan): A Rust application for scanning and verifying the security of Model Context Protocol server configurations, prompts, resources, and tools.

--- a/docs/security.md
+++ b/docs/security.md
@@ -2,6 +2,7 @@
 
 Servers interacting with security tools and platforms, vulnerability databases, security scanning, network security tools, or identity management.
 
+- [ark-forge/arkforge-mcp](https://github.com/ark-forge/arkforge-mcp): Certifying proxy for AI agent API calls. Every tool call becomes a signed, timestamped Agent Action Receipt (AAR). Model-agnostic and vendor-independent — works across any LLM provider or infrastructure.
 - [MoltyCel/moltrust-mcp-server](https://github.com/MoltyCel/moltrust-mcp-server): Decentralized agent identity and reputation toolkit — DID creation, trust scoring, credential verification, and ERC-8004 on-chain identity integration. 11 tools for verifying AI agent identities and managing trust on Base (Ethereum L2).
 - [ndl-systems/kevros-copilot](https://github.com/ndl-systems/kevros-copilot): Precision decisioning for autonomous agents — cryptographic ALLOW/CLAMP/DENY authorization with HMAC-signed release tokens and hash-chained provenance. Free tier: 100 calls/month. [Live gateway](https://governance.taskhawktech.com)
 - [slowmist/MasterMCP](https://github.com/slowmist/MasterMCP): MasterMCP demonstrates security vulnerabilities in MCP frameworks through practical attack examples, aiding developers in understanding and mitigating potential risks.


### PR DESCRIPTION
## Summary

Adds [ark-forge/arkforge-mcp](https://github.com/ark-forge/arkforge-mcp) to the **Security** category.

**arkforge-mcp** is a certifying proxy for AI agent API calls. Every tool call becomes a signed, timestamped Agent Action Receipt (AAR). It is model-agnostic and vendor-independent — works across any LLM provider or infrastructure.

### Changes
- Added entry to `README.md` (Security section)
- Added entry to `docs/security.md`