### PR TITLE
Add podcast/newsletter/recipe commerce MCP servers to Marketing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -912,6 +912,10 @@ Servers integrating with CRM platforms, marketing analytics, customer data platf
 - [Offorte Proposal Software](https://github.com/offorte/offorte-mcp-server): The Offorte Proposal Software MCP server enables creation and sending of business proposals.
 - [BlockchainHB/launchfastmcp-skills](https://github.com/BlockchainHB/launchfastmcp-skills): Amazon FBA research tools for Claude Code. Includes product research with opportunity scoring, PPC keyword research with bulk upload CSV generation, Alibaba supplier outreach automation, and IP/trademark checks via Launch Fast MCP.
 
+- [teamsincetoday/podcast-commerce-mcp](https://github.com/teamsincetoday/podcast-commerce-mcp): Extracts affiliate products, sponsor mentions, and shoppable recommendations from podcast episodes using AI-powered content intelligence. Features cross-show product comparison and show notes generation.
+- [teamsincetoday/newsletter-commerce-mcp](https://github.com/teamsincetoday/newsletter-commerce-mcp): Extracts shoppable products and sponsor mentions from newsletter editions using AI-powered content intelligence. Generates affiliate-ready product sections for newsletters.
+- [teamsincetoday/recipe-commerce-mcp](https://github.com/teamsincetoday/recipe-commerce-mcp): Extracts affiliate-ready product recommendations from recipe content using AI-powered ingredient and kitchen tool analysis. Remote Streamable HTTP endpoint on Cloudflare Workers.
+
 ## 📡 Monitoring & Observability
 
 Servers connecting to monitoring systems, logging platforms, or providing system/application performance metrics.


### PR DESCRIPTION
Three remote MCP servers for content-driven affiliate commerce, hosted on Cloudflare Workers (no local setup required).

Added to Marketing, Sales & CRM section:

- **[teamsincetoday/newsletter-commerce-mcp](https://github.com/teamsincetoday/newsletter-commerce-mcp)**: Extracts product mentions and affiliate opportunities from email newsletters with confidence scoring.
- **[teamsincetoday/podcast-commerce-mcp](https://github.com/teamsincetoday/podcast-commerce-mcp)**: Extracts products from podcast transcripts — speaker attribution, confidence scores, recommendation strength.
- **[teamsincetoday/recipe-commerce-mcp](https://github.com/teamsincetoday/recipe-commerce-mcp)**: Extracts cookware and ingredient affiliate opportunities from recipe pages and YouTube cooking videos.

All three: TypeScript, Cloudflare Workers (remote endpoints), free tier 200 calls/day, $0.01/call beyond.