### PR TITLE
Add operant-mcp to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1162,6 +1162,8 @@ Servers interacting with security tools and platforms, vulnerability databases, 
 - [Ludok-4/Ghidra](https://github.com/Ludok-4/Ghidra): ghidraMCP enables LLMs to autonomously reverse engineer applications by integrating Ghidra's decompilation and analysis tools with MCP clients.
 - [microsoft/agent-governance-toolkit](https://github.com/microsoft/agent-governance-toolkit): Kernel-level governance MCP server for AI agents — enforces deterministic policies (tool filtering, budget caps, rate limits, audit logging) instead of prompt-based guardrails. Part of microsoft/agent-lightning (14k★). Run via `npx agentos-mcp-server`.
 
+- [operantlabs/operant-mcp](https://github.com/operantlabs/operant-mcp): Security testing MCP server with 51 tools for penetration testing, network forensics, memory analysis, and vulnerability assessment. Install via `npx operant-mcp`.
+
 ## 📱 Social Media & Content Platforms
 
 Servers interacting with social networks, content platforms, or feed aggregators.


### PR DESCRIPTION
## Summary

Adds [operant-mcp](https://github.com/operantlabs/operant-mcp) to the **Security** section.

**operant-mcp** is a security testing MCP server with 51 tools covering:
- Penetration testing (SQL injection, XSS, SSRF, command injection, etc.)
- Network forensics (PCAP analysis, DNS analysis, TLS inspection)
- Memory analysis (Linux/Windows volatility, rootkit detection)
- Vulnerability assessment (file upload testing, deserialization, GraphQL introspection)

Install via `npx operant-mcp`.

## Changes

- Added operant-mcp entry to the Security section in README.md