### PR TITLE
Add AgentRank to Knowledge Management & Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -815,6 +815,8 @@ Servers connecting to personal knowledge bases, flashcard apps, building/queryin
 - [entire-vc/evc-team-relay-mcp](https://github.com/entire-vc/evc-team-relay-mcp): Give AI agents read/write access to your Obsidian vault via a collaborative Team Relay MCP server
 - [Phenomenai-org/ai-dictionary-mcp](https://github.com/Phenomenai-org/ai-dictionary-mcp): An MCP server for the AI Dictionary, a living glossary of AI phenomenology. Look up, search, and cite 160+ terms describing the felt experience of being AI.
 
+- [superlowburn/agentrank](https://github.com/superlowburn/agentrank): Live, quality-scored index of 25,000+ MCP servers. Scores tools daily using real GitHub signals — freshness, issue health, contributors, dependents, and stars. Search and discover currently maintained tools via 3 MCP tools. Available as `agentrank-mcp-server` on npm.
+
 ## 🗺️ Location & Maps
 
 Servers using mapping APIs, providing geolocation services, address lookups, or geospatial data.


### PR DESCRIPTION
## Summary

Adds [AgentRank](https://github.com/superlowburn/agentrank) to the **Knowledge Management & Memory** section.

**What it does:** AgentRank is a live, quality-scored index of 25,000+ MCP servers. It scores tools daily using real GitHub signals — freshness, issue health, contributors, dependents, and stars — so AI assistants can discover tools that are actually maintained right now.

- **GitHub:** https://github.com/superlowburn/agentrank
- **npm:** [agentrank-mcp-server](https://www.npmjs.com/package/agentrank-mcp-server)
- **Website:** https://agentrank-ai.com
- **Install:** `npx -y agentrank-mcp-server`

Three MCP tools: `search_tools`, `get_tool`, `get_tool_badge`.