### PR TITLE
Add AtlasMemory — evidence-backed AI memory for codebases

### DIFF
--- a/README.md
+++ b/README.md
@@ -785,6 +785,7 @@ Servers or systems that deliver core runtime functionalities for MCP, such as pr
 
 Servers connecting to personal knowledge bases, flashcard apps, building/querying knowledge graphs, or providing persistent memory for LLMs.
 
+- [Bpolat0/atlasmemory](https://github.com/Bpolat0/atlasmemory): Evidence-backed AI memory for codebases. Tree-sitter indexing (11 languages), proof system with line:hash anchors, token-budgeted context packs, drift detection, cross-session learning, and AI enrichment. 28 MCP tools, VS Code extension, zero config.
 - [gdcc/mcp-dataverse](https://github.com/gdcc/mcp-dataverse): Facilitates multilingual data integration and exploration in Dataverse using Croissant ML.
 - [digila/linear-mcp](https://github.com/digila/linear-mcp): A TypeScript-based MCP server for managing and summarizing text notes with URI-based access and LLM integration.
 - [xsp52Hz/cognigraph-mcp-server](https://github.com/xsp52Hz/cognigraph-mcp-server): CogniGraph MCP Server generates mind maps, relationship graphs, and knowledge graphs using CLI tools and AI analysis, compatible with various local MCP clients.


### PR DESCRIPTION
## Add AtlasMemory

**[AtlasMemory](https://github.com/Bpolat0/atlasmemory)** — Turn any codebase into an AI-readable neural map — with proof.

- Evidence-backed claims (line + SHA-256 hash proof)
- 11 languages via Tree-sitter
- Token-budgeted context packs
- Drift detection via SHA-256 contracts
- Cross-session learning + AI enrichment
- 28 MCP tools, VS Code extension, zero config

> *"~700 tokens to understand an 83-file project."* — Google Antigravity
> *"The tool I wish I had from day one."* — Claude Opus 4.6

- GitHub: https://github.com/Bpolat0/atlasmemory
- npm: https://www.npmjs.com/package/atlasmemory

Added to 🧠 Knowledge Management & Memory section.