### PR TITLE
Add clipboard-mcp to Operating System & Command Line

### DIFF
--- a/README.md
+++ b/README.md
@@ -993,6 +993,7 @@ Servers providing access to the host operating system's command line/shell, exec
 
 - [anurag-dhamala/os-info-mcp-server](https://github.com/anurag-dhamala/os-info-mcp-server): Provides real-time operating system information through an MCP server interface.
 - [aybelatchane/mcp-server-terminal](https://github.com/aybelatchane/mcp-server-terminal): MCP server enabling AI agents to interact with terminal applications (TUI/CLI) through structured Terminal State Tree representation. Think Playwright for terminals.
+- [mnardit/clipboard-mcp](https://github.com/mnardit/clipboard-mcp): Cross-platform system clipboard access (read, write, watch for changes) for AI assistants. Single Rust binary, zero runtime deps. Supports Windows, macOS, Linux (X11 + Wayland).
 - [magicuidesign/cli](https://github.com/magicuidesign/cli): Facilitates the installation and configuration of Magic UI components through a command-line interface.
 - [classfang/ssh-mcp-server](https://github.com/classfang/ssh-mcp-server): Facilitates secure remote SSH command execution via the MCP protocol, enabling AI assistants to interact with servers without exposing SSH credentials.
 - [winterfx/mcpcli](https://github.com/winterfx/mcpcli): A command-line interface for managing and interacting with multiple MCP servers, offering features like tool invocation and server inspection.


### PR DESCRIPTION
Adds [clipboard-mcp](https://github.com/mnardit/clipboard-mcp) — cross-platform MCP server for system clipboard access.

- **Tools:** get_clipboard, set_clipboard, watch_clipboard
- **Platforms:** Windows, macOS, Linux (X11 + Wayland)
- **Stack:** Rust, single binary, zero runtime deps
- **Published:** [crates.io](https://crates.io/crates/clipboard-mcp), [MCP Registry](https://registry.modelcontextprotocol.io)