### PR TITLE
Add universal-mcp-toolkit to Utilities & Helpers category

### DIFF
--- a/docs/utilities--helpers.md
+++ b/docs/utilities--helpers.md
@@ -3,7 +3,6 @@
 Servers providing simple, general-purpose tools like time/date information, calculators, dice rollers, formatters, unit converters, UUID generation, etc.
 
 - [Markgatcha/universal-mcp-toolkit](https://github.com/Markgatcha/universal-mcp-toolkit): An all-in-one MCP server aggregating 15+ tools across file system, web search, weather, SQLite database, system info, and more. Zero-config via `npx universal-mcp-toolkit`, Glama-listed, 100+ monthly npm downloads.
-- - [FlatFilers/mcp-server-flatfile](https://github.com/FlatFilers/mcp-server-flatfile): Facilitates interaction with the Flatfile API through a customizable MCP server, enabling streamlined data management and integration.
 - [Nozomuts/date-mcp](https://github.com/Nozomuts/date-mcp): Provides current date and time in specified formats and timezones via a simple MCP server.
 - [BrightLin/mcp-server-port-cleaner](https://github.com/BrightLin/mcp-server-port-cleaner): Node.js server for resolving port conflicts by terminating processes occupying specified ports, ensuring smooth development workflows.
 - [raymondlowe/roo-code-custom-mode-editor-mcp-server](https://github.com/raymondlowe/roo-code-custom-mode-editor-mcp-server): Facilitates editing of Roo Code custom modes by providing tools to list, create, and modify mode fields without direct file manipulation.


### PR DESCRIPTION
Hey! I wanted to submit [universal-mcp-toolkit](https://github.com/Markgatcha/universal-mcp-toolkit) for inclusion in the **Utilities & Helpers** category. I think it's a great fit for this list and would love to get some feedback!

## About the project

`universal-mcp-toolkit` is an all-in-one MCP server that bundles 15+ general-purpose tools into a single, zero-config package — covering file system operations, web search, weather lookups, SQLite database access, system info, and more. It's designed so developers can drop it into any MCP-compatible client instantly via `npx universal-mcp-toolkit` with no setup required.

**Key highlights:**
- ⚡ Zero-config quickstart: `npx universal-mcp-toolkit`
- 🛠️ 15+ tools in one server (file system, web search, weather, SQLite, system info, and more)
- 📦 Listed on [Glama](https://glama.ai/mcp/servers/@Markgatcha/universal-mcp-toolkit) — discoverable by AI models and developers
- 📈 100+ monthly npm downloads and growing
- 🔑 MIT licensed, written in TypeScript

## Why Utilities & Helpers?

This toolkit is purpose-built as a collection of simple, general-purpose utilities — exactly the kind of servers this category is meant to surface. Rather than being domain-specific, it aggregates a broad range of small helper tools that any developer can immediately put to use.

Happy to adjust the description or placement if needed — thanks for maintaining such a great list! 🙌