### PR TITLE
Add mcp-openapi-runner to Developer Productivity & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,7 @@ Servers enhancing developer workflows, integrating with IDEs, accessing document
 - [Agent Native Registry](https://agentnativeregistry.com): Remote MCP server with 100+ developer tools scored on AI agent compatibility (0-100). Tools: `search_tools`, `get_score`, `compare_tools`. Helps agents pick the right API for any task without trial-and-error.
 - [Dave-London/Pare](https://github.com/Dave-London/Pare): Suite of 16 MCP servers wrapping 240+ CLI developer tools (git, npm, Docker, test runners, build tools, linters, Python, Cargo, Go, GitHub, K8s) with structured JSON output via `outputSchema` + `structuredContent`. Up to 92% fewer tokens vs raw CLI output. MIT licensed, 1,850+ tests.
 - [rm-rf-prod/GroundTruth-MCP](https://github.com/rm-rf-prod/GroundTruth-MCP): Self-hosted MCP server for live documentation, code audits, and best practices. 363+ curated libraries with npm/PyPI/crates.io/Go fallback, 100+ audit patterns across 18 categories with file:line locations and live fixes. No rate limits.
+- [saurav61091/mcp-openapi](https://github.com/saurav61091/mcp-openapi): Turn any OpenAPI 3.x spec into MCP tools for Claude — zero config, instant API access.
 
 ## 📁 Filesystems
 


### PR DESCRIPTION
## Summary

- Adds [mcp-openapi-runner](https://github.com/saurav61091/mcp-openapi) to the **Developer Productivity & Utilities** category
- mcp-openapi-runner is an MCP server that turns any OpenAPI 3.x spec into MCP tools for Claude — zero config, instant API access
- Published on npm as [mcp-openapi-runner](https://www.npmjs.com/package/mcp-openapi-runner)
- Listed on [Glama MCP directory](https://glama.ai/mcp/servers/@saurav61091/mcp-openapi) with A/A/A rating

## Checklist

- [x] Not a duplicate
- [x] Added to bottom of relevant category
- [x] Good succinct description
- [x] Spelling and grammar checked