### PR TITLE
fix: clean up README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,6 @@ For more, please click the category name in the next section.
 - 🔄 - [Version Control](docs/version-control.md)
 - ⚽ - [Sport](docs/sport.md)
 
-
-
 ## 🤖 AI & LLM Integration
 
 Servers integrating with other AI models, AI platforms, RAG tools, prompt management, or agent frameworks.
@@ -1294,6 +1292,7 @@ Servers providing simple, general-purpose tools like time/date information, calc
 - [OpenSourceGuru776/consist](https://github.com/OpenSourceGuru776/consist): Markdownify transforms diverse file types and web content into Markdown format, enhancing readability and shareability.
 
 - [IteraTools](https://api.iteratools.com): Cloud-hosted multi-tool MCP API providing 34+ capabilities through a single endpoint: image generation (Flux), web scraping, TTS, OCR, browser automation, sandboxed code execution, DNS lookup, WHOIS, weather, crypto, QR codes, charts, and more. Pay-per-use with x402 micropayment protocol.
+
 ## 🔄 Version Control
 
 Servers interacting with version control systems and platforms for repository management, issues, pull requests, etc.


### PR DESCRIPTION
## Summary

This PR fixes two formatting issues in `README.md`:

- **Extra blank lines before `## 🤖 AI & LLM Integration`**: There were 3 consecutive blank lines before this heading (after the Server Categories list). Reduced to 1 blank line, consistent with every other section heading in the file.
- **Missing blank line before `## 🔄 Version Control`**: This heading had 0 blank lines separating it from the last list entry above it (`[IteraTools]`). Added the standard 1 blank line separator, consistent with every other section heading in the file.

## Changes

- 2 formatting issues fixed
- No content, links, or entry order was changed
- File now ends with exactly one newline (unchanged)
- Net change: -1 line (removed 2 extra blanks, added 1 missing blank)

## Diff overview

```
@@ -65,8 +65,6 @@
 - ⚽ - [Sport](docs/sport.md)
-
-
 
 ## 🤖 AI & LLM Integration

@@ -1294,6 +1292,7 @@
 - [IteraTools](...): Cloud-hosted multi-tool MCP API ...
+
 ## 🔄 Version Control
```