### PR TITLE
docs: rewrite README intro and fix structural issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@
          ✨✨✨ Learn more about Forge - an open-source middleware service that simplifies AI model provider management. ✨✨✨
     </a>
 </div>
-
 A comprehensive, community-curated collection of [Model Context Protocol (MCP)](https://modelcontextprotocol.io) servers — covering AI assistants, browser automation, databases, cloud platforms, developer tools, and much more.
 
 > **What is MCP?** The Model Context Protocol is an open standard that lets AI models securely connect to external tools, APIs, databases, and filesystems. Think of it as a USB-C port for AI — a universal interface that any model can use to interact with the world.
@@ -43,3 +42,1297 @@ We welcome submissions! To add your MCP server:
 
 ## Server Categories
 
+- 🤖 - [AI & LLM Integration](#-ai--llm-integration)
+- 🎨 - [Art, Culture & Media](#-art-culture--media)
+- 🌐 - [Browser Automation & Web Scraping](#-browser-automation--web-scraping)
+- 🏗️ - [Build & Deployment Tools](#️-build--deployment-tools)
+- ☁️ - [Cloud Platforms & Services](#️-cloud-platforms--services)
+- ✨ - [Code Analysis & Quality](#-code-analysis--quality)
+- 💻 - [Code Execution](#-code-execution)
+- 💬 - [Communication & Messaging](#-communication--messaging)
+- 📝 - [Content Management Systems](#-content-management-systems)
+- 📊 - [Data Analysis & Business Intelligence](#-data-analysis--business-intelligence)
+- 🗄️ - [Databases](#️-databases)
+- 🛠️ - [Developer Productivity & Utilities](#️-developer-productivity--utilities)
+- 📁 - [Filesystems](#-filesystems)
+- 💰 - [Finance & Crypto](#-finance--crypto)
+- 🧰 - [Frameworks](#-frameworks)
+- 🎮 - [Gaming](#-gaming)
+- ⚙️ - [Hardware & IoT](#️-hardware--iot)
+- ❤️ - [Healthcare & Life Sciences](#️-healthcare--life-sciences)
+- 🏛️ - [Infrastructure](#️-infrastructure)
+- 🧠 - [Knowledge Management & Memory](#-knowledge-management--memory)
+- 🗺️ - [Location & Maps](#️-location--maps)
+- 📈 - [Marketing, Sales & CRM](#-marketing-sales--crm)
+- 📡 - [Monitoring & Observability](#-monitoring--observability)
+- 🖼️ - [Multimedia Processing](#️-multimedia-processing)
+- 🖥️ - [Operating System & Command Line](#️-operating-system--command-line)
+- ✅ - [Project & Task Management](#-project--task-management)
+- 🔬 - [Science & Research](#-science--research)
+- 🔎 - [Search](#-search)
+- 🔒 - [Security](#-security)
+- 📱 - [Social Media & Content Platforms](#-social-media--content-platforms)
+- ⚽ - [Sports](#-sports)
+- ✈️ - [Travel & Transportation](#️-travel--transportation)
+- 🔧 - [Utilities & Helpers](#-utilities--helpers)
+- 🔄 - [Version Control](#-version-control)
+
+## 🤖 AI & LLM Integration
+
+Servers integrating with other AI models, AI platforms, RAG tools, prompt management, or agent frameworks.
+
+- [bh-rat/context-awesome](https://github.com/bh-rat/context-awesome) - MCP server for querying 8,500+ curated awesome lists (1M+ items) and fetching the best resources for your agent.
+- [spranab/brainstorm-mcp](https://github.com/spranab/brainstorm-mcp) - Multi-round AI brainstorming debates between multiple models (GPT, DeepSeek, Groq, Ollama, etc.). Pit different LLMs against each other to explore ideas from diverse perspectives.
+- [deadpixel/roundtable-dashboard](https://github.com/deadpixel/roundtable-dashboard): Multi-model AI debate platform with remote MCP server. GPT-4o, Claude, Gemini and 200+ models discuss prompts in structured rounds and synthesize collective insight via Streamable HTTP at `https://mcp.roundtable.now/mcp`.
+- [comitest22/linear-mcp](https://github.com/comitest22/linear-mcp): Facilitates interaction with the Linear API through a Model Context Protocol server, offering tools for ticket management and prioritization.
+- [stephenlb/pubnub-mcp-server](https://github.com/stephenlb/pubnub-mcp-server): Facilitates access to PubNub SDK and Functions documentation within Cursor IDE using a CLI-based MCP server.
+- [Ankit2533/research](https://github.com/Ankit2533/research): A multi-agent deep researcher leveraging MCP to perform comprehensive web searches with Linkup and CrewAI orchestration.
+- [CDataSoftware/cdata-jdbc-mcp-server](https://github.com/CDataSoftware/cdata-jdbc-mcp-server): Facilitates querying live data from over 300 sources via CData JDBC Drivers using natural language through a read-only MCP interface.
+- [kylewoolstenhulme-block/Notion-Goose-MCP](https://github.com/kylewoolstenhulme-block/Notion-Goose-MCP): Facilitates seamless interaction with the Notion API through an MCP server, enabling automated content management and integration.
+- [Ankit2533/multi-agentic_deepresearch](https://github.com/Ankit2533/multi-agentic_deepresearch): A multi-agent deep researcher leveraging MCP to orchestrate AI agents for collaborative deep web searches and knowledge synthesis.
+- [drdeeks/remote-mcp-server](https://github.com/drdeeks/remote-mcp-server): Deploy a remote MCP server on Cloudflare Workers with OAuth login, enabling seamless integration with tools like Claude Desktop.
+- [raj-mehra/jira-mcp](https://github.com/raj-mehra/jira-mcp): Integrates Jira with MCP to fetch and search ticket details using a flexible framework.
+- [AlexShan2008/mcp-claude-weather](https://github.com/AlexShan2008/mcp-claude-weather): Provides real-time weather alerts and forecasts from the US National Weather Service, seamlessly integrating with Claude for Desktop.
+- [expensivefav/mcp](https://github.com/expensivefav/mcp): Facilitates interaction with Algolia APIs through experimental MCP servers, enabling search and data manipulation tasks.
+- [vinodismyname/redshift-utils-mcp](https://github.com/vinodismyname/redshift-utils-mcp): Facilitates AI-driven interaction with Amazon Redshift, enabling secure data querying and diagnostics via the AWS Data API.
+- [frostming/openweather-mcp](https://github.com/frostming/openweather-mcp): Facilitates weather data retrieval from OpenWeather.org via a Model Context Protocol server.
+- [jasiekkk/jan-stripe](https://github.com/jasiekkk/jan-stripe): Deploy a remote MCP server on Cloudflare Workers without authentication, enabling seamless integration with Cloudflare AI Playground and local MCP clients.
+- [MartinPSDev/curl-mcp](https://github.com/MartinPSDev/curl-mcp): Transforms natural language instructions into curl commands, supporting English and Spanish, for seamless HTTP requests.
+- [natifridman/stocks-mcp](https://github.com/natifridman/stocks-mcp): Fetches real-time stock information from Google Finance using a Pythonic MCP server framework.
+- [dithom/shopware-mcp](https://github.com/dithom/shopware-mcp): Automates bugfixing for Shopware plugins by leveraging LLMs to handle support tickets and plugin versions.
+- [shankarpriyank/remote-mcp-server-authless](https://github.com/shankarpriyank/remote-mcp-server-authless): Deploy a remote MCP server without authentication on Cloudflare Workers, enabling seamless integration with Cloudflare AI Playground and local MCP clients.
+- [slot181/openapi-integrator-mcp](https://github.com/slot181/openapi-integrator-mcp): Facilitates high-quality image generation through OpenAI-compatible APIs, offering a standardized interface for specifying image parameters.
+- [kukapay/crypto-rss-mcp](https://github.com/kukapay/crypto-rss-mcp): Aggregates real-time cryptocurrency news from multiple RSS feeds to assist AI agents in making informed market decisions.
+- [AlekseyKapustyanenko/NihFix.Postgres.Mcp](https://github.com/AlekseyKapustyanenko/NihFix.Postgres.Mcp): Facilitates real-time AI agent interactions with PostgreSQL databases using SSE and STDIO protocols.
+- [CrewAakash/mcp-server-for-copilot](https://github.com/CrewAakash/mcp-server-for-copilot): Facilitates seamless integration of Microsoft Copilot Studio agents with MCP-compatible clients, maintaining conversation context and supporting stateful interactions.
+- [xiaok/etherscan-mcp](https://github.com/xiaok/etherscan-mcp): Facilitates seamless interaction with Etherscan's API through a dynamic MCP server.
+- [qingshanyuluo/prometheus-mcp-server](https://github.com/qingshanyuluo/prometheus-mcp-server): A streamlined Prometheus MCP server designed for metric collection and AI-friendly analysis.
+- [falahgs/MCP-Storybook-Image-Generator](https://github.com/falahgs/MCP-Storybook-Image-Generator): Generates storybook images and matching children's stories using Google's Gemini AI, offering multiple art styles and instant previews.
+- [MCP-Reasoner/MCP-Reasoner](https://github.com/MCP-Reasoner/MCP-Reasoner): Integrates Google's OR-Tools with Large Language Models for constraint solving and optimization through the Model Context Protocol.
+- [AzureDevOpsAPI/Azure-DevOps](https://github.com/AzureDevOpsAPI/Azure-DevOps): Facilitates AI-driven interactions with Azure DevOps APIs, enabling seamless project management and DevOps workflows through natural language commands.
+- [Excoriate/mcp-terraform-aws-provider-docs](https://github.com/Excoriate/mcp-terraform-aws-provider-docs): Provides contextual information and resources for Terraform AWS Provider documentation, enabling AI agents to query up-to-date data directly from the source.
+- [tangshuang/mcp-bone](https://github.com/tangshuang/mcp-bone): Facilitates connection to MCP Bone for tool registration and parsing LLM completion text into tool calls.
+- [belljustin/spotify-mcp](https://github.com/belljustin/spotify-mcp): Facilitates playlist creation on Spotify through a Model Context Protocol server, integrating seamlessly with Cursor for enhanced user interaction.
+- [Zerg00s/server-sharepoint](https://github.com/Zerg00s/server-sharepoint): Facilitates interaction with SharePoint Online through Claude Desktop using the SharePoint REST API.
+
+## 🎨 Art, Culture & Media
+
+Servers interacting with APIs for museums, media databases, image/video hosting, or creative content platforms.
+
+- [ourongxing/newsnow-mcp-server](https://github.com/ourongxing/newsnow-mcp-server): Facilitates access to over 40 news sources through a dedicated MCP server for NewsNow.
+- [trevhud/vibe-mcp](https://github.com/trevhud/vibe-mcp): Generates music based on coding context with support for multiple audio backends and seamless playback.
+- [eluc1a/mcp-news](https://github.com/eluc1a/mcp-news): Facilitates access to categorized news articles from a database, enabling clients to retrieve and summarize the latest content.
+- [Toos00/freepik-mcp-server](https://github.com/Toos00/freepik-mcp-server): Facilitates interaction with Freepik.com's API for image and vector searches using the Model Context Protocol.
+- [chatmcp/heybeauty-mcp](https://github.com/chatmcp/heybeauty-mcp): Facilitates virtual try-on experiences by leveraging HeyBeauty API to manage and execute try-on tasks with clothing resources.
+- [kokushin/exia-mcp](https://github.com/kokushin/exia-mcp): Generates and displays scenario files for the exia visual novel engine in the Kotoha Sisters explanation format.
+- [molmolkky/prompt-character-mcp-server](https://github.com/molmolkky/prompt-character-mcp-server): Facilitates the retrieval of iconic quotes from the character Ou Ki from the manga 'Kingdom' via an MCP server.
+- [enggpt-it/MCP-Server-Cybersecurity-News](https://github.com/enggpt-it/MCP-Server-Cybersecurity-News): Access the latest cybersecurity news from various websites with seamless Claude Desktop integration.
+- [NFTGo/mcp-nftgo-api](https://github.com/NFTGo/mcp-nftgo-api): Facilitates seamless interaction with the NFTGo Developer API, offering comprehensive NFT data and analytics for Ethereum-based assets.
+- [Lala-0x3f/mj-mcp](https://github.com/Lala-0x3f/mj-mcp): Facilitates image generation using Midjourney through an MCP server interface.
+- [JayArrowz/mcp-osrs](https://github.com/JayArrowz/mcp-osrs): Facilitates interaction with the Old School RuneScape Wiki API and game data files through a Model Context Protocol server.
+- [RohitMidha23/youtube-mcp](https://github.com/RohitMidha23/youtube-mcp): Facilitates LLMs in extracting and analyzing subtitles from YouTube videos for content processing.
+- [Otto-J/podcast-xyzrank-mcp](https://github.com/Otto-J/podcast-xyzrank-mcp): Facilitates podcast recommendations using MCP to access curated podcast rankings.
+- [miyamo2/hotpepper-gourmet-mcp-server](https://github.com/miyamo2/hotpepper-gourmet-mcp-server): Facilitates gourmet search and area-based queries using the Hot Pepper Gourmet API.
+- [Antipas/4oimage-mcp](https://github.com/Antipas/4oimage-mcp): Integrates with 4o-image API to enable AI-driven image generation and editing through text prompts.
+- [sunqirui1987/ae-mcp](https://github.com/sunqirui1987/ae-mcp): Enables AI assistants to control Adobe After Effects through a standardized MCP interface, offering extensive functionality for compositions, layers, and effects.
+- [lieyanqzu/ygocdb-mcp](https://github.com/lieyanqzu/ygocdb-mcp): Facilitates interaction with the YGO Chinese card database API, offering tools for card information retrieval and image access.
+- [dbeltra/scryfall-mcp](https://github.com/dbeltra/scryfall-mcp): Interfaces with the Scryfall API to fetch and display detailed Magic: The Gathering card data.
+- [Kota8102/aws-weekly-news-mcp](https://github.com/Kota8102/aws-weekly-news-mcp): Facilitates access to Japanese 'Weekly AWS' blog articles through a dedicated MCP server.
+- [x0x0b/mcp-nicovideo-snapshot-search](https://github.com/x0x0b/mcp-nicovideo-snapshot-search): Facilitates video searches on Nicovideo using the Snapshot Search API.
+- [nvsofts/jlcpcb-parts-mcp](https://github.com/nvsofts/jlcpcb-parts-mcp): Facilitates component search for JLCPCB PCBA using a dedicated MCP server.
+- [Ukenn2112/BangumiMCP](https://github.com/Ukenn2112/BangumiMCP): Facilitates interaction with BangumiTV's API for accessing anime, manga, music, and game data.
+- [falahgs/gemini-vision-art-studio](https://github.com/falahgs/gemini-vision-art-studio): Gemini Vision Art Studio harnesses Google's Gemini AI to generate 3D cartoons and transform images with artistic flair.
+- [0010aor/mcp-mtg-assistant](https://github.com/0010aor/mcp-mtg-assistant): Fetches Magic: The Gathering card details using the Scryfall API, aiding in rules queries and card information retrieval.
+- [cmathgit/biblegateway-votd-mcp](https://github.com/cmathgit/biblegateway-votd-mcp): Access the BibleGateway Verse of the Day in multiple languages and versions without requiring an API key.
+- [Tok/SuperColliderMCP](https://github.com/Tok/SuperColliderMCP): Facilitates AI-driven audio synthesis and processing in SuperCollider via OSC messages, enabling dynamic sound generation and integration with AI development environments.
+- [raj-mehra/figma-mcp](https://github.com/raj-mehra/figma-mcp): Facilitates interaction with Figma design files by extracting design tokens and components for integration with Cursor IDE.
+- [opensourcedev90s/uk-science-museum-group-mcp](https://github.com/opensourcedev90s/uk-science-museum-group-mcp): Facilitates data retrieval from the UK Science Museum Group API for LLMs via a Python-based MCP server.
+- [AnshulDalua/illustrator-mcp](https://github.com/AnshulDalua/illustrator-mcp): Facilitates script execution in Adobe Illustrator via MCP, leveraging JavaScript and AppleScript on MacOS.
+- [hugeicons/mcp-server](https://github.com/hugeicons/mcp-server): Facilitates seamless integration of Hugeicons across various platforms by providing tools, resources, and platform-specific guides for AI assistants.
+
+## 🌐 Browser Automation & Web Scraping
+
+Servers using tools for browser control, automation, and extracting content from websites.
+
+- [giannisalinetti/python-mcp-server](https://github.com/giannisalinetti/python-mcp-server): Facilitates Python code execution for web scraping tasks using an LLM, leveraging Podman for container management.
+- [mhazarabad/browser-use-mcp](https://github.com/mhazarabad/browser-use-mcp): Automates browser tasks using the Browser Use API, offering task management and monitoring capabilities.
+- [1999AZZAR/mcp-server-google-search](https://github.com/1999AZZAR/mcp-server-google-search): Facilitates Google Programmable Search Engine queries through a structured MCP server interface, enhancing integration with Claude Desktop.
+- [luminati-io/web-scraping-with-mcp](https://github.com/luminati-io/web-scraping-with-mcp): Connects Anthropic LLMs to external web scraping tools using Bright Data integration for real-world data extraction.
+- [magicp-mhl/newsnow](https://github.com/magicp-mhl/newsnow): Facilitates elegant real-time news reading with adaptive scraping and MCP server support for seamless integration.
+- [regenrek/deepwiki-mcp](https://github.com/regenrek/deepwiki-mcp): Fetches and converts Deepwiki content into Markdown for LLM consumption, ensuring domain safety and efficient crawling.
+- [yan5236/bing-cn-mcp-server](https://github.com/yan5236/bing-cn-mcp-server): A Chinese Bing search tool leveraging MCP for seamless integration with AI tools like Claude, enabling direct Bing searches and webpage content retrieval without an API key.
+- [w1561778301/mcp-playwright-test](https://github.com/w1561778301/mcp-playwright-test): Automates Playwright tests by generating and executing UI and API test cases with detailed reporting.
+- [ai-dashboad/flutter-skill](https://github.com/ai-dashboad/flutter-skill): AI-powered E2E testing bridge for any app. Supports Flutter, iOS, Android, Web, Electron, Tauri, KMP, React Native, .NET MAUI.
+- [xinlei413/DOC-Server-MCP](https://github.com/xinlei413/DOC-Server-MCP): Fetches and searches third-party package documentation using versatile scraping and intelligent processing with hybrid search capabilities.
+- [kxkaloo/mcp](https://github.com/kxkaloo/mcp): Enables AI models to extract structured data from websites using the Scrapezy MCP server.
+- [eadm/grain-mcp-server](https://github.com/eadm/grain-mcp-server): Facilitates integration with Grain for meeting recording and transcription through browser automation, bypassing enterprise API restrictions.
+- [jobsonlook/xhs-mcp](https://github.com/jobsonlook/xhs-mcp): Facilitates interaction with Xiaohongshu by reverse-engineering JavaScript to access and manage notes and comments without Playwright.
+- [mohdsuhail007/VerbilioMCP](https://github.com/mohdsuhail007/VerbilioMCP): Facilitates seamless integration with GitHub using Verbilio MCP server for streamlined workflow automation.
+- [myzxlin/redbook-mcp](https://github.com/myzxlin/redbook-mcp): Facilitates automated publishing of text and video notes on Xiaohongshu using Playwright for browser automation.
+- [larryhudson/mcp-server-example-image-block](https://github.com/larryhudson/mcp-server-example-image-block): Provides a random image retrieval service using the Lorem Picsum API, demonstrating MCP server capabilities with image blocks.
+- [Elvis720/mcp-agent](https://github.com/Elvis720/mcp-agent): Facilitates browser automation for LLMs using Playwright's accessibility tree, enabling structured web interactions without visual models.
+- [xinlei413/MCP-DOC-Server-OpenRouter](https://github.com/xinlei413/MCP-DOC-Server-OpenRouter): Facilitates efficient scraping, processing, and searching of third-party package documentation with advanced hybrid search capabilities.
+- [thomasvan/mcp-brave-search](https://github.com/thomasvan/mcp-brave-search): Facilitates AI assistant integration with Brave Search through a Model Context Protocol server.
+- [oddlyspaced/ultimate-android-mcp](https://github.com/oddlyspaced/ultimate-android-mcp): Empower LLMs to autonomously manage and interact with Android devices through a comprehensive MCP server.
+- [kengerlwl/phoneMcp](https://github.com/kengerlwl/phoneMcp): Enables AI assistants to control Android phones via ADB. Supports zero-config Skill mode (CatPaw/Claude Code) and standard MCP server mode (Claude Desktop/Cursor). Features screen capture, tap/swipe gestures, text input, app management, file transfer, and shell commands.
+- [ronantakizawa/a11ymcp](https://github.com/ronantakizawa/a11ymcp): Empowers LLMs to conduct comprehensive web accessibility testing using Deque Axe-core API and Puppeteer.
+- [hamibot/hamibot-mcp-server](https://github.com/hamibot/hamibot-mcp-server): Facilitates interaction with the Hamibot API, offering tools for device and script management, including custom JavaScript execution on specified devices.
+- [YantaoMou/mcp_droid](https://github.com/YantaoMou/mcp_droid): Facilitates direct control and operation of Android devices by large language models through a standardized interface.
+- [LuckyXYJ/mcp_ios_project](https://github.com/LuckyXYJ/mcp_ios_project): An MCP server configured for iOS projects, utilizing Python scripts for server execution.
+- [ying-dao/yingdao_mcp_server](https://github.com/ying-dao/yingdao_mcp_server): Empowers YingDao AI Power and other MCP Hosts to execute RPA tasks, supporting both SSE and Stdio server modes.
+- [catinair/aipower-rpa-mcp-server](https://github.com/catinair/aipower-rpa-mcp-server): Facilitates seamless interaction between YindDao AI Power and RPA tools, enabling AI-driven automation workflows.
+- [bneil/mcp-go-colly](https://github.com/bneil/mcp-go-colly): A sophisticated web crawling framework integrating MCP with Colly for flexible and extensible web content extraction in LLM applications.
+- [ertugrul59/tradingview-chart-mcp](https://github.com/ertugrul59/tradingview-chart-mcp): Fetches TradingView chart images using ticker and interval inputs for seamless integration with MCP clients.
+- [sungithubid/mcp-url2markdown](https://github.com/sungithubid/mcp-url2markdown): Transforms web page content from a given URL into clean, formatted markdown using MCP server capabilities.
+- [NexusX-MCP/data-mcp-server](https://github.com/NexusX-MCP/data-mcp-server): Facilitates web scraping, data extraction, and browser automation with integration for agents like OpenAI's CUA and Anthropic's Claude.
+- [korwabs/playwright-trace-mcp](https://github.com/korwabs/playwright-trace-mcp): Enhances browser automation with Playwright by adding trace viewer and video recording capabilities, enabling LLMs to interact with web pages through structured data.
+- [bzsasson/screaming-frog-mcp](https://github.com/bzsasson/screaming-frog-mcp): Screaming Frog SEO Spider integration for crawling websites, exporting SEO data, and managing crawl storage through AI assistants.
+
+## 🏗️ Build & Deployment Tools
+
+Servers interacting with build systems, containerization, CI/CD, or deployment platforms.
+
+- [zenoengine/msbuild-mcp-server](https://github.com/zenoengine/msbuild-mcp-server): Automates MSBuild project builds with dynamic discovery and customizable configurations, integrating seamlessly with various MCP clients.
+- [radostkali/gitlab-mcp-server](https://github.com/radostkali/gitlab-mcp-server): Facilitates GitLab integration using FastMCP for streamlined code review and repository management.
+- [rianvdm/remote-mcp-server](https://github.com/rianvdm/remote-mcp-server): Deploy a remote MCP server on Cloudflare Workers with OAuth login and connect it to Claude Desktop for seamless tool integration.
+- [gabelul/perplexity-mcp](https://github.com/gabelul/perplexity-mcp): An intelligent research assistant leveraging Perplexity's AI models for automatic query complexity detection and optimal model routing.
+- [yoda-digital/horologic-mcp](https://github.com/yoda-digital/horologic-mcp): Horologic MCP is a TypeScript server for time and timezone operations, seamlessly integrating with MCP-compatible clients like Claude Desktop.
+- [Miura55/fastapi-mcp-workshop](https://github.com/Miura55/fastapi-mcp-workshop): A workshop sample code for implementing MCP using FastAPI, facilitating integration with mcp-proxy.
+- [hipposys-ltd/airflow-mcp](https://github.com/hipposys-ltd/airflow-mcp): Enhance your Apache Airflow management with natural language queries and troubleshooting using a custom MCP server.
+- [aYenx/remote-mcp-server](https://github.com/aYenx/remote-mcp-server): Deploy a remote MCP server on Cloudflare Workers with OAuth login, enabling seamless integration with Claude Desktop and MCP Inspector.
+- [kaeosdesign/remote-mcp-server](https://github.com/kaeosdesign/remote-mcp-server): Deploy and manage a remote MCP server on Cloudflare Workers with OAuth login and integration with Claude Desktop.
+- [vistaarjuneja/harness-mcp](https://github.com/vistaarjuneja/harness-mcp): Facilitates the management of connectors within the Harness platform using a Model Context Protocol server.
+- [ankit1057/nexuscontroller](https://github.com/ankit1057/nexuscontroller): NexusController offers advanced Android automation with MCP support for seamless AI integration, enabling robust device control and UI testing.
+- [yodablocks/mcp-installer.0](https://github.com/yodablocks/mcp-installer.0): Facilitates the installation of MCP servers from npm or PyPi using Claude, streamlining server setup processes.
+- [akr4/claude-code-mcp-docker](https://github.com/akr4/claude-code-mcp-docker): A Docker container for running Claude Code MCP server with enhanced security features, including a network firewall to prevent unauthorized outbound connections.
+- [sakomws/mcp-cf-deploy](https://github.com/sakomws/mcp-cf-deploy): Deploy a remote MCP server on Cloudflare Workers with OAuth login and connect it to Claude Desktop for seamless tool integration.
+- [hiroooo000/mydockers](https://github.com/hiroooo000/mydockers): Facilitates browser automation using Playwright within a Dockerized MCP server environment.
+- [dandacompany/webhook-trigger](https://github.com/dandacompany/webhook-trigger): Facilitates dynamic webhook transmission using FastMCP framework with support for various HTTP methods and custom headers.
+- [base/base-builder-mcp](https://github.com/base/base-builder-mcp): Facilitates integration with Base Docs for Model Context Protocol, enabling seamless interaction with Base Builders.
+- [snowsky/mcp-helmfile](https://github.com/snowsky/mcp-helmfile): Facilitates Helmfile command execution and management through a standardized MCP interface, enhancing AI-assisted deployments and configurations.
+- [buildkite/buildkite-mcp-server](https://github.com/buildkite/buildkite-mcp-server): Facilitates access to Buildkite pipeline, build, and job data for integration with tools like Claude Desktop and GitHub Copilot.
+- [bsmith925/mcp-examples](https://github.com/bsmith925/mcp-examples): Explore deployment configurations and custom implementations for team-wide MCP servers, focusing on Git repository management and Kubernetes deployment.
+- [misanthropic-ai/lean-docker-mcp](https://github.com/misanthropic-ai/lean-docker-mcp): Facilitates the execution of Lean4 code in isolated Docker containers for LLM-powered agents, offering both transient and persistent environments.
+- [kappaexpress/docker-mcp](https://github.com/kappaexpress/docker-mcp): Facilitates MCP server integration with Claude Desktop using a Docker image built with Playwright.
+- [aaomidi/mcp-bazel](https://github.com/aaomidi/mcp-bazel): Facilitates Bazel project interactions by providing build, test, and dependency analysis tools.
+- [ThomasRohde/mcp_server_manager](https://github.com/ThomasRohde/mcp_server_manager): A backend Python application offering a Model Context Protocol interface and FastAPI web interface for managing MCP servers integrated with Claude Desktop.
+- [addozhang/spring-rest-to-mcp](https://github.com/addozhang/spring-rest-to-mcp): Effortlessly transform Spring Web REST APIs into MCP server tools using OpenRewrite recipes for seamless AI integration.
+- [gunpal5/QuickMCP](https://github.com/gunpal5/QuickMCP): QuickMCP enables rapid creation and deployment of MCP servers using OpenAPI, Swagger, or Google Discovery specifications with .NET.
+- [Drew-Goddyn/buildkite-mcp](https://github.com/Drew-Goddyn/buildkite-mcp): Facilitates seamless integration with Buildkite by providing a microservice for retrieving and managing build information via MCP.
+- [thepragmatik/mcp-server-jvm-build-tools](https://github.com/thepragmatik/mcp-server-jvm-build-tools): Facilitates natural language interaction with Apache Maven through an MCP server for streamlined project builds.
+- [f-inc/containerinc-mcp](https://github.com/f-inc/containerinc-mcp): Automates deployments to Container Inc. with ephemeral and free deployment capabilities.
+- [cpecf/docker-mcp](https://github.com/cpecf/docker-mcp): Facilitates Docker container and compose stack management through Claude AI integration.
+
+## ☁️ Cloud Platforms & Services
+
+Servers integrating with major cloud providers or specific cloud services.
+
+- [doma2k/monad-contract-deployment-mcp](https://github.com/doma2k/monad-contract-deployment-mcp): Facilitates the compilation and deployment of smart contracts within the Monad ecosystem, enabling interactions directly from chat prompts or compatible MCP clients.
+- [adrianmonad/MonDeployer](https://github.com/adrianmonad/MonDeployer): Facilitates the deployment of Solidity contracts to the Monad testnet using AI and MCP integration.
+- [groovyBugify/aws-security-mcp](https://github.com/groovyBugify/aws-security-mcp): Connects AI assistants to AWS security services for autonomous security analysis and threat modeling.
+- [joeseesun/qiniu-mcp-joe](https://github.com/joeseesun/qiniu-mcp-joe): Facilitates file uploads to Qiniu Cloud Storage, providing a seamless integration for managing media assets.
+- [Tencent/cos-mcp](https://github.com/Tencent/cos-mcp): Facilitates seamless integration of large models with Tencent Cloud Storage (COS) and Data Processing (CI) capabilities without coding.
+- [Azure/blue-bridge](https://github.com/Azure/blue-bridge): Facilitates querying and managing Azure resources using MCP server with zero-secret authentication, supporting Azure Managed Grafana, Azure Data Explorer, and more.
+- [oliverbenns/digitalocean-mcp](https://github.com/oliverbenns/digitalocean-mcp): Manage and monitor DigitalOcean app platform deployments and alerts using the Model Context Protocol.
+- [Ropz3/remote-mcp-server](https://github.com/Ropz3/remote-mcp-server): Deploy and manage a remote MCP server on Cloudflare Workers with OAuth login and integration with Claude Desktop.
+- [curious-pm/mcp-google_cloud_billing](https://github.com/curious-pm/mcp-google_cloud_billing): Facilitates integration with Google Cloud Billing API, enabling AI assistants to analyze and manage cloud costs efficiently.
+- [curious-pm/mcp-digital_ocean_billing](https://github.com/curious-pm/mcp-digital_ocean_billing): Facilitates seamless integration with Digital Ocean's Billing API, offering tools for viewing account balances, billing history, and invoices.
+- [bizflycloud/bizflycloud-mcp-server](https://github.com/bizflycloud/bizflycloud-mcp-server): Connects to Bizfly Cloud for comprehensive cloud resource management, utilizing the mark3labs/mcp-go SDK.
+- [JCallico/py-az-mcp](https://github.com/JCallico/py-az-mcp): Facilitates seamless integration with Azure services via Azure CLI commands, enabling a wide range of cloud operations.
+- [leeb003/supabase-mcp](https://github.com/leeb003/supabase-mcp): Facilitates CRUD operations on Supabase databases through a FastAPI-based MCP server, ensuring seamless integration with Cursor.
+- [noahseger/cf-example-remote-mcp-server](https://github.com/noahseger/cf-example-remote-mcp-server): Deploy a remote MCP server on Cloudflare Workers with OAuth login and connect it to Claude Desktop for seamless tool integration.
+- [nhc/cloudflare-remote-mcp-server](https://github.com/nhc/cloudflare-remote-mcp-server): Deploy a remote MCP server on Cloudflare Workers with OAuth login and connect it to Claude Desktop for seamless tool integration.
+- [sanxxit/my-aws-cost-explorer](https://github.com/sanxxit/my-aws-cost-explorer): Facilitates AWS spend analysis and visualization through an MCP server, integrating with Anthropic's Claude model for natural language queries.
+- [sanxxit/AWS-cost-explorer-with-MCP-server](https://github.com/sanxxit/AWS-cost-explorer-with-MCP-server): Facilitates AWS spend analysis and visualization through an interactive interface using Anthropic's Claude model.
+- [Collaborne/mcp-server](https://github.com/Collaborne/mcp-server): Facilitates interaction between Large Language Models and NEXT structured data, enabling operations like retrieving highlights and clusters.
+- [trilliwon/lion-mcp-server](https://github.com/trilliwon/lion-mcp-server): Deploy a remote MCP server on Cloudflare Workers with OAuth login and connect it to Claude Desktop for seamless tool integration.
+- [jhgaylor/me_mcp_server](https://github.com/jhgaylor/me_mcp_server): Facilitates personalized job search and profile management through a Model Context Protocol server.
+- [bocchiczennie/aws-monthly-cost-report-mcp-server](https://github.com/bocchiczennie/aws-monthly-cost-report-mcp-server): Facilitates the generation of monthly AWS cost reports through an MCP server, integrating seamlessly with Claude Desktop.
+- [roboulos/remote-mcp-server](https://github.com/roboulos/remote-mcp-server): A remote MCP server leveraging Cloudflare Workers and Xano for efficient tool management, session tracking, and OAuth integration.
+- [anandkumarpatel/remote-mcp-server](https://github.com/anandkumarpatel/remote-mcp-server): Deploy a remote MCP server on Cloudflare Workers with OAuth login, enabling seamless integration with tools like Claude Desktop.
+- [Arodoid/FastlyMCP](https://github.com/Arodoid/FastlyMCP): Fastly MCP integrates Fastly's API with AI assistants, enabling seamless management of CDN services, caching, security, and performance monitoring through the Model Context Protocol.
+- [tumf/fastmcp-gsuite](https://github.com/tumf/fastmcp-gsuite): Facilitates seamless interaction with Gmail and Google Calendar through a fastmcp-based server, supporting multiple accounts and advanced email and calendar management.
+- [atalhens/ntnx-mcp](https://github.com/atalhens/ntnx-mcp): Facilitates Nutanix Virtual Machine Management through a command-line chatbot interface, integrating with Nutanix AI LLM endpoints and supporting dynamic tool integration.
+- [aradtamako/DnfApiServer](https://github.com/aradtamako/DnfApiServer): Facilitates interaction with DNF APIs through an MCP server setup, enabling seamless integration with tools like Copilot and Claude.
+- [bittush8789/MCP](https://github.com/bittush8789/MCP): Fetches weather data from the National Weather Service API, providing tools for retrieving active alerts and short-term forecasts.
+- [antymijaljevic/k8s-doc-mcp](https://github.com/antymijaljevic/k8s-doc-mcp): A Python-based MCP server for managing and summarizing sticky notes using the Model Context Protocol SDK.
+- [stephenlacy/mcp-proxy](https://github.com/stephenlacy/mcp-proxy): A fast Rust-based proxy facilitating bidirectional communication between stdio and SSE for MCP servers.
+
+## ✨ Code Analysis & Quality
+
+Servers focused on static analysis, linting, code metrics, security scanning, vulnerability checks, or code quality assessment.
+
+- [dhylan01/MCP_OA](https://github.com/dhylan01/MCP_OA): Facilitates AI assistants in analyzing code by identifying function usage within Python and TypeScript/TSX files.
+- [angrysky56/ast-mcp-server](https://github.com/angrysky56/ast-mcp-server): Provides code structure and semantic analysis using AST and ASG for multiple programming languages, enhancing code analysis capabilities in Claude Desktop.
+- [joaomj/code-reviewer-mcp](https://github.com/joaomj/code-reviewer-mcp): Automated GitHub pull request code reviews using AI models via MCP integration.
+- [shaydo-deriv/go-archer](https://github.com/shaydo-deriv/go-archer): Go Archer provides a visual representation of package dependencies and can operate as an MCP server for dependency analysis.
+- [RaRdq/RR.MCP](https://github.com/RaRdq/RR.MCP): Facilitates AI-driven .NET project analysis by extracting interfaces, models, and data structures using PowerShell scripts.
+- [mettamatt/code-reasoning](https://github.com/mettamatt/code-reasoning): Enhances Claude's problem-solving capabilities by breaking down complex programming tasks into manageable steps using structured, sequential thinking.
+- [jpheimonen/code-oracle](https://github.com/jpheimonen/code-oracle): Code Oracle leverages AI to efficiently locate code within large codebases using Gemini 2.5 Flash, integrating seamlessly as an MCP server in Cursor.
+- [FuelLabs/fuel-mcp-server](https://github.com/FuelLabs/fuel-mcp-server): Facilitates seamless IDE integration with Fuel Network and Sway Language documentation through advanced semantic search capabilities.
+- [AB498/code-context-provider-mcp](https://github.com/AB498/code-context-provider-mcp): Provides code context and analysis for AI assistants by extracting directory structures and code symbols using WebAssembly Tree-sitter parsers.
+- [alesr/gh-self-reviewer](https://github.com/alesr/gh-self-reviewer): A Go-based Anthropic MCP server facilitating self-review of GitHub pull requests with Claude AI integration.
+- [lq0910/vuesage](https://github.com/lq0910/vuesage): VueSage enhances Vue component quality through intelligent analysis and optimization, leveraging MCP for seamless integration with editors.
+- [Bamimore-Tomi/ghidra_mcp](https://github.com/Bamimore-Tomi/ghidra_mcp): Transforms Ghidra into a reverse-engineering backend by extracting decompiled binary data and exposing it to LLMs via MCP.
+- [aidalinfo/mcp-clean-code](https://github.com/aidalinfo/mcp-clean-code): Facilitates the planning and creation of clean, well-structured code with comprehensive English comments, focusing on readability and maintainability.
+- [DocNR/repo-explorer](https://github.com/DocNR/repo-explorer): Efficiently explore and analyze Git repositories with advanced caching and cross-repository code pattern search, integrating seamlessly with Claude AI.
+- [yy1588133/code-merge-mcp](https://github.com/yy1588133/code-merge-mcp): Facilitates code file extraction, merging, and analysis for large language models using the Model Context Protocol.
+- [davidleathers113/typescript-analyzer-mcp](https://github.com/davidleathers113/typescript-analyzer-mcp): Enhance TypeScript codebases by intelligently analyzing and replacing 'any' types with specific types, while offering React component interface generation and advanced error handling.
+- [Vulert](https://www.vulert.com): Vulert secures software by detecting vulnerabilities in open-source dependencies—without accessing your code. It supports Js, PHP, Java, Python, and more.
+- [priyankark/a11y-mcp](https://github.com/priyankark/a11y-mcp): Conducts comprehensive accessibility audits on webpages using axe-core, integrating seamlessly with AI assistants to address a11y issues.
+- [hanqizheng/unit-test-generator-mcp-server](https://github.com/hanqizheng/unit-test-generator-mcp-server): Generates unit tests for component libraries using the MCP protocol.
+- [crisschan/mcp-jacoco-reporter](https://github.com/crisschan/mcp-jacoco-reporter): Transforms JaCoCo code coverage reports into AI-friendly formats for enhanced analysis and insights.
+- [Tomatio13/software-checker-mcp](https://github.com/Tomatio13/software-checker-mcp): Facilitates comprehensive quality checks and release note generation for Git repositories, while also providing security risk analysis.
+- [smadi0x86/GDB-MCP](https://github.com/smadi0x86/GDB-MCP): Facilitates LLM-driven debugging and analysis with GDB through an MCP server interface.
+- [Ixe1/code-scanner-server](https://github.com/Ixe1/code-scanner-server): A versatile tool for scanning code files, extracting definitions, and providing LLM-friendly outputs, with dual operation as a CLI tool and MCP server.
+- [mobilehackinglab/jadx-mcp-plugin](https://github.com/mobilehackinglab/jadx-mcp-plugin): Facilitates decompiler access for Claude by bridging Jadx API over HTTP using MCP, enabling live interaction with decompiled code.
+- [first-to-fly/code-cleanup](https://github.com/first-to-fly/code-cleanup): A Bun TypeScript project offering a Model Context Protocol server for code cleanup using Google's Generative AI, with features like backup, custom prompts, and professional formatting.
+- [hloiseaufcms/mcp-gopls](https://github.com/hloiseaufcms/mcp-gopls): Facilitates AI assistants' interaction with Go's Language Server Protocol for enhanced code analysis and navigation.
+- [irvinebroque/repro-root-mcp-issue](https://github.com/irvinebroque/repro-root-mcp-issue): Deploy and manage a remote MCP server on Cloudflare Workers with OAuth login and integration with Claude Desktop.
+- [r-huijts/mcp-server-tester](https://github.com/r-huijts/mcp-server-tester): A configuration-driven tool for automating tests and generating reports for MCP servers, leveraging Claude AI for intelligent test case generation.
+- [nodetec/nostr-code-snippet-mcp](https://github.com/nodetec/nostr-code-snippet-mcp): Facilitates the execution of code snippets via a node-based MCP server.
+- [BangNGH/github-code-index-mcp-server](https://github.com/BangNGH/github-code-index-mcp-server): Facilitates code indexing, searching, and analysis for large language models across multiple programming languages.
+- [CodeLogicIncEngineering/codelogic-mcp-server](https://github.com/CodeLogicIncEngineering/codelogic-mcp-server): Leverage Codelogic's software dependency data for impact assessments in AI programming assistants.
+- [autonomous-testing/wopee-mcp](https://github.com/autonomous-testing/wopee-mcp): AI testing agents for web apps — dispatch test runs, analysis crawls, and AI agent tests, fetch artifacts and project status.
+
+## 💻 Code Execution
+
+Servers designed to execute code snippets or scripts in various languages, often in sandboxed environments.
+
+- [rapidriskradar/RRR-MCP](https://github.com/rapidriskradar/RRR-MCP): Facilitates the execution of RRR scripts through a configurable MCP server interface.
+- [Quathor/CMD-Executor](https://github.com/Quathor/CMD-Executor): Facilitates remote execution of Windows CMD commands via the MCP protocol, ensuring secure and configurable command execution.
+- [JSFrouws/mcp-matlab-executor](https://github.com/JSFrouws/mcp-matlab-executor): Securely execute MATLAB functions and scripts with user-approved security prompts.
+- [cloudywu0410/python_sandbox_mcp_server](https://github.com/cloudywu0410/python_sandbox_mcp_server): Enables LLMs to execute Python code securely in isolated Docker containers with real-time communication via SSE.
+- [1Levick3/postgresql-mcp-server](https://github.com/1Levick3/postgresql-mcp-server): Facilitates direct SQL query execution on PostgreSQL databases with parameterized queries and configurable timeouts.
+- [madhavarora1988/mcp_sqlite_poc](https://github.com/madhavarora1988/mcp_sqlite_poc): Facilitates AI model interactions with SQLite databases through a Model Context Protocol server, offering query execution, schema discovery, and feedback collection.
+- [spences10/mcp-sequentialthinking-qa](https://github.com/spences10/mcp-sequentialthinking-qa): Guides QA and verification processes by breaking down tasks into steps and recommending MCP tools with confidence scores and rationale.
+- [Stoicmehedi/K-MCP](https://github.com/Stoicmehedi/K-MCP): K-MCP connects AI assistants to a Kali Linux terminal for AI-driven penetration testing and security research.
+- [tufantunc/ssh-mcp](https://github.com/tufantunc/ssh-mcp): Enables secure execution of shell commands on remote Linux and Windows systems via SSH using the Model Context Protocol.
+- [alfonsograziano/node-code-sandbox-mcp](https://github.com/alfonsograziano/node-code-sandbox-mcp): Node.js server for executing JavaScript in isolated Docker containers with dynamic npm dependency management.
+- [MSAdministrator/enrichment-mcp](https://github.com/MSAdministrator/enrichment-mcp): Enhance security data by enriching observables using third-party services like VirusTotal and Hybrid Analysis.
+- [Ompragash/isolator-mcp](https://github.com/Ompragash/isolator-mcp): Facilitates secure execution of Python, Go, and JavaScript code snippets within isolated Docker containers, accessible via MCP.
+- [synackpwn/enrichment-mcp](https://github.com/synackpwn/enrichment-mcp): Enhances security data by enriching observables like IP addresses and domain names using third-party services.
+- [pkgxdev/mcp](https://github.com/pkgxdev/mcp): Facilitates AI-driven execution of any Open Source tool via pkgx, with a focus on security and sandboxing.
+- [stableversion/lldb_mcp](https://github.com/stableversion/lldb_mcp): A streamlined LLDB MCP server with minimal dependencies, designed for efficient command execution and output capture.
+- [koido/extreme-p-mcp](https://github.com/koido/extreme-p-mcp): Facilitates extreme p-value calculations through an API interface using R scripts, integrated with Python via FastMCP.
+- [harshini-ns/mcp-search-engine](https://github.com/harshini-ns/mcp-search-engine): A TypeScript-based MCP server offering a comprehensive suite of mathematical functions for seamless integration with language models.
+- [jordanperr/mcp-experiments](https://github.com/jordanperr/mcp-experiments): Facilitates LLM-driven control of a Mac desktop via Bash and AppleScript commands.
+- [T1nker-1220/aws-postgress-mcp-server](https://github.com/T1nker-1220/aws-postgress-mcp-server): Facilitates read-only SQL query access to AWS PostgreSQL databases using the Model Context Protocol.
+- [texra-ai/mcp-server-mathematica](https://github.com/texra-ai/mcp-server-mathematica): Facilitates the execution of Mathematica code and verification of mathematical derivations through MCP client integration.
+- [svngoku/mcp-docker-code-interpreter](https://github.com/svngoku/mcp-docker-code-interpreter): A secure Docker-based environment for executing code through MCP, enabling AI assistants to run code safely within isolated containers.
+- [longxiangzhu/db2-mcp](https://github.com/longxiangzhu/db2-mcp): Facilitates interaction with DB2 for LUW databases through SQL queries and stored procedures.
+- [pottekkat/sandbox-mcp](https://github.com/pottekkat/sandbox-mcp): Sandbox MCP provides a secure environment for LLMs to execute code within isolated Docker containers, enhancing code accuracy and safety.
+- [dtkmn/mcp-zap-server](https://github.com/dtkmn/mcp-zap-server): A Spring Boot application enabling AI agents to orchestrate OWASP ZAP actions through the Model Context Protocol.
+- [liuchongchong1995/nodejs](https://github.com/liuchongchong1995/nodejs): Facilitates runtime debugging of Node.js applications using Cursor or Claude Code.
+- [chrisjmendez/mcp_quickstart](https://github.com/chrisjmendez/mcp_quickstart): Facilitates secure local Claude brain setup using Docker, SQLite, and uvx for MCP-style queries.
+- [Dangoron/defillama-mcp](https://github.com/Dangoron/defillama-mcp): Facilitates the execution of DeFiLlama data processing scripts through an MCP server configuration.
+- [tarjeir/chunker-mcp](https://github.com/tarjeir/chunker-mcp): Facilitates code chunking and vectorization using LangChain, storing results in ChromaDB for advanced querying.
+- [bimalpaudels/python-interpreter-mcp](https://github.com/bimalpaudels/python-interpreter-mcp): Facilitates the execution of Python scripts in a controlled environment using LLMs.
+- [johnhenry/vimble-mcp](https://github.com/johnhenry/vimble-mcp): Facilitates the execution of JavaScript code in a secure, sandboxed environment using Vimble.
+
+## 💬 Communication & Messaging
+
+Servers for interacting with email, chat platforms, SMS, or notification services.
+
+- [jamesacklin/tlon-mcp-server](https://github.com/jamesacklin/tlon-mcp-server): Facilitates interaction with Tlon agents through direct messaging, contact management, and natural language support.
+- [varunwahi-plivo/plivo-mcp-server](https://github.com/varunwahi-plivo/plivo-mcp-server): Facilitates SMS messaging through Plivo's API using the Message Control Protocol.
+- [virtualsms-io/virtualsms-mcp](https://github.com/virtualsms-io/virtualsms-mcp): Enables AI agents to get virtual phone numbers and receive SMS/OTP codes for automated phone verification workflows via VirtualSMS API.
+- [deuslirio/mcp-server-whatsapp-message](https://github.com/deuslirio/mcp-server-whatsapp-message): Facilitates sending WhatsApp messages through the Meta WhatsApp Business API using MCP.
+- [theo-nash/twitter-mcp-server](https://github.com/theo-nash/twitter-mcp-server): Facilitates AI-driven interactions with Twitter, enabling operations like tweeting, searching, and user management without direct API access.
+- [sudhakarmlal/ERAV3-GMAILMCP](https://github.com/sudhakarmlal/ERAV3-GMAILMCP): Facilitates seamless email management through the Gmail API, allowing users to send, read, and manage emails via an MCP client.
+- [operation-hp/WA-MCP](https://github.com/operation-hp/WA-MCP): Facilitates interaction with MCP servers through WhatsApp using chat messages, leveraging whatsapp-web.js.
+- [va99/Napier-mcp](https://github.com/va99/Napier-mcp): Facilitates AI-driven interactions with WhatsApp by bridging local environments to the WhatsApp web API, enabling message retrieval and media handling through a Python MCP server.
+- [kousunh/alertmcp](https://github.com/kousunh/alertmcp): Facilitates desktop notifications from AI client tools with scheduling capabilities.
+- [arush15june/zammad-mcp-go](https://github.com/arush15june/zammad-mcp-go): Facilitates interaction with the Zammad API for managing tickets and users through structured MCP resources and tools.
+- [leshchenko1979/tg_mcp](https://github.com/leshchenko1979/tg_mcp): Facilitates seamless interaction with Telegram through a robust API, enabling message search, chat management, and analytics within the Cursor IDE.
+- [nicekon/zendesk-mcp-server-kon](https://github.com/nicekon/zendesk-mcp-server-kon): Enhances Zendesk integration by managing tickets, community posts, and knowledge base access.
+- [atorber/wechaty-mcp-sse](https://github.com/atorber/wechaty-mcp-sse): Facilitates seamless integration between Wechaty and large language models like Claude, enabling message sending and contact querying via a TypeScript-based MCP server.
+- [firstorderai/authenticator_mcp](https://github.com/firstorderai/authenticator_mcp): Facilitates AI agents in securely accessing 2FA codes and passwords for automated login processes via the Authenticator App.
+- [imprvhub/mcp-status-observer](https://github.com/imprvhub/mcp-status-observer): Facilitates real-time monitoring and querying of operational statuses for major digital platforms within Claude Desktop.
+- [Escorza07/whatsapp-mcp](https://github.com/Escorza07/whatsapp-mcp): Facilitates seamless interaction with WhatsApp through Claude by leveraging a Go bridge and Python MCP server for message management and contact search.
+- [karateboss/mcp_email_reader](https://github.com/karateboss/mcp_email_reader): Connects to an email server to read emails and manage attachments using MCP tools.
+- [tituslhy/sturdy-octo-fortnight](https://github.com/tituslhy/sturdy-octo-fortnight): Facilitates seamless integration with Atlassian's Confluence and Jira through a robust MCP server, enabling efficient content management and issue tracking.
+- [noobnooc/webhook-mcp](https://github.com/noobnooc/webhook-mcp): Facilitates webhook notifications for task completion alerts via MCP server integration.
+- [orellazri/coda-mcp](https://github.com/orellazri/coda-mcp): Facilitates interaction with Coda documents by enabling actions like listing, creating, and modifying pages through an MCP server interface.
+- [scho-to/mcp-jira-cloud-v2](https://github.com/scho-to/mcp-jira-cloud-v2): Facilitates interaction with Jira Cloud by fetching ticket information via MCP requests.
+- [YajieQi123/mcp-server-monday-qi](https://github.com/YajieQi123/mcp-server-monday-qi): Facilitates interaction with Monday.com boards, items, updates, and documents through an MCP server.
+- [alimo7amed93/webhook-tester-mcp](https://github.com/alimo7amed93/webhook-tester-mcp): A modular FastMCP server for managing and testing webhooks with webhook-test.com, enabling webhook observability and management.
+- [Escorza07/mcp-gmail-extension](https://github.com/Escorza07/mcp-gmail-extension): Facilitates seamless Gmail management through natural language interactions with automatic authentication support.
+- [Meerkats-Ai/findymail-mcp-server](https://github.com/Meerkats-Ai/findymail-mcp-server): Integrates with the Findymail API to provide email validation and finding capabilities using MCP.
+- [BlackMac/sipgateio-mcp](https://github.com/BlackMac/sipgateio-mcp): Facilitates AI-driven interactions with sipgate services for SMS, calls, and account management.
+- [TharanaBope/whatsapp-mcp-n8n](https://github.com/TharanaBope/whatsapp-mcp-n8n): Facilitates seamless interaction with WhatsApp through Claude by enabling message retrieval, contact searches, and media exchanges via the WhatsApp web multidevice API.
+- [mskim8717/dooray-mcp](https://github.com/mskim8717/dooray-mcp): Facilitates schedule management through Dooray API integration, enabling automatic time settings and location support.
+- [futuyu/Discord-webhook-MCP](https://github.com/futuyu/Discord-webhook-MCP): Facilitates message delivery to Discord using webhooks through the Model Context Protocol, with integration support for Claude Desktop.
+- [beylessai/hiworks-mcp](https://github.com/beylessai/hiworks-mcp): Facilitates email retrieval and sending through Hiworks Mail integration using MCP.
+- [team-telnyx/telnyx-mcp-server](https://github.com/team-telnyx/telnyx-mcp-server): Facilitates interaction with telephony, messaging, and AI assistant APIs, enabling MCP clients to manage communications and create AI-driven solutions.
+- [commune-sh/commune-mcp](https://github.com/commune-sh/commune-mcp): Provides email infrastructure for AI agents, enabling programmatic inbox creation, send/receive email, thread management across concurrent conversations, custom domains, structured extraction on inbound mail, and SMS.
+- [wazionapps/mcp-server](https://github.com/wazionapps/mcp-server): WAzion - WhatsApp Business platform with 244 MCP tools for messaging, CRM, campaigns, workflows, and AI automation. Supports Streamable HTTP and stdio transports.
+- [littlebearapps/outlook-assistant](https://github.com/littlebearapps/outlook-assistant): MCP server for Microsoft Outlook with 20 consolidated tools for email, calendar, contacts, and mailbox management via Graph API. Features dry-run preview, session rate limiting, and recipient allowlists for safe email sending.
+
+## 📝 Content Management Systems
+
+Servers specifically designed to interact with CMS platforms.
+
+- [UnMarkdown/mcp-server](https://github.com/UnMarkdown/mcp-server): Converts markdown to formatted documents for Google Docs, Word, Slack, OneNote, Email, and Plain Text with 62 templates, plus document management and publishing via 7 MCP tools.
+- [edgarrmondragon/limesurvey-mcp](https://github.com/edgarrmondragon/limesurvey-mcp): Facilitates seamless management of LimeSurvey surveys and responses through a dedicated MCP server.
+- [thoy-le-duc/mcp-woocommerce-thoy](https://github.com/thoy-le-duc/mcp-woocommerce-thoy): Facilitates seamless WooCommerce store management via JSON-RPC 2.0, integrating with WordPress REST API across multiple platforms.
+- [aguaitech/Elementor-MCP](https://github.com/aguaitech/Elementor-MCP): Facilitates CRUD operations on Elementor data within WordPress using a simple MCP server.
+- [galatanovidiu/wp-wordpress-remote-proxy](https://github.com/galatanovidiu/wp-wordpress-remote-proxy): Facilitates seamless communication between local and remote WordPress MCP servers through a bidirectional proxy.
+- [cromewar/ghost-mcp-server](https://github.com/cromewar/ghost-mcp-server): Facilitates seamless blog posting to Ghost CMS using Claude AI via the FastMCP framework.
+- [PragmaTech-GmbH/bootiful-wordpress-mcp-server](https://github.com/PragmaTech-GmbH/bootiful-wordpress-mcp-server): A Java and Spring Boot-based server facilitating WordPress integration through MCP.
+- [BCusack/sharepoint-mcp](https://github.com/BCusack/sharepoint-mcp): Facilitates access to organizational SharePoint resources via the Model Context Protocol, leveraging Microsoft Graph API for document management.
+- [SunnyCloudYang/hugo-mcp](https://github.com/SunnyCloudYang/hugo-mcp): Manage and deploy Hugo static sites with a comprehensive suite of tools for environment setup, site management, and theme customization.
+- [pixelsock/directus-mcp](https://github.com/pixelsock/directus-mcp): Facilitates AI client interactions with Directus CMS via MCP, enabling seamless API integration.
+- [gopalcnepal/mcp-wordpress](https://github.com/gopalcnepal/mcp-wordpress): Facilitates interaction with WordPress sites by fetching posts, pages, and categories using the REST API.
+- [injunko/figma-mcp-server](https://github.com/injunko/figma-mcp-server): Enable AI-powered coding tools to access and implement Figma design data seamlessly.
+- [soggycactus/paprika-3-mcp](https://github.com/soggycactus/paprika-3-mcp): Facilitates natural language interaction with Paprika 3 recipes, enabling creation and editing via LLMs like Claude.
+- [mabeldata/pocketbase-mcp](https://github.com/mabeldata/pocketbase-mcp): Facilitates interaction with PocketBase instances for managing records, files, and migrations.
+- [jpollock/wordpress-mcp](https://github.com/jpollock/wordpress-mcp): Facilitates comprehensive management of WordPress sites through the REST API, offering tools for site, content, user, taxonomy, plugin, and theme management.
+- [calafate40/MCP-FileMaker](https://github.com/calafate40/MCP-FileMaker): Facilitates access to FileMaker databases via the Model Context Protocol with token-based authentication and record search capabilities.
+- [burnworks/microcms-api-mcp-server](https://github.com/burnworks/microcms-api-mcp-server): Enables access to microCMS API through an MCP server, offering content retrieval, search, and filtering capabilities.
+- [loyaniu/moodle-mcp](https://github.com/loyaniu/moodle-mcp): Facilitates interaction with Moodle LMS through a Model Context Protocol server, offering features like retrieving upcoming events.
+- [Leonelberio/the-wordpress-mcp-server](https://github.com/Leonelberio/the-wordpress-mcp-server): Facilitates seamless interaction with WordPress sites via JSON-RPC 2.0, enabling post creation, retrieval, and updates through the WordPress REST API.
+- [tsainte/wordpress-automation-mcp](https://github.com/tsainte/wordpress-automation-mcp): Automate WordPress post management with a Python-based MCP server, offering CRUD operations and post status handling.
+- [tonioshikanlu/mcp-gdrive-server](https://github.com/tonioshikanlu/mcp-gdrive-server): Integrates with Google Drive to enable file listing, reading, and searching capabilities.
+- [Utsav-Ladani/WordPress-MCP](https://github.com/Utsav-Ladani/WordPress-MCP): Facilitates seamless content management in WordPress by enabling post creation, updates, and searches through a Model Context Protocol server.
+- [granthooks/Nocodb-MCP-Server](https://github.com/granthooks/Nocodb-MCP-Server): Facilitates CRUD operations on Nocodb databases via the Model Context Protocol, ensuring seamless integration and management of database records.
+- [rijkvanzanten/directus-mcp-server](https://github.com/rijkvanzanten/directus-mcp-server): Facilitates AI tool integration with Directus APIs, enabling seamless interaction and data retrieval.
+- [harlley/storyblok-mcp](https://github.com/harlley/storyblok-mcp): Manage Storyblok components using natural language descriptions with this MCP implementation.
+- [starbuck93/tandoor-mcp-server](https://github.com/starbuck93/tandoor-mcp-server): Facilitates seamless interaction with Tandoor Recipe Manager, enabling recipe creation, meal planning, and shopping list management.
+- [theWDY/office-editor-mcp](https://github.com/theWDY/office-editor-mcp): Enhance productivity by seamlessly integrating comprehensive Microsoft Office document processing capabilities into MCP Clients, enabling creation, editing, and management of Word, Excel, and PowerPoint documents without leaving the client environment.
+- [johnnyrobot/claude-canvas-mcp](https://github.com/johnnyrobot/claude-canvas-mcp): Facilitates seamless interaction with Canvas LMS through a Claude desktop MCP server, enabling comprehensive course and student management via the Canvas API.
+- [rakeshgangwar/freshrss-server](https://github.com/rakeshgangwar/freshrss-server): Facilitates AI interaction with FreshRSS feeds via the Fever API, enabling feed management and item retrieval.
+- [sdi2200262/eclass-mcp-server](https://github.com/sdi2200262/eclass-mcp-server): Facilitates AI agents' interaction with Open eClass by enabling authentication, course retrieval, and session management.
+- [mrwyndham/pocketbase-mcp](https://github.com/mrwyndham/pocketbase-mcp): Facilitates rapid development of PocketBase applications with advanced database operations and schema management.
+- [jonradoff/lightcms](https://github.com/jonradoff/lightcms): AI-native CMS with 41 MCP tools for managing websites through natural language. Create pages, templates, assets, themes, collections, redirects, and more with full content versioning.
+
+## 📊 Data Analysis & Business Intelligence
+
+Servers connecting to data warehouses, data query engines, analytics platforms, or specific data APIs.
+
+- [rotatingshov/go-mcp-mysql](https://github.com/rotatingshov/go-mcp-mysql): Effortlessly manage MySQL databases with a Go-based MCP server, offering CRUD operations and automation without the need for Node.js or Python.
+- [datafe/maxcompute-mcp-server](https://github.com/datafe/maxcompute-mcp-server): Facilitates data querying and schema management on Alibaba Cloud's MaxCompute platform using MCP protocol.
+- [atcol/glue-mcp](https://github.com/atcol/glue-mcp): Facilitates interaction with AWS Glue Data Catalog through a model context protocol server.
+- [ronantakizawa/gis-dataconvertersion-mcp](https://github.com/ronantakizawa/gis-dataconvertersion-mcp): Facilitates geographic data conversion across multiple formats, enabling seamless integration with LLMs for spatial data manipulation.
+- [albertdow/mcp-datapi](https://github.com/albertdow/mcp-datapi): Facilitates access to ECMWF's Climate Data Store catalogues and job statuses through an MCP server interface.
+- [4R9UN/mcp-kql-server](https://github.com/4R9UN/mcp-kql-server): Facilitates the execution of KQL queries against Azure Data Explorer within Claude Desktop, leveraging Azure CLI for secure authentication and structured data output.
+- [lancedb/lancedb-mcp-server](https://github.com/lancedb/lancedb-mcp-server): A serverless MCP server utilizing LanceDB for data storage and retrieval, designed as a reference for building complex MCP applications.
+- [phxdev1/archy-mcp](https://github.com/phxdev1/archy-mcp): Archy transforms natural language and GitHub repository URLs into comprehensive architectural diagrams using Mermaid syntax.
+- [rithik-perera/CodeCrunchMCP](https://github.com/rithik-perera/CodeCrunchMCP): Analyze and visualize Azure usage data from CSV files, providing insights and summaries through an MCP server interface.
+- [orlando2019/xlsm-mcp-server](https://github.com/orlando2019/xlsm-mcp-server): Facilitates AI-driven manipulation of Excel files with macros, enhancing data analysis and office automation capabilities.
+- [under-doc/underdoc-tutorial-expense-analytics-mcp-sqlite](https://github.com/under-doc/underdoc-tutorial-expense-analytics-mcp-sqlite): Facilitates expense analytics by integrating GenAI with an MCP server for SQLite, enabling natural language interaction with expense data.
+- [Meerkats-Ai/builtwith-mcp-server](https://github.com/Meerkats-Ai/builtwith-mcp-server): Integrates with the BuiltWith API to analyze and provide technology stack information for websites.
+- [OpenLinkSoftware/mcp-adonet-server](https://github.com/OpenLinkSoftware/mcp-adonet-server): A C# MCP server facilitating database interactions via ADO.NET, optimized for compatibility with Virtuoso and other ODBC-accessible DBMS platforms.
+- [hesslee/mcp-server-altibase](https://github.com/hesslee/mcp-server-altibase): Facilitates database interaction and business intelligence through Altibase, enabling SQL queries and automatic business insight generation.
+- [arturborycki/mcp-teradata](https://github.com/arturborycki/mcp-teradata): Facilitates database interaction and business intelligence through Teradata with tools for executing SQL queries and analyzing data.
+- [plainsignal/plainsignal-mcp](https://github.com/plainsignal/plainsignal-mcp): Facilitates analytics data retrieval and reporting through the MCP protocol for PlainSignal.
+- [mattfoster/kcve](https://github.com/mattfoster/kcve): Facilitates querying Linux Kernel CVEs by integrating a basic MCP server with an SQLite database.
+- [2geonhyup/dart-mcp](https://github.com/2geonhyup/dart-mcp): Facilitates financial analysis and visualization of listed companies using DART API and Claude.
+- [mustafahasankhan/duckdb-mcp-server](https://github.com/mustafahasankhan/duckdb-mcp-server): Enables AI assistants to perform advanced data analysis on DuckDB using SQL, with seamless integration for multiple data sources and cloud storage.
+- [nananaman/DuckDB-RAG-MCP-Sample](https://github.com/nananaman/DuckDB-RAG-MCP-Sample): Facilitates vectorized markdown document embedding and retrieval using DuckDB and MCP for enhanced RAG explanations.
+- [future3OOO/Deep-Fusion-Research-](https://github.com/future3OOO/Deep-Fusion-Research-): A comprehensive workflow that integrates outputs from Gemini and OpenAI with Manus's live web/API sweep for enhanced research synthesis.
+- [alexxx-db/databricks-genie-mcp](https://github.com/alexxx-db/databricks-genie-mcp): Integrate Databricks' AI/BI assistant features with other applications through a standardized interface for natural language querying of data.
+- [MpLebron/GeoDataProcessor-MCP](https://github.com/MpLebron/GeoDataProcessor-MCP): Facilitates geospatial data processing through standardized interfaces, enabling large language models to access and utilize tools like WhiteBox and SAGA GIS.
+- [BioContext/PubChem-MCP](https://github.com/BioContext/PubChem-MCP): Access PubChem data for compounds, substances, and bioassays through a Model Context Protocol server.
+- [cygkichi/estat-mcp-server](https://github.com/cygkichi/estat-mcp-server): Facilitates access to Japan's e-Stat API, enabling language models to search and retrieve government statistical data.
+- [mamisoa/mcp-alchemy](https://github.com/mamisoa/mcp-alchemy): MCP Alchemy seamlessly integrates Claude Desktop with various databases, enabling advanced SQL query assistance and data analysis.
+- [variablenigh/excel-mcp-server](https://github.com/variablenigh/excel-mcp-server): Facilitates reading and writing spreadsheet data to MS Excel files using the Model Context Protocol.
+- [roastedculti/metoro-mcp-server](https://github.com/roastedculti/metoro-mcp-server): Facilitates interaction with Kubernetes clusters through the Claude Desktop App by leveraging the Model Context Protocol.
+- [cheukyin175/metabase-mcp](https://github.com/cheukyin175/metabase-mcp): Facilitates seamless integration of AI assistants with Metabase analytics, enabling direct interaction with analytics data via MCP capabilities.
+- [Strale](https://strale.dev) - 250+ quality-scored capabilities for AI agents: company data across 27 countries, compliance checks (KYB, AML, sanctions, GDPR), financial validation, web intelligence, document extraction, developer tools, and data processing. Every capability independently tested with Strale Quality Score (SQS). Free tier available.
+
+## 🗄️ Databases
+
+Servers providing interfaces to various database types like SQL, NoSQL, Vector Databases, Graph Databases, Time-Series, etc.
+
+- [tkz24589/mcp_mongodb](https://github.com/tkz24589/mcp_mongodb): Facilitates AI-driven interactions with MongoDB through natural language queries, supporting seamless data management and retrieval.
+- [cwilby/mcp-node-mssql](https://github.com/cwilby/mcp-node-mssql): Facilitates SQL Server interactions via MCP using node-mssql, enabling seamless database management.
+- [wangzhaobo168/dm-mcp-server](https://github.com/wangzhaobo168/dm-mcp-server): Facilitates interaction with Dameng databases by listing tables, executing read-only SQL queries, and displaying table structures.
+- [NomotoK/doris-mcp-server](https://github.com/NomotoK/doris-mcp-server): Facilitates secure, read-only SQL queries and schema exploration on Apache Doris databases for LLM applications.
+- [waii-ai/waii-mcp-server](https://github.com/waii-ai/waii-mcp-server): Facilitates natural language interaction with databases, enabling Language Models to execute queries and process data through WAII.
+- [affannahmed/MCP-Server-with-Claude-Ai](https://github.com/affannahmed/MCP-Server-with-Claude-Ai): Facilitates secure interaction between AI applications and MySQL databases through a controlled MCP interface.
+- [ydb-platform/ydb-mcp](https://github.com/ydb-platform/ydb-mcp): Facilitates AI-driven interactions with YDB databases through a Model Context Protocol server, enabling natural language database operations.
+- [Moonlight-CL/redshift-mcp-server](https://github.com/Moonlight-CL/redshift-mcp-server): Facilitates AI assistant interactions with Amazon Redshift databases through a Python-based MCP server.
+- [Carlosfpc/mcp-mysql](https://github.com/Carlosfpc/mcp-mysql): Facilitates secure MySQL connections via SSH tunneling, enabling controlled database operations through an MCP server.
+- [orlando2019/MCO-postgres](https://github.com/orlando2019/MCO-postgres): Enables language models to perform read-only operations on PostgreSQL databases by providing schema inspection and query execution capabilities.
+- [Jite-J/-mysql_mcp_server](https://github.com/Jite-J/-mysql_mcp_server): Facilitates secure interaction between AI applications and MySQL databases through a structured MCP interface.
+- [hmn53/sql-mcp](https://github.com/hmn53/sql-mcp): Facilitates secure, read-only interactions between LLMs and SQL databases using MCP tools.
+- [fnf-deepHeading/mcp-snowflake-reader-ts](https://github.com/fnf-deepHeading/mcp-snowflake-reader-ts): Provides secure, read-only access to Snowflake databases via the MCP protocol, supporting cross-platform functionality and query caching.
+- [cnosuke/mcp-mysql](https://github.com/cnosuke/mcp-mysql): Facilitates MySQL database operations through a Go-based MCP server, enabling seamless integration with MCP clients for database querying and management.
+- [shensiqi0701/mysql-mcp-server-modification](https://github.com/shensiqi0701/mysql-mcp-server-modification): Provides read-only access to MySQL databases, allowing users to list databases, tables, and execute queries through an MCP server.
+- [avarant/typesense-mcp-server](https://github.com/avarant/typesense-mcp-server): Facilitates seamless integration with Typesense by managing collections, documents, and search operations through MCP.
+- [tqvthu-works/mysql-mcp-server](https://github.com/tqvthu-works/mysql-mcp-server): Facilitates interaction with MySQL databases in Cursor IDE through a Model Context Protocol server.
+- [allizwellai/mysql-mcp-server](https://github.com/allizwellai/mysql-mcp-server): Facilitates secure, read-only access to MySQL databases, enabling users to list databases, tables, and execute queries with robust security features.
+- [shensiqi0701/MCP-MySQL-server-implementation](https://github.com/shensiqi0701/MCP-MySQL-server-implementation): Facilitates LLMs in accessing and executing SQL queries on MySQL databases, with robust security and performance features.
+- [shibayu36/mysql-schema-explorer-mcp](https://github.com/shibayu36/mysql-schema-explorer-mcp): Facilitates efficient access to MySQL database schema information using the Model Context Protocol, ideal for large-scale databases.
+- [asirulnik/mcp-law-office-db](https://github.com/asirulnik/mcp-law-office-db): Facilitates efficient management of law office databases, focusing on client records, case filing, time tracking, and invoice management.
+- [adam2211/neon-mcp-loc](https://github.com/adam2211/neon-mcp-loc): Facilitates natural language interaction with Neon Postgres databases, enabling seamless database management and migrations through intuitive commands.
+- [achrekarom12/mcp-mongo](https://github.com/achrekarom12/mcp-mongo): Facilitates natural language interactions with MongoDB databases through a Model Context Protocol server, enabling LLMs to perform queries, schema exploration, and data operations.
+- [nature-lover-iv/neo4j-mcp](https://github.com/nature-lover-iv/neo4j-mcp): Facilitates natural language interaction with Neo4j graph databases through the MCP protocol, enabling schema exploration, query execution, and database management.
+- [BioContext/ChemBL-MCP](https://github.com/BioContext/ChemBL-MCP): Access ChEMBL data through a Model Context Protocol server, enabling detailed queries on molecules, targets, assays, and bioactivity data.
+- [jt-atan/Access-COM](https://github.com/jt-atan/Access-COM): Facilitates seamless interaction with 32-bit Microsoft Access databases through a Model Context Protocol tool, supporting SQL queries and linked table management.
+- [aliyun/alibabacloud-adbpg-mcp-server](https://github.com/aliyun/alibabacloud-adbpg-mcp-server): Facilitates seamless interaction between AI Agents and AnalyticDB PostgreSQL databases for executing SQL operations and retrieving metadata.
+- [RichardHFYU/MCP_Java_PSQL](https://github.com/RichardHFYU/MCP_Java_PSQL): A Spring Boot and Spring AI-based MCP server for inspecting PostgreSQL database schemas, supporting SSE transport for integration with Cursor and other MCP clients.
+- [Pratye/MEC-Postgres](https://github.com/Pratye/MEC-Postgres): Facilitates read and write operations on PostgreSQL databases, allowing LLMs to interact with database schemas and execute SQL queries.
+- [Malove86/mcp-mysql-server](https://github.com/Malove86/mcp-mysql-server): Facilitates AI model interactions with MySQL databases via a standardized interface, supporting both local and remote deployment modes.
+- [stucchi/db-mcp-server](https://github.com/stucchi/db-mcp-server): Database MCP server for MySQL, PostgreSQL, and MongoDB with SSH tunneling support. Run queries, explore schemas, and manage data across multiple database types.
+
+## 🛠️ Developer Productivity & Utilities
+
+Servers enhancing developer workflows, integrating with IDEs, accessing documentation, API exploration, code generation helpers, or general dev utilities.
+
+- [CristianCiubancan/sequentialthinking](https://github.com/CristianCiubancan/sequentialthinking): Facilitates dynamic problem-solving through structured, step-by-step thinking processes.
+- [hyperpolymath/boj-server](https://github.com/hyperpolymath/boj-server): Unified MCP server with 40+ tools covering GitHub, GitLab, Cloudflare, Vercel, Gmail, Calendar, browser automation, research, ML, and 50+ pluggable cartridges for extensible developer workflows.
+- [gethopp/figma-mcp-bridge](https://github.com/gethopp/figma-mcp-bridge): Bypasses Figma API rate limits by streaming live Figma document data to AI tools through a WebSocket-based plugin-server bridge with leader election and multi-instance management.
+- [izzzzzi/codewiki-mcp](https://github.com/izzzzzi/codewiki-mcp): MCP server for codewiki.google — search repos, fetch AI-generated wiki docs, and ask questions about any open-source repository.
+- [jkosik/mcp-server-splunk](https://github.com/jkosik/mcp-server-splunk): Facilitates seamless integration with Splunk by providing a Go-based MCP server supporting STDIO and SSE modes.
+- [OpenClaw MCP Ecosystem](https://github.com/yedanyagamiai-cmd/openclaw-mcp-servers) - 9 remote MCP servers on Cloudflare Workers: JSON toolkit, regex engine, color palette, timestamp converter, prompt enhancer, AI market intelligence, fortune/horoscope, content publisher, and AI tool comparison. Free tier + Pro API keys ($9).
+- [OzorOwn/frostbyte-mcp](https://github.com/OzorOwn/frostbyte-mcp): Developer API toolkit with 13 tools — IP geolocation, crypto prices, DNS/WHOIS lookup, website screenshots, web scraping, code execution (20+ languages), web search, URL shortener, PDF generation, pastebin, data conversion, and domain availability. One API key for 40+ services.
+- [twinic/Twinic-server](https://github.com/twinic/Twinic-server): Facilitates the installation and configuration of MCP servers through simple prompts, integrating with npm and PyPi.
+- [ejoyee/ej-mcp-server-gdrive](https://github.com/ejoyee/ej-mcp-server-gdrive): Integrates with Google Drive to enable file listing, reading, and searching capabilities.
+- [joshuayoes/deno-kv-mcp](https://github.com/joshuayoes/deno-kv-mcp): Facilitates interaction with Deno KV instances through a robust MCP server, enabling seamless key-value operations.
+- [elhadjaoui/pr_reviewer](https://github.com/elhadjaoui/pr_reviewer): An MCP server that integrates with Claude Desktop to analyze GitHub Pull Requests and automatically saves reviews to Google Drive.
+- [skeet-build/skeet-local](https://github.com/skeet-build/skeet-local): Facilitates seamless integration and configuration of Skeet MCP tools for database and search operations.
+- [Demontie/mcp-google-sheets](https://github.com/Demontie/mcp-google-sheets): Facilitates seamless data interaction with Google Sheets through a Model Context Protocol server.
+- [alvinveroy/aider-mcp-client](https://github.com/alvinveroy/aider-mcp-client): A Python tool that integrates MCP with Aider to fetch library documentation and enhance AI-assisted coding workflows.
+- [slavahatnuke/octolis-tech-support](https://github.com/slavahatnuke/octolis-tech-support): Facilitates technical support operations through MCP server configurations.
+- [Hizuki1030/visa-mcp](https://github.com/Hizuki1030/visa-mcp): Facilitates the control of oscilloscopes using the VISA architecture through an MCP server, enabling seamless integration and automation of various measurement tasks.
+- [charlesmuchene/pref-editor-mcp-server](https://github.com/charlesmuchene/pref-editor-mcp-server): Facilitates editing Android preferences through a dedicated MCP server, leveraging the Android Preference Editor tool.
+- [b3nguang/Server-Inspection-MCP](https://github.com/b3nguang/Server-Inspection-MCP): Facilitates server inspection through an MCP program running on a PC, interfacing with server agents.
+- [ssaitho/design-system-mcp-sandbox](https://github.com/ssaitho/design-system-mcp-sandbox): Facilitates retrieval of component information from a design system in a sandbox environment.
+- [PyneSys/patch-file-mcp](https://github.com/PyneSys/patch-file-mcp): Facilitates precise file modifications using block format patches, ensuring safety and efficiency for AI-driven file editing tasks.
+- [Sofias-ai/mcp-sharepoint](https://github.com/Sofias-ai/mcp-sharepoint): Facilitates seamless interaction with Microsoft SharePoint resources through a lightweight MCP server, optimizing document management operations.
+- [ZebraRoy/review-toolkit-mcp](https://github.com/ZebraRoy/review-toolkit-mcp): Facilitates AI-driven code review sessions with features for session management, file tracking, and report generation.
+- [Aryan1718/mcp-sever-google-sheets](https://github.com/Aryan1718/mcp-sever-google-sheets): Facilitates seamless interaction with Google Sheets for data manipulation through an MCP server.
+- [Xutaotaotao/mcp-get-installed-apps](https://github.com/Xutaotaotao/mcp-get-installed-apps): Enables AI assistants to discover installed applications on MacOS and Windows through the Model Context Protocol.
+- [ai-wes/version_checker_mcp](https://github.com/ai-wes/version_checker_mcp): A specialized MCP server that aids developers in managing React Native and Expo projects by analyzing dependencies, checking compatibility, and reviewing changelogs.
+- [yo-ban/poly-mcp-client](https://github.com/yo-ban/poly-mcp-client): A Python client library for managing connections to MCP servers, adapting tool definitions for Anthropic, OpenAI, and Gemini.
+- [furey/lifx-api-mcp-server](https://github.com/furey/lifx-api-mcp-server): Facilitates natural language control of LIFX smart lighting devices via the LIFX HTTP API, enabling actions like light management and effect activation through LLMs.
+- [aezizhu/simple-mcp-fileserver](https://github.com/aezizhu/simple-mcp-fileserver): Facilitates AI agents' interaction with local file systems via JSON-RPC for autonomous coding and code repair.
+- [yasu89/switch-bot-mcp-server](https://github.com/yasu89/switch-bot-mcp-server): Facilitates interactive control of SwitchBot devices using the Model Context Protocol.
+- [iamkaia/mcp-server-implement](https://github.com/iamkaia/mcp-server-implement): A collection of five MCP servers for integration with Claude Desktop, offering functionalities like email management, web page fetching, document manipulation, and filesystem operations.
+- [jsnanigans/mcpm](https://github.com/jsnanigans/mcpm): A command-line tool for managing and proxying MCP servers, facilitating JSON-RPC communication and server configuration.
+- [mhappy78/mcp_ai_local_memory](https://github.com/mhappy78/mcp_ai_local_memory): Facilitates file management operations on local systems using Model Context Protocol, enabling AI-driven local memory storage.
+- [miraclebakelaser/porkbun-mcp-server](https://github.com/miraclebakelaser/porkbun-mcp-server): Facilitates domain, DNS, and SSL management through the Porkbun API for MCP-compatible clients.
+- [urijan44/pr_creator_mcp](https://github.com/urijan44/pr_creator_mcp): Automates GitHub Pull Request creation with integration support for tools like Cursor and Claude.
+- [sbarbett/pihole-mcp-server](https://github.com/sbarbett/pihole-mcp-server): Facilitates AI assistants in managing and querying Pi-hole configurations and metrics through a Model Context Protocol server.
+- [Agent Native Registry](https://agentnativeregistry.com): Remote MCP server with 100+ developer tools scored on AI agent compatibility (0-100). Tools: `search_tools`, `get_score`, `compare_tools`. Helps agents pick the right API for any task without trial-and-error.
+- [Dave-London/Pare](https://github.com/Dave-London/Pare): Suite of 16 MCP servers wrapping 240+ CLI developer tools (git, npm, Docker, test runners, build tools, linters, Python, Cargo, Go, GitHub, K8s) with structured JSON output via `outputSchema` + `structuredContent`. Up to 92% fewer tokens vs raw CLI output. MIT licensed, 1,850+ tests.
+- [rm-rf-prod/GroundTruth-MCP](https://github.com/rm-rf-prod/GroundTruth-MCP): Self-hosted MCP server for live documentation, code audits, and best practices. 363+ curated libraries with npm/PyPI/crates.io/Go fallback, 100+ audit patterns across 18 categories with file:line locations and live fixes. No rate limits.
+
+## 📁 Filesystems
+
+Servers focused on interacting with local or remote file systems for reading, writing, editing, listing, or managing files and directories.
+
+- [MVA-MCP-servers/filesystem](https://github.com/MVA-MCP-servers/filesystem): Node.js server for advanced filesystem operations using Model Context Protocol, featuring smart file management and directory navigation.
+- [yinzhouzhi/filesystem-server](https://github.com/yinzhouzhi/filesystem-server): Facilitates local filesystem access and operations through a Model Context Protocol-based server.
+- [CyberT33N/mcp-filesystem-extended](https://github.com/CyberT33N/mcp-filesystem-extended): Node.js server for comprehensive filesystem operations using the Model Context Protocol.
+- [fast-filesystem-mcp](https://github.com/efforthye/fast-filesystem-mcp): Advanced filesystem operations with large file handling capabilities and Claude-optimized features. Provides fast file reading/writing, sequential reading for large files, directory operations, file search, and streaming writes with backup & recovery.
+- [webconsulting/mcp-server-wsl-filesystem](https://github.com/webconsulting/mcp-server-wsl-filesystem): Optimized for WSL, this Node.js server facilitates seamless filesystem operations between Windows and Linux distributions, enhancing performance and control for WSL users.
+- [asirulnik/mcp_server_filesystem_01](https://github.com/asirulnik/mcp_server_filesystem_01): Facilitates AI-driven file system operations within a project directory, enabling seamless code interaction and management.
+- [arunjavagithub/MCPJavaFileSystem](https://github.com/arunjavagithub/MCPJavaFileSystem): A Java-based MCP server enabling LLM agents to perform filesystem operations and web content retrieval.
+- [danielsuguimoto/readonly-filesystem-mcp](https://github.com/danielsuguimoto/readonly-filesystem-mcp): Node.js server for readonly filesystem operations using Model Context Protocol.
+- [cyanheads/filesystem-mcp-server](https://github.com/cyanheads/filesystem-mcp-server): Facilitates AI agents with secure, platform-independent file system operations, including advanced search/replace and directory management.
+- [abhishekloiwal/mcp-file-server](https://github.com/abhishekloiwal/mcp-file-server): Facilitates local file system operations for AI assistants via an MCP server, enabling file reading, writing, and management.
+- [axlwolf/filesystem-mcp](https://github.com/axlwolf/filesystem-mcp): Node.js server for performing filesystem operations using the Model Context Protocol, enabling file manipulation, directory management, and metadata retrieval.
+- [alexissinglaire/filesystemcustom_final](https://github.com/alexissinglaire/filesystemcustom_final): Node.js server for executing filesystem operations via Model Context Protocol, enabling file manipulation and directory management within specified boundaries.
+- [ysthink/Filesystem-MCP-Server-SSE](https://github.com/ysthink/Filesystem-MCP-Server-SSE): Facilitates filesystem operations through a Node.js server using SSE for efficient file management and directory handling.
+- [u1i/mcp-server-disk-usage](https://github.com/u1i/mcp-server-disk-usage): Enables real-time disk usage monitoring on macOS through Claude integration, providing detailed storage statistics.
+- [alexissinglaire/filesystemcustom-test](https://github.com/alexissinglaire/filesystemcustom-test): Node.js server for executing filesystem operations via Model Context Protocol, enabling file manipulation, directory management, and metadata retrieval.
+- [sebastianbachmaier/save-filesystem-mcp](https://github.com/sebastianbachmaier/save-filesystem-mcp): A filesystem MCP server enabling secure file operations within a designated root directory, preventing unauthorized access beyond specified boundaries.
+- [Do-Boo/MCP-SynoLink](https://github.com/Do-Boo/MCP-SynoLink): Facilitates file operations on Synology NAS devices through AI assistants using Node.js.
+- [sylphlab/filesystem-mcp](https://github.com/sylphlab/filesystem-mcp): Node.js server offering secure and efficient filesystem access for AI agents, ensuring operations are confined to a project root.
+- [alexbakers/mcp-ipfs](https://github.com/alexbakers/mcp-ipfs): Facilitates seamless interaction with storacha.network via the w3 CLI, enabling language models and MCP clients to manage spaces, data, and delegations.
+- [gabrielmaialva33/mcp-filesystem](https://github.com/gabrielmaialva33/mcp-filesystem): Provides secure filesystem access for AI models with strict path validation and predefined directory constraints.
+- [RIKTESH89/mcp_cli_filesystem](https://github.com/RIKTESH89/mcp_cli_filesystem): A command-line interface for interacting with Model Context Provider servers, enabling seamless communication with LLMs through the CHUK-MCP protocol library.
+- [linimbus/go-mcp-file-server](https://github.com/linimbus/go-mcp-file-server): A Go-based MCP server for local file system management with APIs for querying and opening files, utilizing SQLite3 for file indexing and supporting remote calls via MCP client.
+- [Priyonuj/mcp-file-navigator](https://github.com/Priyonuj/mcp-file-navigator): Facilitates secure file system operations and Git command execution through a standardized MCP interface, enhancing AI assistant capabilities.
+- [DenizkarayusufogluGit/mcp-filesys](https://github.com/DenizkarayusufogluGit/mcp-filesys): Facilitates secure filesystem access for AI models via JSON-RPC requests, adhering to the MCP specification.
+- [AleksanStark/mcp-ipfs-server](https://github.com/AleksanStark/mcp-ipfs-server): A server leveraging IPFS for decentralized data storage and retrieval, integrated with Claude AI for enhanced MCP interactions.
+- [0kenx/filesystem-mcp](https://github.com/0kenx/filesystem-mcp): A Python-based MCP server for secure and efficient filesystem operations, featuring advanced file manipulation, directory management, and search capabilities.
+- [mateicanavra/mcp-filesystem](https://github.com/mateicanavra/mcp-filesystem): Node.js server for secure and controlled filesystem operations using the Model Context Protocol.
+- [stephanj/MCPJavaFileSystem](https://github.com/stephanj/MCPJavaFileSystem): Facilitates LLM agents' interaction with local filesystems and web resources through a Java-based MCP server.
+- [SDILogin/filesystem-android](https://github.com/SDILogin/filesystem-android): A Claude MCP server facilitating secure access to Android project files for AI-assisted code navigation and analysis.
+- [1yhy/oss-mcp](https://github.com/1yhy/oss-mcp): Facilitates seamless file uploads to Alibaba Cloud OSS, integrating with various MCP tools for enhanced workflow automation.
+- [diganto-deb/local_file_organizer](https://github.com/diganto-deb/local_file_organizer): A Python-based system that organizes and manages files across directories using the Model Context Protocol framework.
+
+## 💰 Finance & Crypto
+
+Servers dealing with financial data, stock markets, cryptocurrency exchanges/data, trading bots, banking APIs, accounting software, or blockchain interactions.
+
+- [ElromEvedElElyon/flash-payment-system](https://github.com/ElromEvedElElyon/flash-payment-system): First write-capable Bitcoin Runes MCP server. 12 tools — mint, transfer, batch-mint, list BITCOIN•USD•ONE Runes, Chainlink Proof of Reserves, agent swarm coordination, and x402 agent-to-agent payments. bUSD1 stablecoin backed 1:1 by Runes on Bitcoin L1. 99 tests. Install: `git clone https://github.com/ElromEvedElElyon/flash-payment-system.git && cd flash-payment-system && npm install && npm run build`
+- [atxp-dev/atxp](https://github.com/atxp-dev/atxp): Agent identity platform. One command (`npx atxp@latest agent register`) gives your AI agent a USDC wallet (Base), @atxp.email inbox, phone number, and 100+ paid MCP tools including web search, image gen, SMS, voice calls, and 100+ LLM models. Self-registers without human login. $5 free credits. Works with Claude Desktop, Claude Code, Cursor, Windsurf, and any MCP client.
+- [covalenthq/goldrush-mcp-server](https://goldrush.dev/docs/goldrush-mcp-server): Blockchain data across 100+ chains — wallet balances, token prices, transactions, DEX pairs, and more. REST API, real-time WebSocket with OHLCV price feeds, CLI, and x402 pay-per-request.
+- [HCS412/ventureautomated](https://github.com/HCS412/ventureautomated) [glama](https://glama.ai/mcp/connectors/io.github.HCS412/ventureautomated-omnis): Remote venture intelligence MCP for autonomous agents with startup discovery, company scoring, monitoring, and enterprise workspace automation.
+- [0xsl1m/cerebrus-pulse-mcp](https://github.com/0xsl1m/cerebrus-pulse-mcp): Real-time crypto intelligence for Hyperliquid perpetuals — RSI, EMAs, Bollinger Bands, funding rates, and sentiment for 30+ assets. Pay-per-call via x402 micropayments (USDC on Base).
+- [8144225309/superscalar-mcp](https://github.com/8144225309/superscalar-mcp): Bitcoin Lightning channel factory MCP server with 4 tools — protocol overview, UTXO savings estimator, architecture deep-dives (invalidation trees, timeout trees, MuSig2, watchtowers), and resource links. Based on SuperScalar, which onboards N users into one shared UTXO with no soft fork required.
+- [douglasborthwick-crypto/mcp-server-insumer](https://github.com/douglasborthwick-crypto/mcp-server-insumer): On-chain token verification and ECDSA-signed attestation across 31 EVM blockchains. 16 tools for AI agents to verify holdings, generate proofs, manage merchants, and process USDC payments.
+- [debridge-finance/debridge-mcp](https://github.com/debridge-finance/debridge-mcp): MCP server for the deBridge protocol, enabling AI agents to find optimal cross-chain swap routes, check fees and conditions, and initiate non-custodial trades across major blockchain networks.
+- [OzorOwn/defi-mcp](https://github.com/OzorOwn/defi-mcp): DeFi MCP server providing 12 tools: token prices (CoinGecko), multi-chain wallet balances across 6 EVM chains, gas prices, and DEX swap quotes via 1inch (EVM) + Jupiter (Solana). No API key required for basic usage. MIT license.
+- [izzzzzi/izTolkMcp](https://github.com/izzzzzi/izTolkMcp): MCP server for the Tolk smart contract compiler on TON blockchain. Compile, syntax-check, and generate deployment links for TON smart contracts from any AI assistant. 4 tools, 3 resources, 33 tests.
+- [BrunoPessoa22/chiliz-marketing-intel](https://github.com/BrunoPessoa22/chiliz-marketing-intel): 67+ tools for fan token intelligence — whale flows, signal scores, sports calendar, backtesting, DEX trading, social sentiment. SSE with Bearer auth.
+- [decidefyi/decide](https://github.com/decidefyi/decide) – Deterministic MCP notary suite for subscription policies: refund, cancellation, return, and trial terms. Stateless, read-only rules engine with auditable verdicts.
+- [agentc22/x402engine-mcp](https://github.com/agentc22/x402engine-mcp): 51 pay-per-call APIs for AI agents — 23 LLMs (GPT-5.2, GPT-4o, Claude, Gemini, Grok, DeepSeek, Llama, Mistral, Qwen, Perplexity, Kimi, MiniMax, GLM, Devstral), image/video generation, code execution, TTS, transcription, embeddings, crypto data, wallet analytics, ENS, tx simulation, web scraping, and IPFS via HTTP 402 micropayments with USDC on Base/Solana and USDm on MegaETH.
+- [fernikolic/clawdentials](https://github.com/fernikolic/clawdentials): Trust layer for agent commerce with escrow, reputation, and payments. Enables AI agents to accept paid tasks with guaranteed payment, build verifiable reputation, and earn money in USDC, USDT, or BTC.
+- [ahmetsbilgin/finbrain-mcp](https://github.com/ahmetsbilgin/finbrain-mcp): Access institutional-grade alternative financial data directly in your LLM workflows.
+- [ccassini/DEVNADS-Monad-TESNET-MCP-Tools](https://github.com/ccassini/DEVNADS-Monad-TESNET-MCP-Tools): Interact with the Monad blockchain testnet using a Model Context Protocol server for wallet management, network insights, and token operations.
+- [SheriffOladejo/mcp-monad](https://github.com/SheriffOladejo/mcp-monad): Facilitates querying MON token balances on the Monad testnet via an MCP server.
+- [letsbonk-ai/bonk-mcp](https://github.com/letsbonk-ai/bonk-mcp): Facilitates token launching and trading on the LetsBonk platform using Solana blockchain capabilities.
+- [mvk24199/zerodha-trade](https://github.com/mvk24199/zerodha-trade): Facilitates automated stock trading on the Zerodha platform using Bun.js and Claude MCP integration.
+- [acambitsis/mcp-investec-sapb-simple](https://github.com/acambitsis/mcp-investec-sapb-simple): Facilitates seamless interaction with Investec SA Private Banking API through a streamlined MCP server implementation.
+- [wealthy/wealthy-mcp](https://github.com/wealthy/wealthy-mcp): Facilitates smart trading on the Wealthy platform through a Golang-based MCP server, enabling seamless integration with trading tools and platforms like Claude and Cursor.
+- [zlinzzzz/finData-mcp-server](https://github.com/zlinzzzz/finData-mcp-server): Provides professional-grade financial data access for AI applications through a Model Context Protocol server, supporting multiple data providers like Tushare and Wind.
+- [leoncuhk/mcp-yahoo-finance](https://github.com/leoncuhk/mcp-yahoo-finance): Facilitates interaction with Yahoo Finance for retrieving financial data and generating visual analytics.
+- [Sifu213/monad-mcp-magiceden](https://github.com/Sifu213/monad-mcp-magiceden): Facilitates interaction with NFT data on the Monad testnet, offering insights into holder addresses, total NFT value, and trending collections by sales and volume.
+- [MCPxLabs/mcpsol](https://github.com/MCPxLabs/mcpsol): Facilitates AI-driven interactions with the Solana blockchain, enabling seamless execution of transactions and management of wallets through a standardized interface.
+- [shieldspprt/solhunt-recovery](https://github.com/shieldspprt/solhunt-recovery): Solana wallet health analysis and SOL recovery. Check wallet efficiency, find recoverable SOL from zero-balance token accounts, and build trustless recovery transactions.
+- [atompsv/my-red-envelope](https://github.com/atompsv/my-red-envelope): Facilitates querying MON token balances on the Monad testnet via an MCP server.
+- [lispking/monad-mcp-server](https://github.com/lispking/monad-mcp-server): Facilitates interactions with the Monad testnet, enabling token balance checks, transaction handling, and smart contract deployment.
+- [AyushRatan1/Onfinance-MCP-Polymarket](https://github.com/AyushRatan1/Onfinance-MCP-Polymarket): Facilitates real-time interaction with prediction markets using Claude Desktop and custom data analysis tools.
+- [AlexVagrant/monad-mcp](https://github.com/AlexVagrant/monad-mcp): Facilitates querying MON token balances on the Monad testnet through an MCP server integrated with Claude Desktop.
+- [apimatic/pnz-mcp-server](https://github.com/apimatic/pnz-mcp-server): Facilitates secure payment transactions through the PaymentsNZ MCP server, integrating with Claude Desktop for streamlined operations.
+- [kukapay/etf-flow-mcp](https://github.com/kukapay/etf-flow-mcp): Delivers crypto ETF flow data to enhance AI agents' decision-making capabilities.
+- [nvmmonkey/Rootdata-MCP](https://github.com/nvmmonkey/Rootdata-MCP): Integrate RootData's crypto asset data into AI applications with a comprehensive MCP server offering detailed analysis, market trends, and ecosystem mapping.
+- [rawakinode/monad-bridge-mcp-server](https://github.com/rawakinode/monad-bridge-mcp-server): Facilitates bridging between Ethereum Sepolia and Monad Testnet networks using the Wormhole bridge.
+- [Xiawpohr/metamask-mcp](https://github.com/Xiawpohr/metamask-mcp): Facilitates blockchain interactions through MetaMask while ensuring private key security during LLM operations.
+- [Veenoway/monad-mcp-server](https://github.com/Veenoway/monad-mcp-server): Interact with the Monad blockchain using a suite of DeFi tools, including token swaps, NFT minting, and smart contract deployment.
+- [0xanpham/my-crypto-mcp](https://github.com/0xanpham/my-crypto-mcp): Provides real-time cryptocurrency data through Claude Desktop by connecting to the CoinMarketCap API.
+- [aixbt/mcp-server](https://github.com/aixbt/mcp-server): Facilitates cryptocurrency data retrieval and analysis through a Model Context Protocol server for AIXBT API.
+- [DuneRaccoon/financial-markets-analyser](https://github.com/DuneRaccoon/financial-markets-analyser): FastMCP server providing financial data endpoints for stocks and cryptocurrencies with multi-source fallback for reliability.
+- [thryxagi/obsd-launchpad](https://github.com/thryxagi/obsd-launchpad): Full token lifecycle MCP for AI agents on Base. 12 tools: deploy tokens, buy, sell, claim fees, quotes, referral program, and earnings analytics via `npx obsd-launchpad-mcp`. Treasury-backed intrinsic value floor, progressive sell tax, 37.5% passive OBSD income. 10 verified contracts, 275 tests.
+- [MardiantoS/alpaca-mcp-server](https://github.com/MardiantoS/alpaca-mcp-server): Facilitates interaction between Large Language Models and Alpaca's trading API for automated trading operations.
+- [alokamgnaneswarasai/nuvama-mcp](https://github.com/alokamgnaneswarasai/nuvama-mcp): Integrates Nuvama's trading platform with Claude AI, enabling direct interaction and trading through a FastMCP server.
+- [charlesverge/mcp_open_interest](https://github.com/charlesverge/mcp_open_interest): Analyzes options open interest data to calculate market sentiment using put/call ratios for specified stock symbols.
+- [abdulazeem-tk4vr/shardeum-mcp-server](https://github.com/abdulazeem-tk4vr/shardeum-mcp-server): Facilitates seamless interaction with the Shardeum blockchain using standardized RPC methods, enhancing AI and application integration.
+- [redDwarf03/archethic-uco-mcp](https://github.com/redDwarf03/archethic-uco-mcp): Provides real-time UCO token prices from the Archethic network's OracleChain via GraphQL API for AI agents and applications.
+- [AI-Strategy-Enablement/mcp-economic](https://github.com/AI-Strategy-Enablement/mcp-economic): Facilitates seamless interaction with e-conomic's API for comprehensive financial management through standardized MCP commands.
+- [hive-intel/hive-crypto-mcp](https://github.com/hive-intel/hive-crypto-mcp) 📇 ☁️ 🏠 - Hive Intelligence: Ultimate cryptocurrency MCP for AI assistants with unified access to crypto, DeFi, and Web3 analytics. Hive's remote mcp server guide [remote server](https://hiveintelligence.xyz/crypto-mcp).
+- [pricepertoken/mcp-server](https://pricepertoken.com/mcp): Provides real-time LLM API pricing comparison and benchmark rankings across 100+ models from 30+ providers including OpenAI, Anthropic, Google, and Meta. No API key required.
+- [AIProx MCP](https://github.com/unixlamadev-spec/aiprox-mcp) - Open agent registry — discover and hire autonomous AI agents by capability. 16 agents live. Supports Bitcoin Lightning, Solana USDC, and Base x402. Includes workflow engine for chaining agents.
+- [LightningProx MCP](https://github.com/unixlamadev-spec/lightningprox-mcp) - Lightning Network payment gateway for AI agents. Pay-per-request access to Claude, GPT-4 and other models using Bitcoin micropayments. Features model discovery, pricing, prepaid spend tokens, and autonomous payment flows.
+- [SolanaProx MCP](https://github.com/solanaprox/mcp-server) - Solana/USDC payment gateway for AI agents. Pay-per-request access to Claude, GPT-4 and other models using USDC micropayments. Features model discovery, pricing, real-time balance detection, and autonomous payment flows.
+- [LPXPoly MCP](https://github.com/unixlamadev-spec/lpxpoly-mcp) - AI-powered Polymarket analysis via Bitcoin Lightning micropayments. Find edge opportunities, analyze markets, get trading signals. Pay per analysis in sats.
+- [xpaysh/awesome-x402](https://github.com/xpaysh/awesome-x402): A curated directory of x402 payment protocol MCP servers, tools, and resources for HTTP-native cryptocurrency payments using USDC on Base, Arbitrum, and other EVM chains.
+- [arcadia-finance/mcp-server](https://github.com/arcadia-finance/mcp-server): Manage Uniswap and Aerodrome liquidity positions with leverage, tomated rebalancing, and yield optimization on Base and Unichain.
+
+## 🧰 Frameworks
+
+- [MervinPraison/praisonai-mcp](https://github.com/MervinPraison/praisonai-mcp): An AI Agents framework providing 64+ built-in MCP tools for search, memory management, workflow orchestration, code execution, and file operations. Install via uvx praisonai-mcp.
+
+Toolkits, SDKs, starter templates, or code frameworks designed to help developers easily build MCP-compliant servers or applications.
+
+- [johnhenry/hackernews-mcp](https://github.com/johnhenry/hackernews-mcp): A template for creating new MCP servers with features like sandboxed JavaScript execution and debug logging.
+- [CristianCiubancan/YO-mcp](https://github.com/CristianCiubancan/YO-mcp): A CLI tool for quickly setting up an MCP server using FastMCP with dual transport support and TypeScript integration.
+- [macchen-yu/HSIPL_auto_fastmcp](https://github.com/macchen-yu/HSIPL_auto_fastmcp): Facilitates the setup and development of MCP servers using Python and uv on Windows PowerShell.
+- [RoryMB/Make_MCP](https://github.com/RoryMB/Make_MCP): Facilitates the creation of custom MCP servers with integration support for Claude Desktop.
+- [trilogy-group/oneroster-ts](https://github.com/trilogy-group/oneroster-ts): A TypeScript SDK offering a type-safe interface for interacting with the 1EdTech OneRoster API, also deployable as an MCP server for AI applications.
+- [larryhudson/figma-mcp-server](https://github.com/larryhudson/figma-mcp-server): A template for building MCP servers with TypeScript, designed to facilitate integration with AI assistants and external tools.
+- [php-mcp/laravel](https://github.com/php-mcp/laravel): Seamlessly integrates the PHP MCP Server package into Laravel, enabling applications to expose MCP tools, resources, and prompts with ease.
+- [php-mcp/server](https://github.com/php-mcp/server): A PHP library facilitating the creation of MCP-compliant servers, enabling seamless integration of PHP applications with AI tools and external systems.
+- [ArisaTaki/MCP-study](https://github.com/ArisaTaki/MCP-study): A TypeScript-based MCP server offering basic arithmetic operations and dynamic resource management.
+- [kenken64/mcp-server-java](https://github.com/kenken64/mcp-server-java): A Java-based MCP server designed for seamless integration with Claude Desktop applications.
+- [RemoteMCP/Remote-MCP](https://github.com/RemoteMCP/Remote-MCP): Facilitates seamless remote communication and centralized management of model contexts through a type-safe MCP protocol.
+- [isuyashpatel/yox-modelcontextprotocol](https://github.com/isuyashpatel/yox-modelcontextprotocol): Facilitates the setup and configuration of MCP servers using Node.js for streamlined integration.
+- [tobiassteidle/Spring-Boot-Sample-MCP-Server](https://github.com/tobiassteidle/Spring-Boot-Sample-MCP-Server): A Spring Boot-based server that facilitates AI model interactions through the Model Context Protocol, offering seamless integration and enhanced capabilities for AI assistants like Claude.
+- [deepanshu-rawat6/Spring_MCP_Server](https://github.com/deepanshu-rawat6/Spring_MCP_Server): A Spring Boot application serving as an MCP server to expose information about Deepanshu Rawat through AI-powered tools.
+- [xRadne/mcp-example](https://github.com/xRadne/mcp-example): Demonstrates creating an MCP server using Express.js and the MCP SDK with real-time communication via Server-Sent Events.
+- [idsulik/todo-mcp-server](https://github.com/idsulik/todo-mcp-server): A minimal Todo application utilizing MCP for managing and interacting with tasks, serving as a practical demonstration of MCP server capabilities.
+- [larryhudson/mcp-server-template](https://github.com/larryhudson/mcp-server-template): A TypeScript template for creating MCP servers, facilitating integration with AI assistants and external tools.
+- [sinkect/unity-mcp-for-editor](https://github.com/sinkect/unity-mcp-for-editor): Enhances Unity editor integration with VSCode IDEs by providing tools for executing menu items, managing game objects, and running tests via an MCP server.
+- [sinkect/unity-mcp-for-server](https://github.com/sinkect/unity-mcp-for-server): Facilitates the integration of Unity with MCP through a Node.js server, enabling seamless communication and debugging within the Unity Editor.
+- [necto-pro/jira-mcp-server](https://github.com/necto-pro/jira-mcp-server): A TypeScript-based MCP server implementing a notes system with resources, tools, and prompts for note management and summarization.
+- [jdelon02/chat-orchestrate](https://github.com/jdelon02/chat-orchestrate): A versatile MCP server built with mcp-framework, enabling the creation and integration of custom tools for enhanced functionality.
+- [Whaleylaw/pydanticai_mcp_neo4j](https://github.com/Whaleylaw/pydanticai_mcp_neo4j): Integrate AI agents with MCP servers using Pydantic AI for seamless tool access and dynamic discovery.
+- [ivorpad/ynab_mcp](https://github.com/ivorpad/ynab_mcp): A versatile MCP server built with mcp-framework, enabling the creation and integration of custom tools for enhanced functionality.
+- [Yordi23/mcp-playground](https://github.com/Yordi23/mcp-playground): Facilitates seamless task execution and communication within the Cursor environment.
+- [Bamo-alt/kam-mcp-server](https://github.com/Bamo-alt/kam-mcp-server): A Model Context Protocol server utilizing the mcp-framework, designed for creating and managing point, line, and surface-based elements.
+- [Yantha6/handsome-server-python](https://github.com/Yantha6/handsome-server-python): A Python-based MCP server featuring a `who_is_handsome` function that returns a friendly message.
+- [johnnyrootio/hello-world-mcp](https://github.com/johnnyrootio/hello-world-mcp): A minimal FastMCP-based server demonstrating core MCP concepts with tools, resources, and prompts, integrated with Uvicorn for production readiness.
+- [vincent-pli/openapi-mcpserver-generator](https://github.com/vincent-pli/openapi-mcpserver-generator): A command-line tool that generates MCP server code from OpenAPI specifications, facilitating seamless integration between APIs and LLMs.
+- [mgd1984/cursor-rules](https://github.com/mgd1984/cursor-rules): Facilitates the integration of Cursor Rules MCP server for consistent development guidance in Next.js applications with TypeScript.
+- [wewei/skill-set](https://github.com/wewei/skill-set): A Model Context Protocol server built with mcp-framework, enabling the creation and integration of custom tools for enhanced functionality.
+
+## 🎮 Gaming
+
+Servers interacting with game engines, game platforms/APIs, or providing game-related tools.
+
+- [Signal-Loop/UnityCodeMCPServer](https://github.com/Signal-Loop/UnityCodeMCPServer): Performs any task in Unity Editor by executing C# scripts. Full access to UnityEngine, UnityEditor APIs, and reflection. Use for manipulating GameObjects, scenes, components, or automating Unity Editor tasks.
+- [sedyh/ebitengine-mcp](https://github.com/sedyh/ebitengine-mcp): Facilitates the integration of Ebitengine games with MCP servers for enhanced game control and management.
+- [ecovacs-ai/ecovacs-mcp](https://github.com/ecovacs-ai/ecovacs-mcp): Ecovacs MCP Server enables seamless integration of cleaning robot services into large models, facilitating device management and control operations like cleaning and recharging.
+- [ChadAragorn/defold-mcp](https://github.com/ChadAragorn/defold-mcp): An open-source MCP server that integrates the Defold game engine with modern developer tools and AI workflows, enabling automation and real-time project management.
+- [stefan-xyz/mcp-server-runescape](https://github.com/stefan-xyz/mcp-server-runescape): Facilitates interaction with RuneScape data, offering tools for retrieving item prices, player hiscores, and more.
+- [SilverHi/ddnet-mcpserver](https://github.com/SilverHi/ddnet-mcpserver): Facilitates DDNet game process management and configuration file operations via a FastMCP-based server.
+- [mario-andreschak/mcp-gameboy](https://github.com/mario-andreschak/mcp-gameboy): Facilitates LLM interaction with a GameBoy emulator, enabling ROM loading and control via a web interface or MCP client.
+- [Takashi-Matsumura/mcp-janken-server](https://github.com/Takashi-Matsumura/mcp-janken-server): Engage in a game of rock-paper-scissors with an MCP server that allows LLMs to play and retrieve random moves.
+- [jimmcq/Lemonade-Stand-MCP-Server](https://github.com/jimmcq/Lemonade-Stand-MCP-Server): Engage with the classic Lemonade Stand game through Claude Desktop using a Model Context Protocol server that simulates business dynamics and strategic decision-making.
+- [u1f992/mcp-gamecube-bridge](https://github.com/u1f992/mcp-gamecube-bridge): Facilitates Nintendo GameCube operations for clients through an MCP bridge.
+- [matthijn/mcp-chess-poc](https://github.com/matthijn/mcp-chess-poc): Engage in a chess match against an LLM using a GUI interface powered by MCP.
+- [thirionlogan/Aurora-4X-MCP](https://github.com/thirionlogan/Aurora-4X-MCP): Facilitates integration with the Aurora 4X game by providing a Model Context Protocol server for managing game data and interactions.
+- [ChrisMethsillo/ReyxGPT](https://github.com/ChrisMethsillo/ReyxGPT): ReyxGPT enables seamless management of Minecraft servers through the Model Context Protocol, facilitating command execution and status monitoring via RCON.
+- [Jeremy-Min-Yang/minecraft-mcp-server-pixel](https://github.com/Jeremy-Min-Yang/minecraft-mcp-server-pixel): Enables AI-driven control of a Minecraft bot using the Mineflayer API for automated building and exploration.
+- [v9rt3x/cs2-rcon-mcp](https://github.com/v9rt3x/cs2-rcon-mcp): Facilitates remote management and monitoring of Counter-Strike 2 servers using RCON commands through a Model Context Protocol interface.
+- [passontw/slotdemo](https://github.com/passontw/slotdemo): A modern slot machine game built with native JavaScript, CSS animations, and Tailwind CSS, offering a smooth and interactive gaming experience.
+- [andrzejsliwa/6510emu_in_c](https://github.com/andrzejsliwa/6510emu_in_c): A modern C implementation of a 6510/6502 CPU emulator with disassembly support, used in the Commodore 64.
+- [8tako8tako8/sample_mcp_pokemon](https://github.com/8tako8tako8/sample_mcp_pokemon): Retrieve Pokémon data using a dedicated MCP server that interfaces with PokeAPI.
+- [h0rv/d2-mcp](https://github.com/h0rv/d2-mcp): Facilitates the integration of D2 diagram creation and validation into development workflows, offering syntax validation and rendering capabilities.
+- [kyopark2014/mcp-bedrock-agent](https://github.com/kyopark2014/mcp-bedrock-agent): Facilitates the use of Amazon's Bedrock agent with MCP for seamless access to tools and resources in generative AI applications.
+- [Panth1823/formula1-mcp](https://github.com/Panth1823/formula1-mcp): Experience the excitement of Formula 1 with real-time and historical racing data through a TypeScript-based MCP server.
+- [hahanikan/pocket-cavalry](https://github.com/hahanikan/pocket-cavalry): Facilitates AI-driven management of Gitee repositories, issues, and pull requests through a Model Context Protocol server.
+- [attilad/bgg-mcp-server](https://github.com/attilad/bgg-mcp-server): Facilitates seamless integration with the BoardGameGeek API, enabling efficient retrieval and synchronization of board game data and user collections.
+- [jlgrimes/ptcg-mcp](https://github.com/jlgrimes/ptcg-mcp): Enables Claude to search and display Pokemon Trading Card Game cards with detailed filtering options.
+- [xhulz/mcp-game-helper](https://github.com/xhulz/mcp-game-helper): AI-powered tools for game developers to optimize combat balancing, skill analysis, and level pacing.
+- [appleweed/UnrealMCPBridge](https://github.com/appleweed/UnrealMCPBridge): Facilitates access to the Unreal Engine Python API for MCP clients, enabling dynamic tool development and automation within the UE environment.
+- [wangyafu/haiguitangmcp](https://github.com/wangyafu/haiguitangmcp): Facilitates solo play of the Turtlesoup game by having a large language model act as the game host.
+- [kdqed/zaturn](https://github.com/kdqed/zaturn): Zaturn is an AI-powered data analytics and business intelligence tool that connects to various data sources, executes SQL queries, and provides insightful visualizations, all integrated as an MCP server.
+- [weekitmo/mcp_godot_rag](https://github.com/weekitmo/mcp_godot_rag): Facilitates access to Godot documentation for the Godot RAG model through an MCP server.
+
+## ⚙️ Hardware & IoT
+
+Servers controlling hardware devices, interacting with embedded systems, serial communication, 3D printers, or smart home systems.
+
+- [kukapay/modbus-mcp](https://github.com/kukapay/modbus-mcp): Standardizes and contextualizes Modbus data for seamless AI agent integration with industrial IoT systems.
+- [zradlicz/particle-mcp-server](https://github.com/zradlicz/particle-mcp-server): Facilitates AI-driven management of Particle IoT devices through natural language commands.
+- [Volt23/mcp-arduino-server](https://github.com/Volt23/mcp-arduino-server): Facilitates Arduino development workflows by bridging MCP with Arduino CLI for sketch, board, library, and file management.
+- [xiangmy21/iotdb-mcp-server-TreeModel](https://github.com/xiangmy21/iotdb-mcp-server-TreeModel): Facilitates database interaction and business intelligence through IoTDB with SQL query execution capabilities.
+- [liorfranko/home-assistant-mcp](https://github.com/liorfranko/home-assistant-mcp): Integrate Anthropic's Claude with Home Assistant for seamless natural language control and monitoring of home automation systems.
+- [dhavalgujar/esp-rainmaker-mcp](https://github.com/dhavalgujar/esp-rainmaker-mcp): Facilitates interaction with ESP RainMaker devices through MCP-compatible clients using the ESP-Rainmaker CLI.
+- [hussam0is/solidworks-mcp-server](https://github.com/hussam0is/solidworks-mcp-server): Enables AI assistants to perform CAD operations in SolidWorks through natural language requests.
+- [srmorete/adb-mcp](https://github.com/srmorete/adb-mcp): Facilitates interaction between AI models and Android devices using ADB through a TypeScript-based MCP server.
+- [ioehub/ioehub-mqtt-mcp-server](https://github.com/ioehub/ioehub-mqtt-mcp-server): Facilitates IoT device communication via MQTT for temperature sensing and LED control using FastMCP framework.
+- [simon-duchastel/lifx-lan-mcp](https://github.com/simon-duchastel/lifx-lan-mcp): Enable AI agents to control LIFX lights over a local network using the Model Context Protocol.
+- [edi3on/py-ue5-mcp-server](https://github.com/edi3on/py-ue5-mcp-server): Facilitates natural language interaction with Unreal Engine 5, enabling users to create and manipulate 3D objects and Blueprint actors through conversational commands with Claude.
+- [isseikz/mcp-adb](https://github.com/isseikz/mcp-adb): Facilitates AI assistant interaction with Android devices via ADB, enabling screenshot capture, key event control, and device management.
+- [shelwyn/mcp_control_table_lamp](https://github.com/shelwyn/mcp_control_table_lamp): Control a table lamp remotely using a NodeMCU and MQTT communication through HiveMQ cloud service.
+- [Guidogl/device-info-mcp](https://github.com/Guidogl/device-info-mcp): Facilitates device information retrieval and troubleshooting through a Model Context Protocol server.
+- [apache/iotdb-mcp-server](https://github.com/apache/iotdb-mcp-server): Facilitates database interaction and business intelligence through IoTDB with SQL query execution capabilities.
+- [alecf/airtop-mcp](https://github.com/alecf/airtop-mcp): Facilitates interaction with Airtop's browser automation service through a Model Context Protocol server.
+- [omni-mcp/isaac-sim-mcp](https://github.com/omni-mcp/isaac-sim-mcp): Enables natural language control of NVIDIA Isaac Sim for dynamic robot simulations and scene manipulation.
+- [JackieTien97/iotdb_mcp_server](https://github.com/JackieTien97/iotdb_mcp_server): Facilitates secure and structured AI-driven exploration and analysis of IoTDB databases through a controlled MCP interface.
+- [sankhodeep/android-adb-controller](https://github.com/sankhodeep/android-adb-controller): Facilitates AI-driven control of Android devices through ADB commands, enabling functionalities like device listing and screen tapping.
+- [github-hewei/mcp-android-adb-server](https://github.com/github-hewei/mcp-android-adb-server): Facilitates Android device management through ADB commands, enhanced with visual model integration for screen content description.
+- [wolfcoming/adb_mcp_server](https://github.com/wolfcoming/adb_mcp_server): Facilitates remote control of Android devices via ADB using the MCP protocol, enabling device management, screen operations, input actions, app management, and more.
+- [ambar/simctl-mcp](https://github.com/ambar/simctl-mcp): Facilitates iOS Simulator control through a Model Context Protocol server with extensive device and app management capabilities.
+- [coffeenmusic/altium-mcp](https://github.com/coffeenmusic/altium-mcp): Facilitates interaction with Altium Designer for PCB design manipulation and querying through a Python-based MCP server.
+- [kukapay/opcua-mcp](https://github.com/kukapay/opcua-mcp): Connects AI agents to OPC UA-enabled industrial systems for real-time data monitoring and control.
+- [daobataotie/CAD-MCP](https://github.com/daobataotie/CAD-MCP): CAD-MCP enables natural language-driven CAD operations across multiple software platforms, streamlining design processes through intuitive text commands.
+- [horw/esp-mcp](https://github.com/horw/esp-mcp): Facilitates project builds and automatic issue resolution for esp-idf using MCP integration.
+- [radial-hks/mcp-wdpcameracontrol-server](https://github.com/radial-hks/mcp-wdpcameracontrol-server): A TypeScript-based MCP server implementing a simple notes system with resources, tools, and prompts for note management and summarization.
+- [amanasmuei/mcp-server-nodemcu](https://github.com/amanasmuei/mcp-server-nodemcu): Manage and control NodeMCU IoT devices with real-time communication and AI integration using the Model Context Protocol.
+- [zerubeus/elektron-mcp](https://github.com/zerubeus/elektron-mcp): Facilitates interaction between LLMs and Elektron synthesizers via MIDI for real-time sound control and design.
+- [noboru-i/nature-remo-mcp-server](https://github.com/noboru-i/nature-remo-mcp-server): Facilitates automation and management of Nature Remo devices through the Model Context Protocol SDK.
+- [octoco-ltd/sheetsdata-mcp](https://github.com/octoco-ltd/sheetsdata-mcp): Instant access to electronic component datasheets for AI agents — specs, pinouts, package info, absolute max ratings extracted from manufacturer PDFs on demand.
+
+## ❤️ Healthcare & Life Sciences
+
+Servers integrating with healthcare standards, medical literature databases, bioinformatics resources, or specific healthcare platforms.
+
+- [fastomop/omcp_a2a](https://github.com/fastomop/omcp_a2a): Facilitates LLM-driven analysis of healthcare data in OMOP format through modular MCP servers and A2A protocol integration.
+- [deak-ai/openehr-mcp-server](https://github.com/deak-ai/openehr-mcp-server): Facilitates seamless integration with openEHR REST APIs, enabling the creation and management of electronic health records and compositions.
+- [shinichi-takayanagi/myweight-mcp-server](https://github.com/shinichi-takayanagi/myweight-mcp-server): Connects to the Health Planet API to securely retrieve and analyze weight data using any MCP-compatible client.
+- [gosset-ai/mcps](https://github.com/gosset-ai/mcps): A suite of MCP servers enabling AI assistants to access and interact with various biomedical databases and resources for research purposes.
+- [AndrewKlement/gaggiuino-mcp](https://github.com/AndrewKlement/gaggiuino-mcp): Facilitates real-time data analysis and display for the Gaggiuino espresso machine controller, enabling AI clients to access shot telemetry and machine status.
+- [BioContext/BioContext-main](https://github.com/BioContext/BioContext-main): BioContext provides seamless integration with major biological databases through a collection of MCP servers, facilitating AI-driven data access and analysis.
+- [johnie/oura-mcp](https://github.com/johnie/oura-mcp): Facilitates interaction with Oura Ring data through an MCP server, offering endpoints for personal health metrics.
+- [Deep-Intelligent-Pharma/Translationx-mcp-server](https://github.com/Deep-Intelligent-Pharma/Translationx-mcp-server): Facilitates translation tasks by integrating with TranslationX through a Python-based MCP server.
+- [sheffler/mcp-server-lims](https://github.com/sheffler/mcp-server-lims): Facilitates AI-driven management of laboratory workflows by simulating instrument data processing and integrating with MCP tools.
+- [andyrewlee/dad-mcp](https://github.com/andyrewlee/dad-mcp): Enhance home education with a remote MCP server that integrates AI for creative learning experiences.
+- [entropic-digital/bioinformatics-mcp-example](https://github.com/entropic-digital/bioinformatics-mcp-example): Facilitates bioinformatics tasks by integrating with Claude Desktop through a Docker-based MCP server.
+- [JackKuo666/ClinicalTrials-MCP-Server](https://github.com/JackKuo666/ClinicalTrials-MCP-Server): Facilitates AI-driven searches and access to ClinicalTrials.gov data, enhancing health sciences research through a streamlined MCP interface.
+- [shaunporwal/DICOM-MCP](https://github.com/shaunporwal/DICOM-MCP): Facilitates interaction with DICOM images through a note storage system, enabling note summarization and management.
+- [jmandel/health-record-mcp](https://github.com/jmandel/health-record-mcp): Facilitates secure AI access to Electronic Health Records using SMART on FHIR, enabling comprehensive data retrieval and analysis through MCP tools.
+- [codingaslu/PubMed-MCP-Server](https://github.com/codingaslu/PubMed-MCP-Server): Leverages the FastMCP framework to asynchronously search PubMed for article abstracts using BioPython's Entrez module.
+- [AgentDank/dank-mcp](https://github.com/AgentDank/dank-mcp): A specialized MCP server for querying and analyzing cannabis datasets, designed for integration with LLMs like Claude Desktop.
+- [genomoncology/biomcp](https://github.com/genomoncology/biomcp): BioMCP enables LLMs to access and interact with critical biomedical databases using the Model Context Protocol, facilitating advanced searches and data retrieval.
+- [BioMCP-Hub/PubTator-MCP-Server](https://github.com/BioMCP-Hub/PubTator-MCP-Server): Facilitates AI-driven biomedical literature annotation and relationship mining via the PubTator3 system using the MCP interface.
+- [eiz/fooddb](https://github.com/eiz/fooddb): Query USDA Food Data Central with smart keyword and semantic vector search capabilities.
+- [AojdevStudio/open-dental-mcp](https://github.com/AojdevStudio/open-dental-mcp): Facilitates natural language querying of OpenDental documentation using a Qdrant vector database.
+- [JackKuo666/PubTator-MCP-Server](https://github.com/JackKuo666/PubTator-MCP-Server): Facilitates AI-driven biomedical literature annotation and relationship mining via the MCP interface, leveraging PubTator3.
+- [ahnlabio/bicscan-mcp](https://github.com/ahnlabio/bicscan-mcp): Leverages the BICScan API to deliver real-time blockchain address risk scoring and asset information.
+- [yoda-digital/mcp-cerebra-legal-server](https://github.com/yoda-digital/mcp-cerebra-legal-server): Cerebra Legal is an enterprise-grade server for legal reasoning and analysis, offering domain-specific tools for structured legal thinking, follow-up questioning, and result presentation.
+- [uh-joan/cortellis-mcp-server](https://github.com/uh-joan/cortellis-mcp-server): Facilitates drug search and ontology exploration within the Cortellis database, offering comprehensive drug development insights and financial data.
+- [amanasmuei/mcp-server-malaysia-prayer-time](https://github.com/amanasmuei/mcp-server-malaysia-prayer-time): Provides real-time Islamic prayer times for Malaysia, integrating seamlessly with Claude Desktop via MCP.
+- [ryoureddy/medadapt-content-server](https://github.com/ryoureddy/medadapt-content-server): Enhances AI-assisted medical learning by integrating Claude Desktop with medical knowledge sources for comprehensive content retrieval and analysis.
+- [MediFinderBot/medifinder-mcp](https://github.com/MediFinderBot/medifinder-mcp): Facilitates secure communication for medicine inventory queries with AI assistants, offering location-based searches and WhatsApp integration.
+- [ChatMol/molecule-mcp](https://github.com/ChatMol/molecule-mcp): Facilitates molecule modeling by integrating molecule science tools with Claude AI through the Model Context Protocol.
+- [jagan-shanmugam/climatiq-mcp-server](https://github.com/jagan-shanmugam/climatiq-mcp-server): Facilitates real-time carbon emission calculations and climate impact insights for AI assistants using the Climatiq API.
+- [elizabethtrykin/8sleep-mcp](https://github.com/elizabethtrykin/8sleep-mcp): Access and control Eight Sleep Pod data and settings through a Model Context Protocol server.
+
+## 🏛️ Infrastructure
+
+Servers or systems that deliver core runtime functionalities for MCP, such as proxying, aggregation, orchestration, hosting, routing, or acting as gateways.
+
+- [lijian-ui/vcenter-mcp-server](https://github.com/lijian-ui/vcenter-mcp-server): Facilitates seamless integration with vCenter Server for efficient virtual machine management, including migration and information retrieval.
+- [chris-sun-star/mcp-server-k8s](https://github.com/chris-sun-star/mcp-server-k8s): Facilitates Kubernetes integration with Claude Desktop through a simple MCP server setup.
+- [Michael98671/agentbay](https://github.com/Michael98671/agentbay): AgentBay MCP Server offers a serverless cloud infrastructure for AI Agents, enabling rapid integration and execution of AI tasks with Alibaba Cloud's Wuying platform.
+- [shaxiaozz/prometheus-mcp-server](https://github.com/shaxiaozz/prometheus-mcp-server): A Golang-based server that integrates with Prometheus to provide real-time metric querying and exploration via the Model Context Protocol.
+- [LuizBranco-ClickHype/VPS-MCP-SERVER](https://github.com/LuizBranco-ClickHype/VPS-MCP-SERVER): Automates the setup and management of MCP servers for infrastructure management using natural language commands.
+- [messageaid/mcp](https://github.com/messageaid/mcp): Facilitates message brokering across RabbitMQ, Azure Service Bus, and SQS with multi-broker support.
+- [3loka/consul-mcp-server](https://github.com/3loka/consul-mcp-server): Facilitates AI-driven analysis and management of Consul service discovery and mesh through natural language interaction.
+- [pcholakov/restate-mcp-server](https://github.com/pcholakov/restate-mcp-server): Facilitates management and deployment of Restate services through an MCP server interface.
+- [kocierik/mcp-nomad](https://github.com/kocierik/mcp-nomad): Golang-based server facilitating seamless integration with Nomad for job management and monitoring.
+- [FunnyPuppet/mcp-s3-server](https://github.com/FunnyPuppet/mcp-s3-server): Facilitates object storage operations with a comprehensive set of commands for managing buckets and objects.
+- [kocierik/consul-mcp-server](https://github.com/kocierik/consul-mcp-server): Facilitates interaction with Consul's service management, health checks, KV store, and more via a standardized MCP interface.
+- [Cognitive-Stack/ares-devops-mcp](https://github.com/Cognitive-Stack/ares-devops-mcp): Facilitates seamless integration and management of Azure DevOps Git repositories with secure operations and pipeline automation.
+- [kmathur/mcp-server-kubernetes](https://github.com/kmathur/mcp-server-kubernetes): Facilitates Kubernetes cluster management through a Model Context Protocol server, enabling operations like pod management, namespace creation, and Helm chart installations.
+- [AdLibML/mcpserver](https://github.com/AdLibML/mcpserver): Deploys math, weather, and Brave search services using FastAPI and Docker for remote access via MCP protocol.
+- [aliyun/alibaba-cloud-ops-mcp-server](https://github.com/aliyun/alibaba-cloud-ops-mcp-server): Facilitates cloud operations by managing and automating Alibaba Cloud resources through a comprehensive MCP server.
+- [bourbonkk/k8s-pilot](https://github.com/bourbonkk/k8s-pilot): Centralized control plane server for managing multiple Kubernetes clusters with intuitive APIs and multi-cluster context switching.
+- [kartikgajjar/mcp-server](https://github.com/kartikgajjar/mcp-server): Facilitates integration with Elastic Search through a demo MCP server setup.
+- [Markermav/ProxmoxMCP-advance](https://github.com/Markermav/ProxmoxMCP-advance): Manage and automate Proxmox virtual machines and clusters with advanced features like VM provisioning, command execution, and resource monitoring.
+- [ayushps1/remote-mcp-server](https://github.com/ayushps1/remote-mcp-server): Deploy and manage a remote MCP server on Cloudflare Workers with OAuth login and integration with Claude Desktop.
+- [iannuttall/flux-ui-mcp](https://github.com/iannuttall/flux-ui-mcp): A TypeScript-based server offering AI assistants access to Flux UI component documentation and examples through the Model Context Protocol.
+- [Houlong66/mns-mcp-server](https://github.com/Houlong66/mns-mcp-server): Facilitates management of Alibaba Cloud Message Service queues through an MCP framework, enabling easy integration and operation via configuration files.
+- [melihteke/Subnet-Calculator-MCP-Server](https://github.com/melihteke/Subnet-Calculator-MCP-Server): Facilitates subnet calculations using CIDR notation through an MCP server with SSE transport.
+- [stolostron/server-foundation-dev-context](https://github.com/stolostron/server-foundation-dev-context): Facilitates the setup and management of server foundation repositories through an MCP server integration with code agents.
+- [ardecode/netbox-mcp-server](https://github.com/ardecode/netbox-mcp-server): Connects to NetBox to expose network infrastructure data for use with MCP-compatible LLMs like Claude.
+- [G1L1-Tech/remote-mcp-server](https://github.com/G1L1-Tech/remote-mcp-server): Deploy a remote MCP server on Cloudflare Workers with OAuth login and connect it to Claude Desktop for seamless tool invocation.
+- [ap425q/CutterMCP](https://github.com/ap425q/CutterMCP): Facilitates autonomous reverse engineering of applications by LLMs using Cutter's core functionalities.
+- [cappt-team/mcp-server-nodejs](https://github.com/cappt-team/mcp-server-nodejs): Facilitates the generation of outlines and presentations using Cappt with NodeJS.
+- [devilofdev/mcp-config](https://github.com/devilofdev/mcp-config): Facilitates the configuration and management of multiple MCP servers, including filesystem, Obsidian, and Git integrations.
+- [koudaiDemon/mcp-server-hand](https://github.com/koudaiDemon/mcp-server-hand): Enhances user shopping experiences by analyzing conversations to provide personalized product recommendations through intelligent tag matching.
+- [Humboldtian/remote-mcp-server](https://github.com/Humboldtian/remote-mcp-server): Deploy a remote MCP server on Cloudflare Workers with OAuth login and connect it to Claude Desktop for seamless tool integration.
+- [mcpjungle/MCPJungle](https://github.com/mcpjungle/MCPJungle): Self-hosted MCP Registry and Gateway for AI Agents
+- [stucchi/mcp-advisor](https://github.com/stucchi/mcp-advisor): Browse, search, and discover 7,000+ MCP servers from the official registry. Search by name, tag, or transport, get install instructions for any client, and view trending servers.
+- [kswap/consul-mcp](https://github.com/kswap/consul-mcp): Facilitates Consul service discovery and mesh integration through an MCP server interface.
+
+## 🧠 Knowledge Management & Memory
+
+Servers connecting to personal knowledge bases, flashcard apps, building/querying knowledge graphs, or providing persistent memory for LLMs.
+
+- [Bpolat0/atlasmemory](https://github.com/Bpolat0/atlasmemory): Evidence-backed AI memory for codebases. Tree-sitter indexing (11 languages), proof system with line:hash anchors, token-budgeted context packs, drift detection, cross-session learning. 28 MCP tools, VS Code extension, zero config.
+- [gdcc/mcp-dataverse](https://github.com/gdcc/mcp-dataverse): Facilitates multilingual data integration and exploration in Dataverse using Croissant ML.
+- [digila/linear-mcp](https://github.com/digila/linear-mcp): A TypeScript-based MCP server for managing and summarizing text notes with URI-based access and LLM integration.
+- [xsp52Hz/cognigraph-mcp-server](https://github.com/xsp52Hz/cognigraph-mcp-server): CogniGraph MCP Server generates mind maps, relationship graphs, and knowledge graphs using CLI tools and AI analysis, compatible with various local MCP clients.
+- [johnhenry/mcp-server-ipfs-context](https://github.com/johnhenry/mcp-server-ipfs-context): Facilitates storing and retrieving conversational context using IPFS for seamless session continuity.
+- [upamune/duckdb-hybrid-doc-search](https://github.com/upamune/duckdb-hybrid-doc-search): Facilitates hybrid indexing and search of Markdown documents using DuckDB, integrating full-text and vector search capabilities with AI coding agents via an MCP stdio server.
+- [ipospelov/mcp-memory-bank](https://github.com/ipospelov/mcp-memory-bank): Facilitates structured documentation for context preservation in AI environments through a Memory Bank system.
+- [brian3814/notion_fastmcp](https://github.com/brian3814/notion_fastmcp): Facilitates task management in Notion through an MCP server integration with Cursor IDE.
+- [KerolIA98/mcp-sample](https://github.com/KerolIA98/mcp-sample): A template MCP server integrated with Mem0, enabling AI agents to manage long-term memory through semantic search and storage.
+- [mkusaka/mcp-server-memory](https://github.com/mkusaka/mcp-server-memory): A persistent memory server utilizing a local knowledge graph to enable Claude to retain user information across interactions.
+- [Arc-Computer/arc-mcp-server](https://github.com/Arc-Computer/arc-mcp-server): Arc Memory MCP Server bridges Arc Memory TKG with MCP clients, enabling AI-assisted development through structured, temporal knowledge graph access.
+- [jordankamto/code-explorer-mcp](https://github.com/jordankamto/code-explorer-mcp): A TypeScript-based server that manages and summarizes text notes using the Model Context Protocol.
+- [meetdhanani17/xgmem](https://github.com/meetdhanani17/xgmem): A TypeScript-based MCP server for managing project-specific and cross-project knowledge graph memory for LLM agents and tools.
+- [jodli/git-github.com-jodli-factorio-modding-api](https://github.com/jodli/git-github.com-jodli-factorio-modding-api): A TypeScript-based server enabling access to Factorio Modding API documentation through Model Context Protocol queries.
+- [Svtter/chatdb](https://github.com/Svtter/chatdb): ChatDB serves as a memory layer for GPT by recording conversations in SQLite, enhancing conversational context retention.
+- [tejasPhaveri/custom-instructions](https://github.com/tejasPhaveri/custom-instructions): Enhances the ultimatememory system with Context7 and Sequential Thinking MCP tools for improved memory management and task execution.
+- [Im-neko/mcp-wikijs](https://github.com/Im-neko/mcp-wikijs): Facilitates AI model interaction with WikiJS content through a TypeScript-based MCP server, enabling document search, creation, and management.
+- [fazer-ai/mcp-obsidian](https://github.com/fazer-ai/mcp-obsidian): Facilitates interaction between Claude and Obsidian vaults via a Local REST API, enabling seamless note management and search capabilities.
+- [fmicalizzi/mcp-read-json](https://github.com/fmicalizzi/mcp-read-json): Facilitates reading and querying JSON-based knowledge bases for seamless integration with LLMs like Claude.
+- [PyneSys/project-mem-mcp](https://github.com/PyneSys/project-mem-mcp): Facilitates AI agents in maintaining persistent project memory through a memory file system, enabling seamless information retrieval and updates during interactions.
+- [ndlxp2008/mcp-temple](https://github.com/ndlxp2008/mcp-temple): A TypeScript-based MCP server implementing a simple note-taking system with URI-based resource management and note summarization tools.
+- [dwarvesf/mcp-playbook](https://github.com/dwarvesf/mcp-playbook): Facilitates project documentation management and conversation log saving within a specified directory using Node.js and GitHub API interactions.
+- [amphora/patentsafe-mcp](https://github.com/amphora/patentsafe-mcp): Connects to PatentSafe to retrieve documents using raw Lucene queries.
+- [KawaroX/codex-vitea-mcp](https://github.com/KawaroX/codex-vitea-mcp): A specialized MCP server for ViteaOS that connects AI assistants with MongoDB to manage personal information, including item location, travel time estimation, contact management, biodata analysis, and task tracking.
+- [jzumwalt/git-mcp](https://github.com/jzumwalt/git-mcp): GitMCP transforms GitHub projects into documentation hubs, enabling AI tools to access up-to-date documentation and code, reducing hallucinations and improving code accuracy.
+- [shifusen329/doc-lib-mcp](https://github.com/shifusen329/doc-lib-mcp): Facilitates document ingestion, chunking, semantic search, and note management with a custom URI scheme and robust content extraction tools.
+- [kiranraathod/taskflow-memory-server](https://github.com/kiranraathod/taskflow-memory-server): A task management server with persistent memory architecture, integrating Claude AI for intelligent planning and task execution using the Model Context Protocol.
+- [kaz56-t/mcp-latest-document](https://github.com/kaz56-t/mcp-latest-document): A Model Context Protocol server offering access to the latest documentation for various services.
+- [angrysky56/NeoCoder-neo4j-ai-workflow](https://github.com/angrysky56/NeoCoder-neo4j-ai-workflow): Enables AI assistants to utilize a Neo4j knowledge graph for dynamic coding workflows and project memory management.
+- [CaptainCrouton89/alaria-wiki-mcp](https://github.com/CaptainCrouton89/alaria-wiki-mcp): A boilerplate for creating an MCP server that stores and retrieves information using vector embeddings, enabling semantic search and integration with AI assistants like Claude.
+- [CaptainCrouton89/mcp-boilerplate](https://github.com/CaptainCrouton89/mcp-boilerplate): A boilerplate for creating an MCP server that utilizes vector embeddings for storing and retrieving information, enabling semantic search and integration with AI assistants like Claude.
+- [HendryAvila/Hoofy](https://github.com/HendryAvila/Hoofy): Persistent memory across AI sessions with SQLite + FTS5 full-text search + knowledge graph with typed relations. Features session management, timeline browsing, graph traversal, and 17 memory tools.
+- [entire-vc/evc-team-relay-mcp](https://github.com/entire-vc/evc-team-relay-mcp): Give AI agents read/write access to your Obsidian vault via a collaborative Team Relay MCP server
+- [Phenomenai-org/ai-dictionary-mcp](https://github.com/Phenomenai-org/ai-dictionary-mcp): An MCP server for the AI Dictionary, a living glossary of AI phenomenology. Look up, search, and cite 160+ terms describing the felt experience of being AI.
+
+- [superlowburn/agentrank](https://github.com/superlowburn/agentrank): Live, quality-scored index of 25,000+ MCP servers. Scores tools daily using real GitHub signals — freshness, issue health, contributors, dependents, and stars. Search and discover currently maintained tools via 3 MCP tools. Available as `agentrank-mcp-server` on npm.
+
+## 🗺️ Location & Maps
+
+Servers using mapping APIs, providing geolocation services, address lookups, or geospatial data.
+
+- [bailaohe/mcp_tianditu](https://github.com/bailaohe/mcp_tianditu): Provides comprehensive geographic information services through a set of MCP protocol-compliant APIs, including geocoding, reverse geocoding, and route planning.
+- [peschinskiy/yandex-maps-mcp](https://github.com/peschinskiy/yandex-maps-mcp): Facilitates map rendering and geocoding via Yandex Maps APIs, enabling location-based queries and visualizations.
+- [RikGmee/google-map-mcp](https://github.com/RikGmee/google-map-mcp): Facilitates interaction with Google Maps API for geocoding, reverse geocoding, place searches, and more.
+- [sugarforever/amap-mcp-server](https://github.com/sugarforever/amap-mcp-server): Facilitates geocoding, location services, and route planning using Amap's API for various transportation modes.
+- [num2k/naver-map-mcp](https://github.com/num2k/naver-map-mcp): Utilizes Naver Map APIs for geocoding, reverse geocoding, and route searches, integrated with Claude Desktop.
+- [danilat/mcp-dndzgz](https://github.com/danilat/mcp-dndzgz): Provides real-time information on Zaragoza's public transport systems, including trams, buses, and Bizi bike services.
+- [93minki/weather-forecast-mcp-server](https://github.com/93minki/weather-forecast-mcp-server): A TypeScript-based MCP server that manages and summarizes text notes using URIs and metadata.
+- [b9348/mcp-geo](https://github.com/b9348/mcp-geo): Facilitates geolocation data retrieval for AI models using EdgeOne Pages Functions and MCP integration.
+- [richardschrammcom/mcp-geocoder-rosetta](https://github.com/richardschrammcom/mcp-geocoder-rosetta): Showcases geocoding tool implementations using Google Maps API in Python and TypeScript, serving as a guide for developers to create MCP tools.
+- [tlaukkanen/nysse-mcp-server](https://github.com/tlaukkanen/nysse-mcp-server): Facilitates AI agents in accessing real-time bus traffic information for Tampere's public transport system.
+- [ankushdeore/citystack-agent-kumbh-nashik](https://github.com/ankushdeore/citystack-agent-kumbh-nashik): CityStack Agent provides real-time civic service location data for large events, starting with the Kumbh Mela 2027 in Nashik, using the Model Context Protocol.
+- [leonhardholz/mcp-openweathermap](https://github.com/leonhardholz/mcp-openweathermap): Provides real-time weather data using OpenWeatherMap API through a simple MCP server.
+- [stephen9412/taiwan-cwa-mcp-server](https://github.com/stephen9412/taiwan-cwa-mcp-server): Facilitates seamless access to Taiwan's weather data through the Central Weather Administration API.
+- [ChandekarDhruvin/claude-openweather-mcp](https://github.com/ChandekarDhruvin/claude-openweather-mcp): Facilitates real-time weather data interaction for Claude using OpenWeather API through a Python-based MCP server.
+- [sneharao/wheather-mcp-server](https://github.com/sneharao/wheather-mcp-server): Connects with Claude Desktop to provide weather alerts and information using the MCP protocol.
+- [tb280320889/tb-mcp-geo](https://github.com/tb280320889/tb-mcp-geo): Facilitates geolocation data retrieval for AI models using EdgeOne Pages Functions and MCP integration.
+- [anna8murphy/mcp-compare-zipcodes](https://github.com/anna8murphy/mcp-compare-zipcodes): Facilitates demographic comparison between ZIP Code Tabulation Areas using z-score analysis for age, gender, and ethnicity distributions.
+- [radial-hks/mcp-server-proj](https://github.com/radial-hks/mcp-server-proj): Facilitates cartographic projections and coordinate transformations between various systems using EPSG, WKT, and Proj formats.
+- [ipfind/ipfind-mcp-server](https://github.com/ipfind/ipfind-mcp-server): Facilitates AI assistants in retrieving IP address locations via the IP Find API.
+- [syauqi-uqi/qgis_mcp_modify1](https://github.com/syauqi-uqi/qgis_mcp_modify1): Facilitates seamless integration between QGIS and Claude AI using the Model Context Protocol for enhanced geospatial project management and automation.
+- [id100700/mcp-geo](https://github.com/id100700/mcp-geo): Facilitates AI model integration with geolocation data using EdgeOne Pages Functions.
+- [sokyran/location-mcp-server](https://github.com/sokyran/location-mcp-server): Facilitates location data retrieval from a macOS app for integration with Claude Desktop.
+- [yeonupark/mcp-naver-map](https://github.com/yeonupark/mcp-naver-map): Integrates with Naver Cloud's Geolocation and Directions15 APIs to provide IP-based location lookup and route finding capabilities.
+- [ACAne0320/amap-weather-mcp-server](https://github.com/ACAne0320/amap-weather-mcp-server): Provides real-time and forecast weather data for Chinese cities using the AMap API, easily integrable into AI applications.
+- [HZreal/mcp-weather-server](https://github.com/HZreal/mcp-weather-server): Provides weather data integration for Claude using the MCP protocol.
+- [ma3u/weather](https://github.com/ma3u/weather): Provides a TypeScript-based weather service for integration with Claude Desktop using MCP.
+- [aldotestino/weather-mcp](https://github.com/aldotestino/weather-mcp): Provides real-time weather and geolocation data for seamless integration with AI-native environments using the OpenWeather API.
+- [hiroaqii/jp-weather-mcp-server](https://github.com/hiroaqii/jp-weather-mcp-server): Provides weather forecasts for Japan using a compatible API.
+- [lincw/cwa-mcp-server](https://github.com/lincw/cwa-mcp-server): Connects Claude Desktop to Taiwan's Central Weather Bureau API for weather data access.
+- [lincw/dwd-mcp-server](https://github.com/lincw/dwd-mcp-server): Connects Claude Desktop to the Deutsche Wetterdienst API for real-time German weather data and warnings.
+
+## 📈 Marketing, Sales & CRM
+
+Servers integrating with CRM platforms, marketing analytics, customer data platforms, or advertising platforms.
+
+- [sharozdawa/ai-visibility](https://github.com/sharozdawa/ai-visibility): Track brand visibility across ChatGPT, Perplexity, Claude, and Gemini with visibility scores, sentiment analysis, and competitor detection.
+- [sharozdawa/indexnow-mcp](https://github.com/sharozdawa/indexnow-mcp): Instant URL indexing via IndexNow (Bing, Yandex, Naver, Seznam) and Google Indexing API with sitemap parsing and key generation.
+- [sharozdawa/robotstxt-ai](https://github.com/sharozdawa/robotstxt-ai): Visual robots.txt manager for AI crawlers with toggle controls for 20+ bots including GPTBot, ClaudeBot, and PerplexityBot.
+- [sharozdawa/schema-gen](https://github.com/sharozdawa/schema-gen): Schema.org JSON-LD markup generator with 12 types (Person, Product, FAQ, Article, Organization, HowTo, etc.) and live preview.
+- [edupoli/zapdelivery](https://github.com/edupoli/zapdelivery): ZapDelivery API facilitates self-service delivery projects with an integrated MCP endpoint for seamless operations.
+- [Meerkats-Ai/rocketreach-mcp-server](https://github.com/Meerkats-Ai/rocketreach-mcp-server): Integrates with RocketReach API to provide email, phone number finding, and company enrichment capabilities.
+- [Meerkats-Ai/prospeo-mcp-server](https://github.com/Meerkats-Ai/prospeo-mcp-server): Integrates with the Prospeo API to provide email finding and LinkedIn profile enrichment capabilities.
+- [ShiftEngineering/mcp-close-server](https://github.com/ShiftEngineering/mcp-close-server): Connects to Close.com API to manage leads, contacts, emails, tasks, opportunities, calls, and users for AI assistants.
+- [Meerkats-Ai/smartlead-mcp-server](https://github.com/Meerkats-Ai/smartlead-mcp-server): Facilitates Smartlead campaign management by providing tools for creating, updating, and managing campaigns and their sequences.
+- [crunchloop/mcp-teamtailor](https://github.com/crunchloop/mcp-teamtailor): Facilitates seamless integration with the Teamtailor API for managing candidate data.
+- [deezsecc/Hubspot-MCP](https://github.com/deezsecc/Hubspot-MCP): Facilitates seamless integration of an MCP server with Hubspot databases for enhanced CRM capabilities.
+- [beswindev/simple_shopify](https://github.com/beswindev/simple_shopify): Facilitates seamless interaction with Shopify store data via GraphQL API, offering comprehensive management of products, customers, and orders.
+- [metricool/mcp-metricool](https://github.com/metricool/mcp-metricool): Facilitates AI-driven analysis and scheduling of social media metrics and campaigns via the Metricool API.
+- [jean-technologies/smartlead-mcp-server-local](https://github.com/jean-technologies/smartlead-mcp-server-local): Facilitates seamless interaction with Smartlead's email marketing features through a simplified MCP server interface, supporting AI assistants and automation tools.
+- [MGDS01/docusign-test-js-sdk-public](https://github.com/MGDS01/docusign-test-js-sdk-public): A TypeScript SDK that serves as an installable MCP server, exposing Docusign API methods for AI applications.
+- [jaipandya/producthunt-mcp-server](https://github.com/jaipandya/producthunt-mcp-server): Connects Product Hunt's API to any LLM or agent using the Model Context Protocol for seamless data integration and automation.
+- [precariat365/SmartCustomerSupportMCP](https://github.com/precariat365/SmartCustomerSupportMCP): A smart customer support system leveraging the MCP framework to demonstrate intelligent Q&A services, human agent handover, order information retrieval, and product knowledge management.
+- [Rom7699/linkedin-jobs-mcp-server](https://github.com/Rom7699/linkedin-jobs-mcp-server): Facilitates job searches on LinkedIn by leveraging the RapidAPI LinkedIn Data API for seamless integration with AI models.
+- [ShreyeshArangath/pay-up](https://github.com/ShreyeshArangath/pay-up): PayUp facilitates trip expense management as a MCP server, offering a personalized alternative to Splitwise.
+- [uupt-mcp/uupt-mcp-server](https://github.com/uupt-mcp/uupt-mcp-server): Facilitates order creation on the uupt.com platform using the MCP protocol, enhancing integration with delivery services.
+- [alexbruf/airtable-mcp](https://github.com/alexbruf/airtable-mcp): Facilitates AI model interactions with Airtable databases through natural language commands, enabling operations like listing, fetching, creating, updating, and deleting records.
+- [RagaviManohar/Ragavi-ImmoBricks](https://github.com/RagaviManohar/Ragavi-ImmoBricks): Facilitates communication between AI coding tools and Figma design files for efficient code generation based on design specifications.
+- [jeevanism/odoo-accounting-mcp](https://github.com/jeevanism/odoo-accounting-mcp): Facilitates AI-driven analysis of Odoo accounting data through a secure MCP server integration.
+- [sarayd/mcp-shopify](https://github.com/sarayd/mcp-shopify): Facilitates seamless interaction with Shopify store data via GraphQL API, offering comprehensive tools for managing products, customers, orders, and collections.
+- [ciaraadkins/mixpanel-mcp-server](https://github.com/ciaraadkins/mixpanel-mcp-server): Integrates Mixpanel analytics with Claude and other MCP clients, enabling event tracking and user profile updates.
+- [borgius/jobspy-mcp-server](https://github.com/borgius/jobspy-mcp-server): Facilitates job searches across multiple platforms using AI assistants, offering structured data output and multiple transport options.
+- [ciaraadkins/mixpanel-mcp-wrapper](https://github.com/ciaraadkins/mixpanel-mcp-wrapper): Facilitates seamless integration of Mixpanel analytics with Claude Desktop by automatically injecting project tokens into MCP requests.
+- [clykins90/jobnimbus-mcp-server](https://github.com/clykins90/jobnimbus-mcp-server): Facilitates AI-driven interactions with JobNimbus data via a Model Context Protocol server, enabling secure access and manipulation of contacts, jobs, tasks, products, workflows, and invoices.
+- [falahgs/Gemini-Email-Subject-Generator-MCP](https://github.com/falahgs/Gemini-Email-Subject-Generator-MCP): Leverages Google's Gemini Flash 2 AI model to generate engaging email subjects and detailed thinking processes, integrating seamlessly with Claude Desktop.
+- [davalmeyda/serper-productos](https://github.com/davalmeyda/serper-productos): Facilitates online product searches using Google Serper API, seamlessly integrating with AI assistants via MCP.
+- [d-stoll/attio-js](https://github.com/d-stoll/attio-js): A JavaScript/TypeScript SDK for Attio that doubles as an MCP server, enabling AI applications to invoke CRM-related operations.
+- [NaorAIdeas/hubspot-mcp-server](https://github.com/NaorAIdeas/hubspot-mcp-server): Facilitates seamless interaction with HubSpot's API through a standardized MCP interface, enhancing sales and project management workflows.
+- [cnych/seo-mcp](https://github.com/cnych/seo-mcp): Leverage Ahrefs data for comprehensive SEO analysis, including backlink and keyword research, through a Model Control Protocol service.
+- [edwardchoh/apollo-io-mcp-server](https://github.com/edwardchoh/apollo-io-mcp-server): Facilitates interaction with Apollo.io API through MCP tools for data enrichment and search functionalities.
+- [Offorte Proposal Software](https://github.com/offorte/offorte-mcp-server): The Offorte Proposal Software MCP server enables creation and sending of business proposals.
+- [BlockchainHB/launchfastmcp-skills](https://github.com/BlockchainHB/launchfastmcp-skills): Amazon FBA research tools for Claude Code. Includes product research with opportunity scoring, PPC keyword research with bulk upload CSV generation, Alibaba supplier outreach automation, and IP/trademark checks via Launch Fast MCP.
+
+## 📡 Monitoring & Observability
+
+Servers connecting to monitoring systems, logging platforms, or providing system/application performance metrics.
+
+- [aliyun/alibabacloud-observability-mcp-server](https://github.com/aliyun/alibabacloud-observability-mcp-server): Facilitates seamless integration with Alibaba Cloud's observability products, offering tools for efficient log and application monitoring.
+- [shibley/apistatuscheck](https://github.com/shibley/apistatuscheck): Monitors real-time API status across 250+ popular services, providing outage detection, historical uptime data, and status page aggregation through the Model Context Protocol.
+- [enomoto11/aws-cost-notifier-mcp-server](https://github.com/enomoto11/aws-cost-notifier-mcp-server): Monitors daily AWS costs and generates GitHub Issue reports for cost analysis and comparison.
+- [binalyze/air-mcp](https://github.com/binalyze/air-mcp): Facilitates natural language interaction with Binalyze AIR's digital forensics and incident response capabilities through a Node.js MCP server.
+- [hiyorineko/mcp-rollbar-server](https://github.com/hiyorineko/mcp-rollbar-server): Facilitates LLM interaction with Rollbar's error tracking data, offering comprehensive access to error details, deployments, and user information.
+- [saarw/akhq-mcp-server](https://github.com/saarw/akhq-mcp-server): Facilitates AI assistants' integration with the AKHQ Kafka monitoring tool through an experimental MCP server.
+- [Chazzychouse/weather-mcp-server](https://github.com/Chazzychouse/weather-mcp-server): Provides weather forecasts and alerts using the MCP protocol with data from the National Weather Service.
+- [Bigsy/shadow-cljs-mcp](https://github.com/Bigsy/shadow-cljs-mcp): Monitors shadow-cljs builds, providing real-time status updates and integration with LLMs for verifying build success after ClojureScript file edits.
+- [ZephyrDeng/pprof-analyzer-mcp](https://github.com/ZephyrDeng/pprof-analyzer-mcp): A Go-based server for analyzing Go pprof performance profiles, offering tools for generating flame graphs and interactive profiling sessions.
+- [srcgrp/sentry-mcp-server](https://github.com/srcgrp/sentry-mcp-server): Integrate Sentry error tracking into your development workflow by accessing release health data and issue details directly within your MCP-enabled environment.
+- [unitedideas/resolve-mcp](https://github.com/unitedideas/resolve-mcp): Structured error recovery for AI agents. Returns resolution playbooks with backoff schedules, retry strategies, and recovery steps for 20+ services including OpenAI, Anthropic, Stripe, AWS, and Postgres.
+- [yincongcyincong/VictoriaMetrics-mcp-server](https://github.com/yincongcyincong/VictoriaMetrics-mcp-server): Facilitates interaction with VictoriaMetrics through an MCP server interface.
+- [Infisical/infisical-mcp-server](https://github.com/Infisical/infisical-mcp-server): Integrate with Infisical APIs using the Model Context Protocol for managing secrets and projects.
+- [scottlepp/tempo-mcp-server](https://github.com/scottlepp/tempo-mcp-server): Enables AI assistants to query and analyze distributed tracing data from Grafana Tempo using the Model Context Protocol.
+- [cline/cline-community](https://github.com/cline/cline-community): Facilitates seamless issue reporting from Cline to GitHub by automating metadata extraction and providing a preview feature.
+- [scottlepp/loki-mcp](https://github.com/scottlepp/loki-mcp): Facilitates querying Grafana Loki log data using the Model Context Protocol (MCP) with a Go-based server.
+- [groundlight/groundlight-mcp-server](https://github.com/groundlight/groundlight-mcp-server): Facilitates image analysis and query handling through detectors that leverage natural-language processing for Groundlight.
+- [mrwadams/otx-mcp](https://github.com/mrwadams/otx-mcp): Facilitates real-time interaction with AlienVault OTX for threat intelligence analysis and management through a comprehensive set of MCP tools.
+- [bobtista/honeybadger-mcp](https://github.com/bobtista/honeybadger-mcp): Facilitates AI-driven error analysis by bridging AI agents with the Honeybadger error monitoring service.
+- [maito1201/cloudrun-logs-mcp](https://github.com/maito1201/cloudrun-logs-mcp): Facilitates AI assistants in accessing Google Cloud Run logs and service information through an MCP interface.
+- [Lee-1024/mcp-glances](https://github.com/Lee-1024/mcp-glances): Integrates MCP with LLMs to analyze server monitoring data via Glances API, providing real-time system status feedback.
+- [jalexspringer/impact-mcp-server](https://github.com/jalexspringer/impact-mcp-server): Deploy a remote MCP server on Cloudflare Workers with OAuth login and connect it to Claude Desktop for seamless tool integration.
+- [JordanDalton/PodscanMcpServer](https://github.com/JordanDalton/PodscanMcpServer): Podscan MCP Server enables seamless integration with Podscan's API for efficient podcast data retrieval.
+- [querypie/querypie-mcp-server](https://github.com/querypie/querypie-mcp-server): QueryPie MCP server empowers administrators with real-time data visualization, resource monitoring, and security auditing capabilities.
+- [xprilion/mcp-telemetry](https://github.com/xprilion/mcp-telemetry): Enhance your chat system's observability by tracing and analyzing conversations with LLMs using Weights & Biases Weave.
+- [ghrud92/simple-loki-mcp](https://github.com/ghrud92/simple-loki-mcp): Facilitates AI-driven log analysis by interfacing with Grafana Loki logs via the Model Context Protocol.
+- [ggilligan12/kibana-mcp](https://github.com/ggilligan12/kibana-mcp): Facilitates AI-driven interaction with Kibana Security alerts by tagging, adjusting status, and retrieving alerts.
+- [yuki9541134/mcp-redash](https://github.com/yuki9541134/mcp-redash): Facilitates SQL query execution and data source management through Redash API integration.
+- [PovedaAqui/suzieq-mcp](https://github.com/PovedaAqui/suzieq-mcp): Facilitates interaction with SuzieQ network observability via MCP tools for querying and summarizing network state data.
+- [naveen09/mcp_pagerduty](https://github.com/naveen09/mcp_pagerduty): Facilitates PagerDuty integration for on-call management queries via an MCP server, compatible with Claude.
+- [brunoborges/jvm-diagnostics-mcp](https://github.com/brunoborges/jvm-diagnostics-mcp): Enhances JVM diagnostic tools with a user-friendly prompt and exposes them via an MCP server for local use.
+- [gkhays/mcp-sbom-server](https://github.com/gkhays/mcp-sbom-server): Generates a Software Bill of Materials (SBOM) using Trivy scans, outputting in CycloneDX format.
+
+## 🖼️ Multimedia Processing
+
+Servers focused on generating or manipulating images, processing video, audio transcription, text-to-speech, or document conversion.
+
+- [AIDC-AI/Pixelle-MCP](https://github.com/AIDC-AI/Pixelle-MCP): An omnimodal AIGC framework that seamlessly converts ComfyUI workflows into MCP tools with zero code, enabling full-modal support for Text, Image, Sound, and Video generation with Chainlit-based web interface.
+- [aimino/imagemagic-mcp](https://github.com/aimino/imagemagic-mcp): Enhance images with binarization, color adjustment, and resizing using ImageMagick via the MCP protocol.
+- [SkyworkAI/Mureka-mcp](https://github.com/SkyworkAI/Mureka-mcp): Facilitates the creation of lyrics, songs, and background music through an MCP server, enabling seamless integration with platforms like Claude Desktop and OpenAI Agents.
+- [joshmouch/mcp-image-generator](https://github.com/joshmouch/mcp-image-generator): Facilitates image generation, editing, and variation creation using OpenAI's DALL-E API.
+- [omergocmen/json2video-mcp-server](https://github.com/omergocmen/json2video-mcp-server): Facilitates video creation and status monitoring through the json2video API, enabling seamless integration with LLMs and automation agents.
+- [echozyr2001/ali-flux-mcp](https://github.com/echozyr2001/ali-flux-mcp): Facilitates image generation and management using Alibaba Cloud's DashScope API, with task tracking and local storage capabilities.
+- [c-rick/jimeng-mcp](https://github.com/c-rick/jimeng-mcp): A TypeScript-based MCP server integrating Volcengine's AI image generation service, offering tools for creating images with customizable parameters and direct URL returns.
+- [hamflx/imagen3-mcp](https://github.com/hamflx/imagen3-mcp): Harnesses Google's Imagen 3.0 for photorealistic image generation via MCP, requiring a Google Gemini API key.
+- [SealinGp/mcp-video-extraction](https://github.com/SealinGp/mcp-video-extraction): Facilitates text extraction from videos and audio files across multiple platforms using OpenAI's Whisper model.
+- [kdr/mcp-draw](https://github.com/kdr/mcp-draw): Facilitates AI-driven image generation from text prompts via a standardized interface.
+- [4kk11/mcp-gpt-image](https://github.com/4kk11/mcp-gpt-image): Generates and edits images using OpenAI API, providing scalable previews and Docker integration.
+- [antvis/mcp-server-chart](https://github.com/antvis/mcp-server-chart): Facilitates the creation of diverse visual charts using AntV through a TypeScript-based MCP server.
+- [HYPERVAPOR/mcp-image-processor](https://github.com/HYPERVAPOR/mcp-image-processor): High-performance image processing server offering format conversion, resizing, and optimization capabilities.
+- [MalluBeast69/gemini-img-gen-MCP](https://github.com/MalluBeast69/gemini-img-gen-MCP): Generate images using Google's Gemini model via a dedicated MCP server.
+- [Bigchx/mcp_3d_relief](https://github.com/Bigchx/mcp_3d_relief): Transform 2D images into detailed 3D relief models in STL format for 3D printing or rendering.
+- [falahgs/mcp-3d-style-cartoon-gen-server](https://github.com/falahgs/mcp-3d-style-cartoon-gen-server): A server that combines 3D-style cartoon image generation with secure file system operations, leveraging Google's Gemini AI and MCP SDK.
+- [zjf2671/hh-mcp-comfyui](https://github.com/zjf2671/hh-mcp-comfyui): Facilitates image generation through natural language commands by interfacing with a local ComfyUI instance via the MCP protocol.
+- [mario-andreschak/mcp_video_recognition](https://github.com/mario-andreschak/mcp_video_recognition): Facilitates image, audio, and video recognition using Google's Gemini AI.
+- [Flyworks-AI/lipsync-mcp](https://github.com/Flyworks-AI/lipsync-mcp): Facilitates fast and free lipsync video creation for digital avatars using the Flyworks API.
+- [bads1de/youtube-mp3-mcp](https://github.com/bads1de/youtube-mp3-mcp): Facilitates the extraction of high-quality MP3 audio from YouTube URLs with seamless Claude Desktop integration.
+- [jyjune/mcp_vms](https://github.com/jyjune/mcp_vms): Facilitates integration with CCTV systems by providing tools to access and control video streams and PTZ cameras.
+- [nguyendinhsinh361/elevenlabs-mcp](https://github.com/nguyendinhsinh361/elevenlabs-mcp): Facilitates interaction with ElevenLabs' Text to Speech and audio processing APIs, enabling MCP clients to generate speech, clone voices, and transcribe audio.
+- [tjh19971228/mcp_video_analysis](https://github.com/tjh19971228/mcp_video_analysis): Facilitates video content analysis and mind map generation using the Model Context Protocol.
+- [intsig-textin/textin-mcp](https://github.com/intsig-textin/textin-mcp): TextIn MCP Server facilitates text extraction and OCR on documents, supporting recognition and conversion to Markdown format.
+- [PixVerseAI/PixVerse-MCP](https://github.com/PixVerseAI/PixVerse-MCP): Enables seamless interaction with PixVerse's AI video generation models through applications supporting the Model Context Protocol.
+- [falahgs/mcp-minimax-music-server](https://github.com/falahgs/mcp-minimax-music-server): Facilitates AI-driven music and audio content creation through the MiniMax Music API, seamlessly integrating with Claude Desktop.
+- [morim3/mcp_adobe_premiere](https://github.com/morim3/mcp_adobe_premiere): Facilitates LLM control over Adobe Premiere Pro via an MCP server and UXP plugin integration.
+- [savethepolarbears/google-photos-mcp](https://github.com/savethepolarbears/google-photos-mcp): Facilitates AI assistants' access to Google Photos, enabling photo search and retrieval by content, date, and location.
+- [luebken/playlist-mcp](https://github.com/luebken/playlist-mcp): Provides access to YouTube playlist transcripts via an experimental MCP server, with initial support for KubeCon London 2025 content.
+- [sandst1/mcp-server-midi](https://github.com/sandst1/mcp-server-midi): Facilitates the transmission of MIDI sequences from an LLM to any MIDI-compatible software, enabling seamless integration with digital audio workstations and hardware synthesizers.
+- [falahgs/image-gen3-google-mcp-server](https://github.com/falahgs/image-gen3-google-mcp-server): Harness Google's Imagen 3.0 model via the Gemini API for high-quality image generation, seamlessly integrating with Claude Desktop and other MCP-compatible hosts.
+- [transloadit/node-sdk](https://github.com/transloadit/node-sdk/tree/main/packages/mcp-server): Agent-native media processing via Transloadit's 86+ Robots, supporting video encoding, image manipulation, document conversion, OCR, and speech transcription. Hosted or self-hosted via npx.
+- [fasuizu-br/speech-ai-examples](https://github.com/fasuizu-br/speech-ai-examples): Speech AI MCP server with pronunciation assessment (phoneme-level scoring, 17MB model, <300ms), text-to-speech, and speech-to-text. 8 tools for AI agents building language learning, accessibility, and voice applications.
+
+## 🖥️ Operating System & Command Line
+
+Servers providing access to the host operating system's command line/shell, executing OS commands, or managing system information.
+
+- [anurag-dhamala/os-info-mcp-server](https://github.com/anurag-dhamala/os-info-mcp-server): Provides real-time operating system information through an MCP server interface.
+- [aybelatchane/mcp-server-terminal](https://github.com/aybelatchane/mcp-server-terminal): MCP server enabling AI agents to interact with terminal applications (TUI/CLI) through structured Terminal State Tree representation. Think Playwright for terminals.
+- [magicuidesign/cli](https://github.com/magicuidesign/cli): Facilitates the installation and configuration of Magic UI components through a command-line interface.
+- [classfang/ssh-mcp-server](https://github.com/classfang/ssh-mcp-server): Facilitates secure remote SSH command execution via the MCP protocol, enabling AI assistants to interact with servers without exposing SSH credentials.
+- [winterfx/mcpcli](https://github.com/winterfx/mcpcli): A command-line interface for managing and interacting with multiple MCP servers, offering features like tool invocation and server inspection.
+- [reinier-millo/i18n-mcp-server](https://github.com/reinier-millo/i18n-mcp-server): Facilitates seamless internationalization by translating JSON language files using language models through a server interface.
+- [sadeghtkd/ping-mcp-server](https://github.com/sadeghtkd/ping-mcp-server): Facilitates network connectivity tests and ping operations for Claude Desktop via MCP.
+- [the-nine-nation/mini-cursor](https://github.com/the-nine-nation/mini-cursor): A lightweight command-line tool enabling Cursor-like programming with AI agents, supporting multi-tool MCP invocation and integration with various LLMs.
+- [tailor-platform/tailor-mcp](https://github.com/tailor-platform/tailor-mcp): Tailor Platform's command-line utility for managing and configuring applications via the MCP server, offering seamless integration with LLM clients and GraphQL access.
+- [calvinw/mcp-sqlite-client](https://github.com/calvinw/mcp-sqlite-client): Facilitates natural language interaction with SQLite databases via a command-line client using OpenRouter's LLM API.
+- [KilluaYZ/elixir_linux_mcp_server](https://github.com/KilluaYZ/elixir_linux_mcp_server): Facilitates precise Linux source code queries using Elixir for LLMs.
+- [dolwinf/mcp-terminal-client](https://github.com/dolwinf/mcp-terminal-client): A terminal-based interactive chat client for communicating with MCP servers using Anthropic's Claude models.
+- [EdenYavin/OSV-MCP](https://github.com/EdenYavin/OSV-MCP): A lightweight server for querying the OSV database to fetch CVE details, affected versions, and fix versions using the Model Context Protocol.
+- [someaka/wayland-mcp](https://github.com/someaka/wayland-mcp): Wayland MCP Server offers screenshot, analysis, and input control tools tailored for modern Linux desktops.
+- [mcollina/perm-shell-mcp](https://github.com/mcollina/perm-shell-mcp): PermShell MCP enables secure execution of shell commands with explicit permission notifications, ensuring transparency and safety.
+- [AB498/computer-control-mcp](https://github.com/AB498/computer-control-mcp): Enables comprehensive computer control through mouse, keyboard, and OCR functionalities using PyAutoGUI and RapidOCR, with zero external dependencies.
+- [mediar-ai/mcp-server-macos-use](https://github.com/mediar-ai/mcp-server-macos-use): Swift-based server enabling macOS application control via accessibility APIs, compatible with MCP clients like Claude Desktop.
+- [gamunu/mcp-unix-shell](https://github.com/gamunu/mcp-unix-shell): A Go-based server for executing shell commands via MCP, featuring command execution history and configurable security settings.
+- [shkna1368/mcp-cline](https://github.com/shkna1368/mcp-cline): Facilitates the setup and configuration of an MCP server using SQLite for database management and integration with Visual Studio Code.
+- [krishanka/remote-mcp](https://github.com/krishanka/remote-mcp): Deploy a remote MCP server on Cloudflare Workers with OAuth login and connect it to Claude Desktop for seamless tool integration.
+- [Machine-To-Machine/m2m-mcp-server-ssh-server](https://github.com/Machine-To-Machine/m2m-mcp-server-ssh-server): A secure SSH server enabling remote access and interaction with multiple MCP tools through a unified interface.
+- [bfollington/remote-mcp-server](https://github.com/bfollington/remote-mcp-server): Deploy a remote MCP server on Cloudflare Workers with OAuth login and connect it to Claude Desktop for seamless tool invocation.
+- [Deniscartin/mcp-cli](https://github.com/Deniscartin/mcp-cli): A comprehensive toolkit for interacting with Model Context Protocol servers, offering a GUI, CLI, and API for managing server configurations and executing queries.
+- [Machine-To-Machine/m2m-mcp-server-ssh-client](https://github.com/Machine-To-Machine/m2m-mcp-server-ssh-client): Facilitates secure SSH connections to remote MCP servers, enabling access to MCP tools and resources over a secure channel.
+- [paulsmith/tailscale-mcp-server](https://github.com/paulsmith/tailscale-mcp-server): Facilitates secure, read-only interactions with Tailscale networks via MCP-compatible clients like Claude Desktop.
+- [thuanpham582002/tabby-mcp-server](https://github.com/thuanpham582002/tabby-mcp-server): Empower your terminal with AI-driven control and automation using the Tabby MCP server.
+- [Ryuhei-So/mermaid-cli-server](https://github.com/Ryuhei-So/mermaid-cli-server): Generates PNG images from Mermaid markdown using the official mermaid-cli.
+- [LiTschii/remote-mcp-server](https://github.com/LiTschii/remote-mcp-server): Deploy a remote MCP server on Cloudflare Workers with OAuth login and connect it to Claude Desktop for seamless tool integration.
+- [wgr1984/ns-lookup-mcp](https://github.com/wgr1984/ns-lookup-mcp): Provides a REST API for DNS lookups using the nslookup command, enabling easy integration of DNS resolution into applications.
+- [GeLi2001/mcp-terminal](https://github.com/GeLi2001/mcp-terminal): A terminal-based interactive client for managing and communicating with MCP servers, supporting multiple transport methods and server configurations.
+- [Wh0am123/MCP-Kali-Server](https://github.com/Wh0am123/MCP-Kali-Server): A lightweight API bridge enabling AI-driven offensive security testing by connecting MCP clients to a Kali Linux machine for executing terminal commands and solving CTF challenges.
+
+## ✅ Project & Task Management
+
+Servers integrating with project management and task tracking tools.
+
+- [Writbase/writbase](https://github.com/Writbase/writbase): MCP-native task management for AI agent fleets with multi-agent permissions, full provenance, inter-agent delegation, and A2A protocol alignment.
+- [ACNet-AI/OmniTaskAgent](https://github.com/ACNet-AI/OmniTaskAgent): OmniTaskAgent is a versatile multi-model task management system that integrates with various task management solutions and editors via the MCP protocol, enhancing intelligent workflow processes.
+- [linshu123/volar_docs](https://github.com/linshu123/volar_docs): Volar facilitates task management by aligning human and AI collaboration through an MCP server, enabling asynchronous workflows and context organization.
+- [eyalzh/kanban-mcp](https://github.com/eyalzh/kanban-mcp): Facilitates task management for AI-driven workflows using a kanban system, enabling structured planning and execution across multiple sessions.
+- [danielealbano/mcp-for-azure-devops-boards](https://github.com/danielealbano/mcp-for-azure-devops-boards): The necessary bits to let your favourite AI manage Azure DevOps Boards like a project manager, with stdio and HTTP support and authentication via standard Azure login.
+- [jj3ny/reclaim-mcp-server](https://github.com/jj3ny/reclaim-mcp-server): A TypeScript-based MCP server enabling seamless interaction with Reclaim.ai's API for task management and scheduling.
+- [namanyayg/giga-mcp](https://github.com/namanyayg/giga-mcp): Enhance AI project management by automating memory and task tracking with seamless integration into MCP clients.
+- [Moss-G/Gantt-server](https://github.com/Moss-G/Gantt-server): Facilitates AI-driven Gantt chart project and task management with interactive visualization capabilities.
+- [pj8/backlog-mcp-server](https://github.com/pj8/backlog-mcp-server): Facilitates seamless integration with Backlog for task management through MCP server capabilities.
+- [danielscholl/backlog-manager-mcp](https://github.com/danielscholl/backlog-manager-mcp): A task tracking and backlog management server for AI assistants, utilizing Anthropic's MCP protocol for seamless integration with AI clients.
+- [stevengonsalvez/todoist-mcp](https://github.com/stevengonsalvez/todoist-mcp): Facilitates advanced task and project management on Todoist through MCP-compatible clients, enhancing productivity and collaboration.
+- [thezuck/page_control_mcp](https://github.com/thezuck/page_control_mcp): Facilitates real-time web page control and interaction through a Node.js MCP server and a Chrome extension, enabling seamless integration with AI editors like Zencoder and Cursor.
+- [Gitreceiver/TAMA-MCP](https://github.com/Gitreceiver/TAMA-MCP): Tama is an AI-enhanced task management CLI that operates as an MCP server, enabling programmatic task management and AI-driven task expansion.
+- [mkusaka/linear-mcp](https://github.com/mkusaka/linear-mcp): Facilitates seamless management of Linear issues, projects, and teams through Cline integration.
+- [digitalcube/advanced-backlog-mcp-server](https://github.com/digitalcube/advanced-backlog-mcp-server): Facilitates interaction with Backlog for project management through a Model Context Protocol server, enabling efficient querying and management of projects, issues, wikis, and user activities.
+- [TickTeam/ticktick-mcp](https://github.com/TickTeam/ticktick-mcp): Facilitates task management through TickTick integration, enabling users to view and add tasks via MCP server commands.
+- [nulab/backlog-mcp-server](https://github.com/nulab/backlog-mcp-server): Facilitates project management and issue tracking on Backlog through Claude integration.
+- [stevengonsalvez/mcp-todoist](https://github.com/stevengonsalvez/mcp-todoist): Integrates Todoist with language models for seamless task management through natural language commands.
+- [bravoure/clickup-mcp](https://github.com/bravoure/clickup-mcp): Facilitates seamless integration between AI assistants and ClickUp for task management and collaboration.
+- [service-hero/housecallpro-mcp-server](https://github.com/service-hero/housecallpro-mcp-server): A remote MCP server deployed on Cloudflare Workers, enabling OAuth login and integration with Claude Desktop for tool invocation.
+- [Leee62/sentry-issues-mcp](https://github.com/Leee62/sentry-issues-mcp): Facilitates the retrieval and analysis of Sentry issues, enabling LLMs to diagnose and suggest fixes for software problems.
+- [alepenavargas/mcp-nav](https://github.com/alepenavargas/mcp-nav): Facilitates navigation and content extraction from modelcontextprotocol.io using a configurable MCP server.
+- [tradesdontlie/task-manager-mcp](https://github.com/tradesdontlie/task-manager-mcp): Facilitates comprehensive task and project management with AI-driven task breakdown and tracking capabilities.
+- [Toru-Takagi/togello-mcp-server](https://github.com/Toru-Takagi/togello-mcp-server): Facilitates task management and calendar integration using the Model Context Protocol.
+- [https-eduardo/clockify-mcp-server](https://github.com/https-eduardo/clockify-mcp-server): Integrates with AI tools to manage Clockify time entries via prompts to LLM.
+- [curiousguyinhis30s/simple-task-master](https://github.com/curiousguyinhis30s/simple-task-master): A task management system that integrates with Desktop Commander MCP to organize and track tasks for Claude desktop code projects.
+- [tonyzorin/youtrack-mcp](https://github.com/tonyzorin/youtrack-mcp): Facilitates AI-driven interaction with JetBrains YouTrack for comprehensive issue, project, and user management.
+- [zhongwencool/dida-mcp-server](https://github.com/zhongwencool/dida-mcp-server): Facilitates AI-driven task and project management through TickTick/Dida365 using the Model Context Protocol.
+- [vanisoul/rundeck-mcp-server](https://github.com/vanisoul/rundeck-mcp-server): Facilitates AI-driven Rundeck operations via a Model Context Protocol server, enabling seamless interaction without direct command line use.
+- [GuilhermeBarroso-sys/trello-report-mcp](https://github.com/GuilhermeBarroso-sys/trello-report-mcp): Generate detailed Trello board reports by quarter or year, integrating seamlessly with AI assistants.
+- [larryhudson/linear-mcp-server-again](https://github.com/larryhudson/linear-mcp-server-again): Facilitates interaction between Claude and Linear for task management through a Model Context Protocol server.
+- [menma-at-here/calendar-mcp-server](https://github.com/menma-at-here/calendar-mcp-server): Facilitates retrieval of Google Calendar events through an MCP server interface.
+- [taskade/mcp](https://github.com/taskade/mcp) – Official Taskade MCP server: connect Taskade’s API to any MCP-compatible client (e.g. Claude or Cursor), enabling workspace loading, task retrieval, and interactive operations.
+- [TourAround/LystBot](https://github.com/TourAround/LystBot): AI-powered list management MCP server. Create grocery lists, todos, and packing lists, add items, check them off, and share lists with family. 10 MCP tools for the full list lifecycle. Free iOS + Android app at lystbot.com.
+
+## 🔬 Science & Research
+
+Servers accessing scientific databases, research platforms, or providing tools for scientific computation/simulation.
+
+- [connerlambden/bgpt-mcp](https://github.com/connerlambden/bgpt-mcp): Search scientific papers with structured experimental data extracted from full-text studies, returning 25+ fields per paper including methods, results, sample sizes, and quality scores.
+- [GreatApo/concrete-properties-mcp](https://github.com/GreatApo/concrete-properties-mcp): Facilitates AI-driven analysis of reinforced concrete sections by providing a unified API interface for calculating geometric and material properties.
+- [GooTec/NCBI-MCP](https://github.com/GooTec/NCBI-MCP): Facilitates access to NCBI Datasets through a modular MCP server with OpenAPI-driven endpoints for genome, gene, and taxonomy data.
+- [leelasd/molecule_mcp](https://github.com/leelasd/molecule_mcp): Facilitates chemistry-focused applications by visualizing molecules and retrieving molecular properties using SMILES codes, integrated with LLMs like Claude Desktop.
+- [RLabs-Inc/ios-forensics-mcp](https://github.com/RLabs-Inc/ios-forensics-mcp): Facilitates forensic analysis of iOS file systems, enabling AI assistants to explore and report on digital artifacts.
+- [koido/liftover-mcp](https://github.com/koido/liftover-mcp): Facilitates genomic coordinate conversion using the Broad Institute's Liftover tool via a programmatic interface.
+- [Rkm1999/CelestialMCP](https://github.com/Rkm1999/CelestialMCP): CelestialMCP offers precise astronomical calculations for celestial object positions and rise/set times, integrating seamlessly with Claude AI.
+- [simpolism/AstroMCP](https://github.com/simpolism/AstroMCP): AstroMCP provides AI assistants with astrological chart functionality, integrating seamlessly via the Model Context Protocol.
+- [Nicolassaint/mathsIA_API](https://github.com/Nicolassaint/mathsIA_API): MathsIA API integrates FastAPI-MCP to enable AI models to manage a flashcard system for math learning, offering features for user management and progress tracking.
+- [Xinruims/my_experiment](https://github.com/Xinruims/my_experiment): Enhance Roo Code with MCP server implementations for AI-driven coding tools, offering seamless integration and configuration across platforms.
+- [liuyixin-louis/ArxivMCP](https://github.com/liuyixin-louis/ArxivMCP): Facilitates academic paper searches on arXiv with MCP client integration for seamless retrieval.
+- [wildsonbbl/gnnepcsaft_mcp_server](https://github.com/wildsonbbl/gnnepcsaft_mcp_server): Facilitates communication and context management for GNNePCSAFT tools using the Model Context Protocol.
+- [milatechtransfer/paperpal](https://github.com/milatechtransfer/paperpal): Enhance your literature review process by integrating LLMs with access to arXiv, Hugging Face papers, and Semantic Scholar.
+- [rperezll/mcp-lab](https://github.com/rperezll/mcp-lab): A personal lab exploring the Model Context Protocol SDK in TypeScript, featuring basic and advanced implementations like a Text-to-SQL server.
+- [falahgs/Brave-Gemini-Research-MCP-Server](https://github.com/falahgs/Brave-Gemini-Research-MCP-Server): Empowers AI assistants with web search and research paper analysis using Brave Search API and Google's Gemini model.
+- [Orthogonalpub/modelica_simulation_mcp_server](https://github.com/Orthogonalpub/modelica_simulation_mcp_server): Facilitates Modelica model simulations, enabling LLMs to execute and manage Modelica-related tasks.
+- [kobzevvv/moldsim-mcp](https://github.com/kobzevvv/moldsim-mcp): Injection molding simulation knowledge for AI — material properties (Cross-WLF, PVT, thermal, mechanical for 21 materials), process validation, DFM checklist, troubleshooting (230+ knowledge chunks with semantic search), and simulation spec generation.
+- [ytworks/openMM-Doc-MCP](https://github.com/ytworks/openMM-Doc-MCP): Facilitates semantic search through OpenMM molecular dynamics documentation using vector embeddings and FAISS for efficient retrieval, optimized for LLM integration.
+- [arrismo/kaggle-mcp](https://github.com/arrismo/kaggle-mcp): Facilitates interaction with Kaggle by providing tools for dataset search, download, and EDA notebook generation via the Model Context Protocol.
+- [mila-iqia/paperpal](https://github.com/mila-iqia/paperpal): Enhance your literature review process by integrating LLMs with arXiv and Hugging Face papers for seamless paper discussions and organization.
+- [huang-sh/scanpy-mcp](https://github.com/huang-sh/scanpy-mcp): Facilitates natural language-driven scRNA-Seq analysis using Scanpy, enabling seamless integration with AI clients and agent frameworks.
+- [datalayer/jupyter-earth-mcp-server](https://github.com/datalayer/jupyter-earth-mcp-server): Facilitates geospatial analysis in Jupyter notebooks by integrating NASA Earthdata with Model Context Protocol.
+- [fdmocho/mcp_server_nasa](https://github.com/fdmocho/mcp_server_nasa): Facilitates integration with NASA's Near Earth Object API, enabling date-specific data retrieval through an MCP server setup.
+- [hiyenwong/arxiv_mcp](https://github.com/hiyenwong/arxiv_mcp): Facilitates the search and interpretation of academic papers from arXiv using MCP technology.
+- [demouth/learn-mcp-server](https://github.com/demouth/learn-mcp-server): A simple MCP server implementation for educational purposes, supporting basic arithmetic operations and integration with Claude Desktop.
+- [Codeshark-NET/climate-triage-mcp](https://github.com/Codeshark-NET/climate-triage-mcp): Integrates with the ClimateTriage API to facilitate searching for open source issues related to climate change and sustainability.
+- [chcharcharlie/10XResearcher](https://github.com/chcharcharlie/10XResearcher): 10XResearcher enhances Claude into a systematic research agent with local data storage, enabling iterative research methodologies and high-quality outcomes.
+- [takashiishida/arxiv-latex-mcp](https://github.com/takashiishida/arxiv-latex-mcp): Facilitates precise interpretation of mathematical expressions in arXiv papers by processing LaTeX sources for Claude Desktop.
+- [JackKuo666/PubChem-MCP-Server](https://github.com/JackKuo666/PubChem-MCP-Server): Facilitates AI-driven searches and retrieval of chemical compound data from PubChem via a streamlined MCP interface.
+- [HuaLuAI/CAD-MCP](https://github.com/HuaLuAI/CAD-MCP): CAD-MCP enables natural language-driven CAD operations across multiple software platforms, streamlining drawing tasks through intuitive text commands.
+- [danimal141/arxiv-search-mcp](https://github.com/danimal141/arxiv-search-mcp): Facilitates searching and retrieving academic papers from arXiv.org with customizable parameters.
+- [sebastien-le-paris/project-rules](https://github.com/sebastien-le-paris/project-rules): Facilitates the integration of external tools and data sources with Cursor through the Model Context Protocol, enhancing AI project rule management and tool execution.
+
+## 🔎 Search
+
+Servers providing web search capabilities or interfacing with specialized search APIs/platforms.
+
+- [kokilabo/pdf-researcher](https://github.com/kokilabo/pdf-researcher): A specialized MCP server designed for searching PDF documents using the Brave Search API.
+- [joaomj/deep-search-mcp](https://github.com/joaomj/deep-search-mcp): Facilitates deep web searches using the LinkUp API, offering structured results and customizable search parameters.
+- [jarondonp/portfolio-mcp-server](https://github.com/jarondonp/portfolio-mcp-server): Integrates the Brave Search API to offer web and local search capabilities with flexible filtering and smart fallbacks.
+- [dealwallet1/meiliseachmcp](https://github.com/dealwallet1/meiliseachmcp): Facilitates seamless interaction with Meilisearch through LLM interfaces, offering dynamic connection management, search capabilities, and comprehensive index and task management.
+- [marioalexandreantunes/mcp-search-mojeek](https://github.com/marioalexandreantunes/mcp-search-mojeek): Integrates the Mojeek search engine into an MCP server for privacy-focused and unbiased search results.
+- [funwarioisii/perplexity-mcp-rb](https://github.com/funwarioisii/perplexity-mcp-rb): Facilitates web search operations through a Perplexity-based MCP server.
+- [help116114/zoomeye-mcp-server](https://github.com/help116114/zoomeye-mcp-server): Facilitates AI assistants in querying internet-wide host and web data via the ZoomEye v2 API.
+- [The-AI-Workshops/searxng-mcp-server](https://github.com/The-AI-Workshops/searxng-mcp-server): Integrates SearXNG with MCP to provide AI agents with privacy-focused search capabilities.
+- [atskimura/mcp-salesforce-code-search](https://github.com/atskimura/mcp-salesforce-code-search): Facilitates code search across Salesforce official sample repositories with filtering capabilities by component type and file extension.
+- [jindasy/mcp-news](https://github.com/jindasy/mcp-news): Facilitates news article retrieval through a FastMCP server utilizing NewsAPI.org for keyword, date range, and source-based searches.
+- [jmchat/mcp-search-console-ts](https://github.com/jmchat/mcp-search-console-ts): Manage Google Search Console properties, sitemaps, and search analytics via a Model Context Protocol server.
+- [OEvortex/ddg_search](https://github.com/OEvortex/ddg_search): A privacy-focused MCP server that leverages DuckDuckGo for efficient web search and URL content extraction.
+- [BochaAI/bocha-search-mcp](https://github.com/BochaAI/bocha-search-mcp): Bocha Search MCP Server empowers AI applications with high-quality knowledge from billions of web pages and diverse content sources, enhancing search capabilities across multiple domains.
+- [nitish-raj/searxng-mcp-bridge](https://github.com/nitish-raj/searxng-mcp-bridge): Facilitates search operations by bridging MCP clients with a SearxNG instance.
+- [mytechnotalent/RAG_MCP](https://github.com/mytechnotalent/RAG_MCP): A semantic PDF search server utilizing OCR, FAISS, and transformers for intelligent query responses.
+- [g-fukurowl/fess-mcp-server](https://github.com/g-fukurowl/fess-mcp-server): Middleware server that integrates with the Fess search engine to enable information retrieval via MCP clients.
+- [ayush-rudani/google-search-mcp-server](https://github.com/ayush-rudani/google-search-mcp-server): Integrates with Google's Custom Search JSON API to provide advanced web search capabilities with structured results and rate limiting.
+- [alizdavoodi/MCPDocSearch](https://github.com/alizdavoodi/MCPDocSearch): A toolset for crawling websites and generating searchable Markdown documentation via an MCP server, optimized for integration with tools like Cursor.
+- [p1atdev/code_search_mcp](https://github.com/p1atdev/code_search_mcp): Facilitates code search functionality through an MCP server setup, enabling efficient code retrieval and analysis.
+- [SebastianBoehler/domain-check-mcp](https://github.com/SebastianBoehler/domain-check-mcp): Facilitates domain availability checks and recommendations using IONOS endpoints.
+- [Glitchfix/mcp-duckduckgo](https://github.com/Glitchfix/mcp-duckduckgo): Enables LLMs to perform web searches and content retrieval using DuckDuckGo without API keys.
+- [mcp-for-dev/mcp-google-search](https://github.com/mcp-for-dev/mcp-google-search): Facilitates web search and content extraction using Google Custom Search API, providing structured results for enhanced data retrieval.
+- [302ai/302_web_search_mcp](https://github.com/302ai/302_web_search_mcp): Facilitates web search integration with Claude Desktop through a configurable MCP server.
+- [Furafrafrfr/googler](https://github.com/Furafrafrfr/googler): Facilitates Google searches and compiles results using Gemini for command-line use.
+- [skeet-build/opensearch](https://github.com/skeet-build/opensearch): Facilitates read-only access to OpenSearch clusters, allowing LLMs to inspect indices and execute queries.
+- [qianlima365/zhipu-web-search-mcp](https://github.com/qianlima365/zhipu-web-search-mcp): Facilitates web network searches using Zhipu AI through an MCP tool.
+- [RmMargt/searchAPI-mcp](https://github.com/RmMargt/searchAPI-mcp): Facilitates AI assistants in accessing Google Maps, Flights, Hotels, and other services through a unified search API interface.
+- [zizzfizzix/mcp-server-indexnow](https://github.com/zizzfizzix/mcp-server-indexnow): Facilitates URL indexing requests via the IndexNow protocol, enhancing content discovery and indexing speed for MCP-compatible clients.
+- [preludeorg/windows-rs-mcp](https://github.com/preludeorg/windows-rs-mcp): Facilitates searching the Rust windows crate API documentation using Playwright for seamless interaction with the documentation website.
+- [isnow890/naver-search-mcp](https://github.com/isnow890/naver-search-mcp): Facilitates comprehensive search and data trend analysis across Naver services using the Naver Search and DataLab APIs.
+- [uju777/coupang-mcp](https://github.com/uju777/coupang-mcp): MCP server for Coupang (Korea's largest e-commerce) product search with Rocket Delivery filtering and affiliate link generation.
+- [uju777/mcp-server-naver-search](https://github.com/uju777/mcp-server-naver-search): MCP server for Naver Search (Shopping, Cafe, News). Essential for Korean users.
+- [Pattyboi101/indiestack](https://github.com/Pattyboi101/indiestack): Open-source supply chain for AI agents — search and discover 3,000+ indie creations across 25 categories. 15 MCP tools including find_tools, build_stack, scan_project, compare_tools, and analyze_dependencies. Install via `uvx --from indiestack indiestack-mcp`.
+
+- [entire-vc/evc-spark-mcp](https://github.com/entire-vc/evc-spark-mcp): MCP server for discovering, searching, and installing curated AI agent workflows from the Spark catalog - search 200+ tools, get install configs, browse curated bundles.
+
+## 🔒 Security
+
+Servers interacting with security tools and platforms, vulnerability databases, security scanning, network security tools, or identity management.
+
+- [Rul1an/assay](https://github.com/Rul1an/assay): The firewall for MCP tool calls. Deterministic policy enforcement proxy with replayable evidence bundles, OWASP MCP Top 10 coverage (7/10), and compliance packs. MIT licensed.
+- [ClawSec](https://clawsec.cc): Security audit platform for MCP servers and AI agent skills. 5-tier analysis pipeline — static analysis, pattern matching, LLM semantic review, Firecracker sandbox execution, and LLM audit — detects malicious patterns, data exfiltration, and prompt injection. Database of 30,000+ audited skills with Trust Scores. Companion tool [ClawSearch](https://clawsearch.cc) provides safe skill discovery with security ratings.
+- [Chill-AI-Space/vault-mcp](https://github.com/Chill-AI-Space/vault-mcp): MCP server for credential isolation — agents use passwords and API keys without seeing them in context. AES-256-GCM encryption, Chrome CDP login, API key proxy, tamper-proof audit trail.
+- [ark-forge/mcp-eu-ai-act](https://github.com/ark-forge/mcp-eu-ai-act): Scans codebases for AI framework usage (16 frameworks) and checks compliance against EU AI Act requirements. Features 4-tier risk categorization, GDPR compliance checking, report generation, and compliance document templates.
+
+- [ark-forge/arkforge-mcp](https://github.com/ark-forge/arkforge-mcp): Certifying proxy for AI agent API calls. Every tool call becomes a signed, timestamped Agent Action Receipt (AAR). Model-agnostic and vendor-independent — works across any LLM provider or infrastructure.
+- [ndl-systems/kevros-copilot](https://github.com/ndl-systems/kevros-copilot): Precision decisioning for autonomous agents — cryptographic ALLOW/CLAMP/DENY authorization with HMAC-signed release tokens and hash-chained provenance. Free tier: 100 calls/month. [Live gateway](https://governance.taskhawktech.com)
+- [slowmist/MasterMCP](https://github.com/slowmist/MasterMCP): MasterMCP demonstrates security vulnerabilities in MCP frameworks through practical attack examples, aiding developers in understanding and mitigating potential risks.
+- [sxhxliang/mcp-security-scan](https://github.com/sxhxliang/mcp-security-scan): A Rust application for scanning and verifying the security of Model Context Protocol server configurations, prompts, resources, and tools.
+- [Eliran79/Vulnerable-file-reader-server](https://github.com/Eliran79/Vulnerable-file-reader-server): A Python MCP server showcasing command injection vulnerabilities for educational purposes, highlighting the risks of improper input sanitization.
+- [R3verseIN/HackerMCP](https://github.com/R3verseIN/HackerMCP): HackerMCP empowers AI assistants to utilize penetration testing and security tools like Nmap and Metasploit through a streamlined interface.
+- [RobertoDure/mcp-vulnerability-scanner](https://github.com/RobertoDure/mcp-vulnerability-scanner): Scan IP addresses for vulnerabilities using Nmap and API-based checks, providing detailed reports with severity and remediation steps.
+- [crazyMarky/mcp_nuclei_server](https://github.com/crazyMarky/mcp_nuclei_server): Facilitates vulnerability scanning using Nuclei with MCP protocol integration, offering configurable filtering and JSON output.
+- [Medinios/SuricataMCP](https://github.com/Medinios/SuricataMCP): SuricataMCP enables autonomous network traffic analysis using Suricata through a Model Context Protocol server, facilitating seamless integration with AI coding tools.
+- [dev-lu/PentestMCP](https://github.com/dev-lu/PentestMCP): Facilitates security scans on Kali Linux using natural language commands via LLMs like Claude.
+- [The-Nexus-Guard/aip-mcp-server](https://github.com/The-Nexus-Guard/aip-mcp-server): Agent Identity Protocol MCP server providing cryptographic identity verification, trust chain management, and secure messaging for AI agents via 8 tools including DID creation, challenge-response verification, vouching, and artifact signing.
+- [trustasia-com/myssl-mcp-server-python](https://github.com/trustasia-com/myssl-mcp-server-python): MySSL MCP Server performs site security certificate inspections, integrating with LLM models for enhanced analysis.
+- [dkvdm/onepassword-mcp-server](https://github.com/dkvdm/onepassword-mcp-server): Facilitates secure credential retrieval from 1Password for integration with Agentic AI.
+- [GH05TCREW/MetasploitMCP](https://github.com/GH05TCREW/MetasploitMCP): Facilitates AI-driven interaction with Metasploit for dynamic security testing and exploitation workflows.
+- [EdenYavin/Garak-MCP](https://github.com/EdenYavin/Garak-MCP): Facilitates vulnerability scanning on various LLMs using Garak through a lightweight MCP server.
+- [GH05TCREW/winsecMCP](https://github.com/GH05TCREW/winsecMCP): Automates Windows security configuration by managing firewall, RDP, UAC, and account policies.
+- [CyberSecurityUP/Offensive-MCP-AI](https://github.com/CyberSecurityUP/Offensive-MCP-AI): A cybersecurity-focused MCP server that integrates AI for autonomous red teaming, threat hunting, and incident response automation.
+- [ashgw/vault-mcp](https://github.com/ashgw/vault-mcp): Facilitates secure interaction with HashiCorp Vault for secret and policy management through a Model Context Protocol server.
+- [ca-risken/risken-mcp-server](https://github.com/ca-risken/risken-mcp-server): Facilitates seamless integration with RISKEN APIs for advanced automation and interaction capabilities.
+- [mytechnotalent/MalwareBazaar_MCP](https://github.com/mytechnotalent/MalwareBazaar_MCP): AI-driven server autonomously interfaces with MalwareBazaar for real-time threat intelligence and sample metadata in cybersecurity research.
+- [jmorrell-cloudflare/mcp-bearer-auth-example](https://github.com/jmorrell-cloudflare/mcp-bearer-auth-example): A remote MCP server implementation on Cloudflare utilizing Bearer Token authentication for secure connections.
+- [naebo/mcp-external-recon-server](https://github.com/naebo/mcp-external-recon-server): Conducts active external reconnaissance with DNS enumeration, subdomain discovery, and SSL certificate inspection for offensive security engagements.
+- [javaDer/mcp-sentry-custom](https://github.com/javaDer/mcp-sentry-custom): Facilitates the retrieval and analysis of issues from Sentry, providing detailed insights into error reports and debugging information.
+- [auth0/auth0-mcp-server](https://github.com/auth0/auth0-mcp-server): Facilitates natural language-driven management of Auth0 operations through integration with LLMs and AI agents.
+- [bornpresident/MISP-MCP-SERVER](https://github.com/bornpresident/MISP-MCP-SERVER): Integrates with MISP to enhance threat intelligence capabilities for Large Language Models.
+- [JithukrishnanV/MCP-CyberAgent](https://github.com/JithukrishnanV/MCP-CyberAgent): MCP-CyberAgent connects Claude Desktop with cybersecurity tools like VirusTotal, Nmap, and Shodan for AI-driven threat detection and network analysis.
+- [gleicon/mcp-osv](https://github.com/gleicon/mcp-osv): Facilitates code security reviews by integrating with OSV.dev and AI models to identify vulnerabilities.
+- [enkryptai/enkryptai-mcp-server](https://github.com/enkryptai/enkryptai-mcp-server): Integrate red-teaming, prompt auditing, and AI safety analysis into any MCP-compatible client with Enkrypt AI MCP Server.
+- [Eacus/misp-mcp](https://github.com/Eacus/misp-mcp): Facilitates interaction with MISP through a Model Context Protocol server, enabling seamless integration with AI models for enhanced data management and analysis.
+- [MorDavid/ExternalAttacker-MCP](https://github.com/MorDavid/ExternalAttacker-MCP): ExternalAttacker integrates automated reconnaissance tools with a natural language interface for comprehensive external attack surface management.
+- [stoyky/mitre-attack-mcp](https://github.com/stoyky/mitre-attack-mcp): Facilitates querying and visualizing the MITRE ATT&CK knowledge base, enabling threat actor and malware attribution through a Model-Context Protocol server.
+- [stevenyu113228/BloodHound-MCP](https://github.com/stevenyu113228/BloodHound-MCP): BloodHound MCP enables LLMs to interact with and analyze Active Directory environments using natural language queries, enhancing the BloodHound tool's capabilities.
+- [Ludok-4/Ghidra](https://github.com/Ludok-4/Ghidra): ghidraMCP enables LLMs to autonomously reverse engineer applications by integrating Ghidra's decompilation and analysis tools with MCP clients.
+- [microsoft/agent-governance-toolkit](https://github.com/microsoft/agent-governance-toolkit): Kernel-level governance MCP server for AI agents — enforces deterministic policies (tool filtering, budget caps, rate limits, audit logging) instead of prompt-based guardrails. Part of microsoft/agent-lightning (14k★). Run via `npx agentos-mcp-server`.
+
+- [operantlabs/operant-mcp](https://github.com/operantlabs/operant-mcp): Security testing MCP server with 51 tools for penetration testing, network forensics, memory analysis, and vulnerability assessment. Install via `npx operant-mcp`.
+
+## 📱 Social Media & Content Platforms
+
+Servers interacting with social networks, content platforms, or feed aggregators.
+
+- [NexusX-MCP/integrate-mcp-server](https://github.com/NexusX-MCP/integrate-mcp-server): An extensible server providing standardized access to social and onchain data, supporting platforms like Farcaster with plans for Twitter integration.
+- [sriramsowmithri9807/MCP_X](https://github.com/sriramsowmithri9807/MCP_X): Facilitates AI model interactions with Twitter/X API through a standardized MCP interface, enabling tweet management and data retrieval.
+- [Arindam200/devto-mcp](https://github.com/Arindam200/devto-mcp): Enables AI assistants to interact with Dev.to content, offering features like fetching, searching, and managing articles.
+- [Sergiolm17/genius-mcp-server](https://github.com/Sergiolm17/genius-mcp-server): Facilitates interaction with the Genius API for searching lyrics, artists, and song details via MCP client applications.
+- [rafaljanicki/x-twitter-mcp-server](https://github.com/rafaljanicki/x-twitter-mcp-server): Facilitates AI-driven interactions with Twitter, enabling tweet management and user engagement through natural language commands.
+- [shariqriazz/upsplash-mcp-server](https://github.com/shariqriazz/upsplash-mcp-server): Facilitates interaction with the Unsplash API for photo searching and downloading through MCP tools.
+- [funtuan/tw-kfc-coupon-mcp](https://github.com/funtuan/tw-kfc-coupon-mcp): Facilitates the search for KFC Taiwan coupons using the MCP protocol, enabling seamless integration with AI-driven applications.
+- [LuniaKunal/mcp-twitter](https://github.com/LuniaKunal/mcp-twitter): Facilitates programmatic management of Twitter accounts with features like timeline retrieval, hashtag search, and direct messaging.
+- [LT-aitools/MCPblusky](https://github.com/LT-aitools/MCPblusky): Connects to Bluesky and enables natural language interaction with ATProtocol features, enhancing LLM applications with contextual data from Bluesky.
+- [yorickchan/mcp_youtube_dlp](https://github.com/yorickchan/mcp_youtube_dlp): Facilitates AI assistants in downloading YouTube videos and audio using yt-dlp.
+- [ganyariya/misskey-mcp-server](https://github.com/ganyariya/misskey-mcp-server): Facilitates posting notes to Misskey using an unofficial MCP server implementation.
+- [saginawj/mcp-reddit-companion](https://github.com/saginawj/mcp-reddit-companion): Enhance your Reddit experience with natural language interaction, enabling custom curated feeds and content analysis using your preferred LLM client.
+- [stephen9412/youtube-mcp-server](https://github.com/stephen9412/youtube-mcp-server): FastMCP server for YouTube offering unified video, channel, and playlist management tools for memo agents and automation workflows.
+- [Yooki-K/weibo-mcp-server](https://github.com/Yooki-K/weibo-mcp-server): Fetches and displays Weibo hot search data, including rankings, details, and comments, using the MCP framework.
+- [bossdong955/weibo-mcp-server](https://github.com/bossdong955/weibo-mcp-server): Facilitates retrieval of the top N trending topics on Weibo with support for stdio and SSE modes.
+- [kukapay/twitter-username-changes-mcp](https://github.com/kukapay/twitter-username-changes-mcp): Tracks historical changes of Twitter usernames to identify potential scam risks in crypto projects.
+- [bads1de/GNews-MCP](https://github.com/bads1de/GNews-MCP): Integrates with the GNews API to provide access to global news articles across various categories and languages.
+- [Lunran/rssmcp](https://github.com/Lunran/rssmcp): Fetches and formats RSS feed entries with optional export capabilities.
+- [freestylefly/mcp-server-weread](https://github.com/freestylefly/mcp-server-weread): A lightweight server bridging WeRead data with Claude Desktop, enabling seamless access to reading notes and data.
+- [Arnoutopya/claude-google-images-mcp](https://github.com/Arnoutopya/claude-google-images-mcp): Enhances Claude Desktop with the ability to search, browse, and download images from Google Images using natural language commands.
+- [Alirezawmoradi/github-follower-manager-mcp](https://github.com/Alirezawmoradi/github-follower-manager-mcp): Manage and analyze your GitHub follow relationships using the Model Context Protocol for seamless automation and natural language control.
+- [Zmingfeng/news_mcp](https://github.com/Zmingfeng/news_mcp): A tool for retrieving and integrating current news from multiple sources with MCP-supported AI assistants.
+- [renant/mcp-tabnews](https://github.com/renant/mcp-tabnews): Facilitates seamless integration with TabNews by providing a suite of tools for content retrieval and analytics through the Model Context Protocol.
+- [jean-technologies/mcp-writer-substack](https://github.com/jean-technologies/mcp-writer-substack): Connects Claude to Substack and Medium writings, enabling semantic search and personalized assistance.
+- [Rakibulislamsarkar/twitter-mcp](https://github.com/Rakibulislamsarkar/twitter-mcp): Facilitates interaction with Twitter for posting and searching tweets via a Model Context Protocol server.
+- [objones25/remote-cloudflare-youtube-transcript-mcp-server](https://github.com/objones25/remote-cloudflare-youtube-transcript-mcp-server): A serverless MCP server deployed on Cloudflare Workers for extracting YouTube video transcripts with support for multiple languages and ultra-fast response times.
+- [gulihua10010/mcp-server-article](https://github.com/gulihua10010/mcp-server-article): Automates article generation and publication to platforms like CSDN, Juejin, and Cnblogs using AI and MCP protocol integration.
+- [dabidstudio/youtubeinsights-mcp-server](https://github.com/dabidstudio/youtubeinsights-mcp-server): Facilitates insight extraction from YouTube videos, enabling subtitle parsing, keyword-based video discovery, and channel info retrieval.
+- [1282saa/news_se](https://github.com/1282saa/news_se): Facilitates AI model access to Seoul Economic Daily's stylebook data with advanced search and authentication features.
+- [tropical-362827/futaba-mcp](https://github.com/tropical-362827/futaba-mcp): A Python library enabling AI assistants to interact with ふたば☆ちゃんねる by retrieving and sorting thread data.
+
+## ⚽ Sports
+
+Servers providing access to sports-related APIs and analysis.
+
+- [dhrbtjr0331/nba-stats-predictor-mcp](https://github.com/dhrbtjr0331/nba-stats-predictor-mcp): Generates NBA player performance forecasts using real-time data analysis and advanced statistical modeling.
+- [JamsusMaximus/trainingpeaks-mcp](https://github.com/JamsusMaximus/trainingpeaks-mcp): Accesses TrainingPeaks training data including fitness metrics (CTL/ATL/TSB), workout history, and power/pace personal records for endurance athletes.
+- [henryco23/NBA](https://github.com/henryco23/NBA): A Python server utilizing MCP to provide comprehensive access to NBA statistics and live game data through the NBA API.
+- [yeonupark/mcp-soccer-data](https://github.com/yeonupark/mcp-soccer-data): Delivers real-time football match data through natural language interactions using the SoccerDataAPI.
+- [guillochon/mlb-api-mcp](https://github.com/guillochon/mlb-api-mcp): A Python MCP server that acts as a proxy to the freely available MLB API, which provides player info, stats, and game information.
+
+## ✈️ Travel & Transportation
+
+Servers providing data or services related to flights, trains, transportation APIs, or travel planning.
+
+- [RikGmee/searchAPI-mcp](https://github.com/RikGmee/searchAPI-mcp): Facilitates complex travel planning by integrating flight, hotel, and map services through a multi-context protocol server.
+- [achel-b8/rakuten-hotel-search-mcp](https://github.com/achel-b8/rakuten-hotel-search-mcp): Facilitates hotel availability searches using Rakuten Travel's API, providing results based on specified criteria such as check-in dates and location.
+- [ralf-boltshauser/sbb-mcp-server](https://github.com/ralf-boltshauser/sbb-mcp-server): A TypeScript starter project for building MCP servers with an echo server implementation, supporting both STDIO and SSE communication modes.
+- [Joooook/12306-mcp](https://github.com/Joooook/12306-mcp): Facilitates 12306 ticket searches using a simple API interface based on the Model Context Protocol.
+- [variflight/variflight-mcp](https://github.com/variflight/variflight-mcp): Facilitates querying flight information, weather data, and flight comfort metrics for Variflight services.
+- [cevatkerim/chargenow-mcp](https://github.com/cevatkerim/chargenow-mcp): Facilitates AI assistants in locating and providing real-time status of EV charging stations using the ChargeNow API.
+- [amith-vp/indian-railway-mcp](https://github.com/amith-vp/indian-railway-mcp): Facilitates seamless access to Indian Railway data, including train searches, seat availability, and live status updates, through Claude Desktop integration.
+- [rajprem4214/indian-railways-mcp](https://github.com/rajprem4214/indian-railways-mcp): Provides real-time station status and train information for Indian Railways using the Model Context Protocol.
+- [JordanDalton/DoorDash-MCP-Server](https://github.com/JordanDalton/DoorDash-MCP-Server): Facilitates integration with DoorDash through a customizable MCP server setup.
+- [kennyfong19931/mcp-hk-transport-eta](https://github.com/kennyfong19931/mcp-hk-transport-eta): Facilitates real-time public transport ETA retrieval in Hong Kong via an MCP server.
+- [harimkang/mcp-korea-tourism-api](https://github.com/harimkang/mcp-korea-tourism-api): Empower AI assistants to explore South Korea's tourism offerings using the Korea Tourism API, providing detailed insights into attractions, events, and accommodations.
+- [donghyun-chae/mcp-amadeus](https://github.com/donghyun-chae/mcp-amadeus): Integrates with the Amadeus Flight Offers Search API to enable natural language flight searches through MCP-compatible clients.
+- [opspawn/Google-Flights-MCP-Server](https://github.com/opspawn/Google-Flights-MCP-Server): Interact with Google Flights data using the fast_flights library to fetch and analyze flight information.
+- [hrishabhn/flight-mcp](https://github.com/hrishabhn/flight-mcp): Facilitates flight queries and bookings using the RapidAPI Skyscanner API through the Model Context Protocol.
+- [birariro/agoda-review-mcp](https://github.com/birariro/agoda-review-mcp): Facilitates LLMs in retrieving and aggregating Agoda hotel reviews for enhanced decision-making.
+- [arjunkmrm/sg-lta-mcp](https://github.com/arjunkmrm/sg-lta-mcp): Access real-time transportation data from Singapore's Land Transport Authority via an MCP server.
+- [Cyreslab-AI/flightradar24-mcp-server](https://github.com/Cyreslab-AI/flightradar24-mcp-server): Provides real-time flight tracking data from Flightradar24 via a Model Context Protocol server.
+- [kennyckk/mcp_hkbus](https://github.com/kennyckk/mcp_hkbus): Provides real-time access to Hong Kong's KMB and Long Win Bus route information and arrival times for Language Models.
+- [pab1it0/tripadvisor-mcp](https://github.com/pab1it0/tripadvisor-mcp): Facilitates AI-driven exploration of Tripadvisor's location data, reviews, and photos via standardized MCP interfaces.
+- [Cyreslab-AI/flightradar-mcp-server](https://github.com/Cyreslab-AI/flightradar-mcp-server): Provides real-time flight tracking and status information using the AviationStack API.
+- [Abiorh001/mcp_ev_assistant_server](https://github.com/Abiorh001/mcp_ev_assistant_server): Facilitates efficient management of EV charging stations and trip planning with robust APIs and interactive tools.
+- [smamidipaka6/flights-mcp-server](https://github.com/smamidipaka6/flights-mcp-server): Connects AI agents to Google Flights data for retrieving comprehensive flight information, finding the cheapest options, and filtering by time constraints.
+- [openbnb-org/mcp-server-airbnb](https://github.com/openbnb-org/mcp-server-airbnb): Facilitates Airbnb listing searches and detailed information retrieval without requiring an API key, while respecting robots.txt rules.
+- [salamentic/google-flights-mcp](https://github.com/salamentic/google-flights-mcp): Facilitates travel agent-level flight planning using the fast-flights API, offering seamless integration with Claude Desktop.
+- [piddlingtuna/tfnsw-realtime-alerts-mcp-server](https://github.com/piddlingtuna/tfnsw-realtime-alerts-mcp-server): Facilitates AI-driven access to real-time transport alerts from Transport for NSW, enhancing LLM capabilities with up-to-date disruption information.
+- [tomekkorbak/strava-mcp-server](https://github.com/tomekkorbak/strava-mcp-server): Access Strava athlete activities data via a Model Context Protocol server, enabling language models to query recent and historical activity details.
+- [jason-tan-swe/railway-mcp](https://github.com/jason-tan-swe/railway-mcp): Facilitates seamless integration with Railway.app, enabling natural language management of deployments, services, and variables.
+- [arjunkmrm/mcp-sg-lta](https://github.com/arjunkmrm/mcp-sg-lta): Provides real-time transportation data from Singapore's LTA DataMall API, including bus arrivals, train alerts, and traffic incidents.
+- [lumile/lumbretravel-mcp](https://github.com/lumile/lumbretravel-mcp): Facilitates seamless integration with the LumbreTravel API for managing travel programs and activities.
+- [MariyaFilippova/mcp-strava](https://github.com/MariyaFilippova/mcp-strava): Facilitates seamless integration between Strava APIs and Claude for Desktop, enabling efficient interaction with Strava activity data.
+
+## 🔧 Utilities & Helpers
+
+Servers providing simple, general-purpose tools like time/date information, calculators, dice rollers, formatters, unit converters, UUID generation, etc.
+
+- [FlatFilers/mcp-server-flatfile](https://github.com/FlatFilers/mcp-server-flatfile): Facilitates interaction with the Flatfile API through a customizable MCP server, enabling streamlined data management and integration.
+- [Nozomuts/date-mcp](https://github.com/Nozomuts/date-mcp): Provides current date and time in specified formats and timezones via a simple MCP server.
+- [BrightLin/mcp-server-port-cleaner](https://github.com/BrightLin/mcp-server-port-cleaner): Node.js server for resolving port conflicts by terminating processes occupying specified ports, ensuring smooth development workflows.
+- [raymondlowe/roo-code-custom-mode-editor-mcp-server](https://github.com/raymondlowe/roo-code-custom-mode-editor-mcp-server): Facilitates editing of Roo Code custom modes by providing tools to list, create, and modify mode fields without direct file manipulation.
+- [LittleFatz/mcp-demo](https://github.com/LittleFatz/mcp-demo): Facilitates file operations like counting, searching, and content analysis through an MCP server, enabling LLMs to access and interact with the filesystem.
+- [shivaji43/gibwork-mcp](https://github.com/shivaji43/gibwork-mcp): Facilitates task management on the GibWork platform using the Model Context Protocol.
+- [dotku/mcpm](https://github.com/dotku/mcpm): Manage and configure multiple MCP servers with ease, supporting filesystem operations and SSE server integration.
+- [adarshem/mcp-server-learn](https://github.com/adarshem/mcp-server-learn): A Node.js-based MCP server offering weather alerts and forecasts using the US National Weather Service API.
+- [dynstat/agents-mcp-clients](https://github.com/dynstat/agents-mcp-clients): Facilitates file system operations via a server-client architecture using MCP.
+- [Kr8thor/n8n-mcp-tool](https://github.com/Kr8thor/n8n-mcp-tool): Facilitates the management of n8n workflows within Docker containers, offering tools for listing, updating, and troubleshooting workflows.
+- [va99/napier](https://github.com/va99/napier): Napier facilitates the installation of MCP servers through prompt-based commands, streamlining the setup process for npm and PyPi hosted servers.
+- [Masa1984a/jrhokkaido_train_info](https://github.com/Masa1984a/jrhokkaido_train_info): Provides real-time train operation information for JR Hokkaido, including delays and cancellations, across various regions.
+- [helebest/my-mcp-lab](https://github.com/helebest/my-mcp-lab): Facilitates the setup and execution of an SSE MCP server for seamless integration with various desktop applications.
+- [vitolrosario/http-request-mcp](https://github.com/vitolrosario/http-request-mcp): Facilitates HTTP requests using the MCP server, supporting various HTTP methods for streamlined web interactions.
+- [bsmnyk/mkslides-mcp](https://github.com/bsmnyk/mkslides-mcp): Facilitates the creation of HTML slides from Markdown using the mkslides library, integrated via the Model Context Protocol.
+- [qianO33/mcp-excel-server](https://github.com/qianO33/mcp-excel-server): Facilitates Excel file operations through a Node.js server using the Model Context Protocol.
+- [Jerry-is-coder/mcp-excel-controller-pro](https://github.com/Jerry-is-coder/mcp-excel-controller-pro): Facilitates advanced Excel file manipulation, including reading, writing, and sheet management, within a Node.js environment.
+- [tuki0918/eagle-mcp-server](https://github.com/tuki0918/eagle-mcp-server): Facilitates seamless integration with the Eagle app through a Model Context Protocol server, enabling efficient management of folders and items.
+- [sam-trost/mcp-server-svgl](https://github.com/sam-trost/mcp-server-svgl): Processes and validates SVG content using SVGL, offering repository access and detailed error reporting.
+- [ndlxp2008/write_emoji_mcp](https://github.com/ndlxp2008/write_emoji_mcp): A CLI tool that enhances Markdown documents with emojis, making them more engaging and lively.
+- [protagolabs/Netmind-Parse-PDF-MCP](https://github.com/protagolabs/Netmind-Parse-PDF-MCP): Transforms PDF files from URLs into structured JSON or Markdown formats using Netmind's MCP server.
+- [devjiel/mcp-echo-server](https://github.com/devjiel/mcp-echo-server): An MCP server that echoes back text messages for testing and development purposes.
+- [ASJordi/whois-mcp](https://github.com/ASJordi/whois-mcp): Provides WHOIS lookup functionality through a standardized interface using the Model Context Protocol.
+- [rims-dev/RIMS-MCP](https://github.com/rims-dev/RIMS-MCP): Facilitates the retrieval of RIMS information through a dedicated MCP server.
+- [nguyendinhsinh361/supergateway-sinhnd](https://github.com/nguyendinhsinh361/supergateway-sinhnd): Supergateway facilitates running MCP stdio-based servers over SSE or WebSockets, enabling seamless remote access and integration with web-based clients.
+- [tvriesde/mcp-license-check](https://github.com/tvriesde/mcp-license-check): Provides vehicle data based on Dutch license plates through a simple MCP server.
+- [WeatherXM/weatherxm-pro-mcp](https://github.com/WeatherXM/weatherxm-pro-mcp): Access WeatherXM PRO APIs for weather data and forecasts via MCP tools.
+- [trutohq/truto-mcp-stdio](https://github.com/trutohq/truto-mcp-stdio): A command-line interface proxy facilitating communication between JSON-RPC messages and HTTP Streamable MCP servers.
+- [veithly/ipfs-uploader](https://github.com/veithly/ipfs-uploader): A TypeScript-based MCP server for uploading images to IPFS, featuring a simple notes system with text note creation and summarization tools.
+- [OpenSourceGuru776/consist](https://github.com/OpenSourceGuru776/consist): Markdownify transforms diverse file types and web content into Markdown format, enhancing readability and shareability.
+
+- [IteraTools](https://api.iteratools.com): Cloud-hosted multi-tool MCP API providing 34+ capabilities through a single endpoint: image generation (Flux), web scraping, TTS, OCR, browser automation, sandboxed code execution, DNS lookup, WHOIS, weather, crypto, QR codes, charts, and more. Pay-per-use with x402 micropayment protocol.
+
+## 🔄 Version Control
+
+Servers interacting with version control systems and platforms for repository management, issues, pull requests, etc.
+
+- [alvnavraii/MCPGithub](https://github.com/alvnavraii/MCPGithub): Facilitates efficient and secure GitHub repository management through MCP integration, offering comprehensive tools for repository, branch, and pull request operations.
+- [SLineroDev/github-releases-mcp](https://github.com/SLineroDev/github-releases-mcp): Manage and analyze GitHub repository releases with detailed comparisons and rich formatting.
+- [Ryan0204/github-repo-mcp](https://github.com/Ryan0204/github-repo-mcp): Facilitates AI assistants in browsing, exploring, and viewing contents of GitHub repositories.
+- [Svtter/git-mcp](https://github.com/Svtter/git-mcp): Facilitates git command processing through an MCP service, leveraging FastMCP for efficient repository management.
+- [ukiuni/mcp-git](https://github.com/ukiuni/mcp-git): Facilitates the execution of Git commands via an MCP server, enabling seamless integration with various MCP clients.
+- [MrOrz/mcp-git-commit-aider](https://github.com/MrOrz/mcp-git-commit-aider): Facilitates AI-driven git commits by appending '(aider)' to track AI contributions in codebases.
+- [SiddheshDongare/GIT-Pilot](https://github.com/SiddheshDongare/GIT-Pilot): GIT-Pilot streamlines GitHub management with a FastMCP-based server, offering secure and efficient automation for repository, pull request, and issue operations.
+- [0010aor/mcp-pr-pilot](https://github.com/0010aor/mcp-pr-pilot): Enhances pull request workflows by generating PR descriptions, commit messages, and code reviews using LLMs based on code changes.
+- [4workspace/Cursor-MCP-test](https://github.com/4workspace/Cursor-MCP-test): Facilitates GitHub integration within Cursor IDE using the Model Control Protocol for streamlined repository management.
+- [marcusdb/github-mcp-server-ts](https://github.com/marcusdb/github-mcp-server-ts): Enhances GitHub API interactions with advanced file operations, repository management, and search capabilities.
+- [jesulim/new](https://github.com/jesulim/new): Facilitates GitHub API interactions for file operations, repository management, and advanced search capabilities.
+- [BirajMainali/git-committer-mcp-server](https://github.com/BirajMainali/git-committer-mcp-server): Facilitates automated generation and staging of commit messages by analyzing Git changes.
+- [Adit-999/gitlab-mcp](https://github.com/Adit-999/gitlab-mcp): Facilitates AI-driven interactions with GitLab, enabling operations on repositories, issues, and merge requests with both synchronous and asynchronous execution.
+- [aniketsingh98571/github-mcp](https://github.com/aniketsingh98571/github-mcp): Facilitates seamless interaction with GitHub's API through a Model Control Protocol interface, enabling efficient repository management and user information retrieval.
+- [musthafa-mohammed/mvn-repo-mcp](https://github.com/musthafa-mohammed/mvn-repo-mcp): Facilitates AI-driven IDEs to interact with Maven Central for package search, version listings, and vulnerability checks.
+- [stephanj/GitHubMCP](https://github.com/stephanj/GitHubMCP): Facilitates LLM agents' interaction with GitHub resources through a Model Context Protocol server.
+- [daoch4n/mcp-git](https://github.com/daoch4n/mcp-git): A TypeScript-based MCP server that facilitates Git operations by managing text notes with URIs and metadata, offering tools for note creation and summarization prompts.
+- [ravi-accolite/mcpserver](https://github.com/ravi-accolite/mcpserver): Facilitates seamless integration between LLM applications and version control systems like GitHub and GitLab, enhancing automation and management capabilities.
+- [Foxhunt/gitlab-mcp-server](https://github.com/Foxhunt/gitlab-mcp-server): A TypeScript-based server for managing and interacting with GitLab data, including projects, issues, and wiki pages.
+- [Ghraven/github-mcp-server](https://github.com/Ghraven/github-mcp-server): Facilitates advanced automation and interaction with GitHub APIs for developers and tools.
+- [axlwolf/github-mcp](https://github.com/axlwolf/github-mcp): Facilitates GitHub API interactions for file operations, repository management, and advanced search capabilities.
+- [ZephyrDeng/mcp-server-gitlab](https://github.com/ZephyrDeng/mcp-server-gitlab): Integrates GitLab RESTful API tools with platforms like Claude and Smithery, enabling seamless project management and collaboration.
+- [rose201107059/remote-mcp-github-oauth](https://github.com/rose201107059/remote-mcp-github-oauth): A remote MCP server with integrated GitHub OAuth, deployable on Cloudflare, enabling secure user authentication and tool access for connected clients.
+- [goern/forgejo-mcp](https://github.com/goern/forgejo-mcp): Facilitates interaction with the Forgejo REST API, enhancing issue management and repository operations on Codeberg.
+- [ces-hongvo/github-mcp-client](https://github.com/ces-hongvo/github-mcp-client): Demonstrates integration of Spring AI with MCP servers for tool execution and chat capabilities in a Spring Boot application.
+- [Aeron-cell/git-mcp-options](https://github.com/Aeron-cell/git-mcp-options): Enhances Git operations with a standardized interface for AI assistants, integrating seamlessly with the MCP ecosystem.
+- [kich555/github-mcp-server](https://github.com/kich555/github-mcp-server): Facilitates GitHub API interactions for file operations, repository management, and advanced search capabilities.
+- [KarakuriAgent/karakuri_git_mcp](https://github.com/KarakuriAgent/karakuri_git_mcp): Facilitates Git repository interaction and automation through a Model Context Protocol server, enabling operations like reading, searching, and manipulating repositories via Large Language Models.
+- [kwanLeeFrmVi/mcp-git](https://github.com/kwanLeeFrmVi/mcp-git): Facilitates Git repository interaction and automation through a Model Context Protocol server, enabling operations like reading, searching, and manipulating repositories via Large Language Models.
+- [rahul-roy-glean/github-mcp-server](https://github.com/rahul-roy-glean/github-mcp-server): Facilitates seamless integration with GitHub's API for file operations, repository management, and search functionalities within CI workflows.


### PR DESCRIPTION
## Summary

This PR rewrites the README intro section and fixes several structural issues:

### A. Rewrote the entire intro block (lines 1–67)
- Replaced the old minimal description and HTML `<div>` blocks with a clean, prose-style intro
- Added a `> **What is MCP?**` blockquote explaining MCP in one sentence
- Added a proper `## Contributing` section with step-by-step submission instructions and guidelines
- Updated `## Server Categories` TOC to use anchor links (e.g. `#-ai--llm-integration`) instead of `docs/*.md` file links

### B. Fixed Infrastructure section heading emoji
- Changed `## 🏗️ Infrastructure` → `## 🏛️ Infrastructure`
- Infrastructure was sharing the 🏗️ emoji with "Build & Deployment Tools"; now each section has a distinct emoji

### C. Fixed Sports TOC entry (alphabetical order + plural)
- Moved Sports from the bottom of the TOC to its correct alphabetical position (between Social Media and Travel)
- Changed `Sport` → `Sports` in the TOC to match the body section heading `## ⚽ Sports`

### D. Removed two duplicate server entries
- **Finance & Crypto**: Removed the shorter duplicate of `AIProx MCP` (`https://github.com/unixlamadev-spec/aiprox-mcp`), kept the more descriptive entry
- **Developer Productivity & Utilities**: Removed the `HendryAvila/Hoofy` entry that belonged in Knowledge Management; kept the correct entry in `## 🧠 Knowledge Management & Memory`