### PR TITLE
Add PageBolt MCP — hosted screenshot, PDF, AI-narrated video, and page inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Servers interacting with APIs for museums, media databases, image/video hosting,
 
 Servers using tools for browser control, automation, and extracting content from websites.
 
+- [Custodia-Admin/pagebolt-mcp](https://github.com/Custodia-Admin/pagebolt-mcp): Provides hosted web capture and browser automation via REST API and MCP. Supports screenshot, PDF, OG image, multi-step sequences, AI-narrated video recording, and page inspection (CSS selectors + element maps for AI agents). Works natively in Claude Desktop, Cursor, and Windsurf.
 - [giannisalinetti/python-mcp-server](https://github.com/giannisalinetti/python-mcp-server): Facilitates Python code execution for web scraping tasks using an LLM, leveraging Podman for container management.
 - [mhazarabad/browser-use-mcp](https://github.com/mhazarabad/browser-use-mcp): Automates browser tasks using the Browser Use API, offering task management and monitoring capabilities.
 - [1999AZZAR/mcp-server-google-search](https://github.com/1999AZZAR/mcp-server-google-search): Facilitates Google Programmable Search Engine queries through a structured MCP server interface, enhancing integration with Claude Desktop.


### PR DESCRIPTION
Adding PageBolt to the Browser Automation & Web Scraping section.\n\nPageBolt provides hosted web capture and browser automation via REST API + MCP server:\n- **Screenshot, PDF, OG image** — hosted API, no self-hosting required\n- **AI-narrated video recording** — records multi-step browser sequences as MP4 with synchronized AI voice narration (unique: no other MCP server does this)\n- **Page inspection** (`/inspect`) — returns structured element maps with CSS selectors, designed for AI agent workflows\n- **Native MCP integration** — works out of the box in Claude Desktop, Cursor, and Windsurf\n\nLinks:\n- GitHub: https://github.com/Custodia-Admin/pagebolt-mcp\n- npm: `pagebolt-mcp`\n- Official MCP Registry: `io.github.Custodia-Admin/pagebolt`\n- Glama.ai: https://glama.ai/mcp/servers/Custodia-Admin/pagebolt-mcp