### PR TITLE
Add SheetsData MCP to Hardware & IoT category

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,6 +707,7 @@ Servers controlling hardware devices, interacting with embedded systems, serial 
 - [amanasmuei/mcp-server-nodemcu](https://github.com/amanasmuei/mcp-server-nodemcu): Manage and control NodeMCU IoT devices with real-time communication and AI integration using the Model Context Protocol.
 - [zerubeus/elektron-mcp](https://github.com/zerubeus/elektron-mcp): Facilitates interaction between LLMs and Elektron synthesizers via MIDI for real-time sound control and design.
 - [noboru-i/nature-remo-mcp-server](https://github.com/noboru-i/nature-remo-mcp-server): Facilitates automation and management of Nature Remo devices through the Model Context Protocol SDK.
+- [octoco-ltd/sheetsdata-mcp](https://github.com/octoco-ltd/sheetsdata-mcp): Instant access to electronic component datasheets for AI agents — specs, pinouts, package info, absolute max ratings extracted from manufacturer PDFs on demand.
 
 ## ❤️ Healthcare & Life Sciences
 

--- a/docs/hardware--iot.md
+++ b/docs/hardware--iot.md
@@ -59,4 +59,5 @@ Servers controlling hardware devices, interacting with embedded systems, serial 
 - [daikw/mcp-server-on-raspi](https://github.com/daikw/mcp-server-on-raspi): A Raspberry Pi-based MCP server for managing and summarizing notes with customizable prompts and note storage capabilities.
 - [miguelg719/home-assistant-mcp](https://github.com/miguelg719/home-assistant-mcp): Integrates with Home Assistant to enable smart home control through an MCP server, supporting functionalities like lighting, climate, and security system management.
 - [allenporter/mcp-server-home-assistant](https://github.com/allenporter/mcp-server-home-assistant): Facilitates seamless integration of Home Assistant with the Model Context Protocol for enhanced smart home automation.
+- [octoco-ltd/sheetsdata-mcp](https://github.com/octoco-ltd/sheetsdata-mcp): Instant access to electronic component datasheets for AI agents — specs, pinouts, package info, absolute max ratings extracted from manufacturer PDFs on demand.
 


### PR DESCRIPTION
## Summary

Adds [SheetsData MCP](https://github.com/octoco-ltd/sheetsdata-mcp) to the **Hardware & IoT** category.

SheetsData MCP gives AI agents instant access to electronic component datasheets — specs, pinouts, package info, absolute max ratings — extracted from manufacturer PDFs on demand. No uploads needed. It's a Python cloud server with tools for searching parts, reading datasheets, comparing components, and validating design fit.

- Added entry to `docs/hardware--iot.md`
- Added entry to `README.md` (Hardware & IoT section)