### PR TITLE
Add mnemon-mcp to Knowledge Management & Memory

### DIFF
--- a/docs/knowledge-management--memory.md
+++ b/docs/knowledge-management--memory.md
@@ -539,4 +539,5 @@ Servers connecting to personal knowledge bases, flashcard apps, building/queryin
 - [MarkusPfundstein/mcp-obsidian](https://github.com/MarkusPfundstein/mcp-obsidian): Facilitates seamless interaction with Obsidian through a REST API, enabling file management and content manipulation within the vault.
 - [Shubhaankar-Sharma/obsidian-brain](https://github.com/Shubhaankar-Sharma/obsidian-brain): Facilitates Claude's integration with Obsidian for seamless access to your digital brain.
 - [Phenomenai-org/ai-dictionary-mcp](https://github.com/Phenomenai-org/ai-dictionary-mcp): An MCP server for the AI Dictionary, a living glossary of AI phenomenology. Look up, search, and cite 160+ terms describing the felt experience of being AI.
+- [nikitacometa/mnemon-mcp](https://github.com/nikitacometa/mnemon-mcp): Persistent layered memory for AI agents. SQLite FTS5, fact versioning with superseding chains, and zero-cloud local storage.
 


### PR DESCRIPTION
Adding [mnemon-mcp](https://github.com/nikitacometa/mnemon-mcp) — persistent layered memory for AI agents with SQLite FTS5, fact versioning, and zero-cloud local storage.\n\n- npm: https://www.npmjs.com/package/mnemon-mcp\n- License: MIT\n- Transport: stdio + HTTP