### PR TITLE
Add GroundTruth MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,7 @@ Servers enhancing developer workflows, integrating with IDEs, accessing document
 - [HendryAvila/Hoofy](https://github.com/HendryAvila/Hoofy): Spec-driven development companion with persistent memory (SQLite + FTS5 + knowledge graph), adaptive change pipeline (12 flow variants), greenfield project pipeline with Clarity Gate, and business rules extraction. 32 MCP tools. Single Go binary, zero dependencies.
 - [Agent Native Registry](https://agentnativeregistry.com): Remote MCP server with 100+ developer tools scored on AI agent compatibility (0-100). Tools: `search_tools`, `get_score`, `compare_tools`. Helps agents pick the right API for any task without trial-and-error.
 - [Dave-London/Pare](https://github.com/Dave-London/Pare): Suite of 16 MCP servers wrapping 240+ CLI developer tools (git, npm, Docker, test runners, build tools, linters, Python, Cargo, Go, GitHub, K8s) with structured JSON output via `outputSchema` + `structuredContent`. Up to 92% fewer tokens vs raw CLI output. MIT licensed, 1,850+ tests.
+- [rm-rf-prod/GroundTruth-MCP](https://github.com/rm-rf-prod/GroundTruth-MCP): Self-hosted MCP server for live documentation, code audits, and best practices. 363+ curated libraries with npm/PyPI/crates.io/Go fallback, 100+ audit patterns across 18 categories with file:line locations and live fixes. No rate limits.
 
 ## 📁 Filesystems
 


### PR DESCRIPTION
Adds [GroundTruth](https://github.com/rm-rf-prod/GroundTruth-MCP) — self-hosted MCP server for live documentation, code audits, and best practices. 363+ curated libraries, 100+ audit patterns, no rate limits.

- npm: [@groundtruth-mcp/gt-mcp](https://www.npmjs.com/package/@groundtruth-mcp/gt-mcp)
- MCP Registry: [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io)
- 704 tests, TypeScript, official MCP SDK