### PR TITLE
Add Codebase Memory MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Servers integrating with major cloud providers or specific cloud services.
 
 Servers focused on static analysis, linting, code metrics, security scanning, vulnerability checks, or code quality assessment.
 
+- [DeusData/codebase-memory-mcp](https://github.com/DeusData/codebase-memory-mcp): Fastest code intelligence MCP server — indexes the Linux kernel (28M LOC) in 3 minutes, answers structural queries in <1ms. Builds a persistent knowledge graph with call chains, HTTP routes, and cross-service links across 66 languages. 120x fewer tokens. Single static binary, plug-and-play across 10 coding agents.
 - [dhylan01/MCP_OA](https://github.com/dhylan01/MCP_OA): Facilitates AI assistants in analyzing code by identifying function usage within Python and TypeScript/TSX files.
 - [angrysky56/ast-mcp-server](https://github.com/angrysky56/ast-mcp-server): Provides code structure and semantic analysis using AST and ASG for multiple programming languages, enhancing code analysis capabilities in Claude Desktop.
 - [joaomj/code-reviewer-mcp](https://github.com/joaomj/code-reviewer-mcp): Automated GitHub pull request code reviews using AI models via MCP integration.

--- a/docs/code-analysis--quality.md
+++ b/docs/code-analysis--quality.md
@@ -3,6 +3,7 @@
 Servers focused on static analysis, linting, code metrics, security scanning, vulnerability checks, or code quality assessment.
 
 - [preflight-dev/preflight](https://github.com/preflight-dev/preflight): A 24-tool MCP server for Claude Code that scores prompts across 12 categories before execution, catches ambiguity and missing context, tracks correction patterns, and provides semantic search over session history with LanceDB vectors.
+- [DeusData/codebase-memory-mcp](https://github.com/DeusData/codebase-memory-mcp): Fastest code intelligence MCP server — indexes the Linux kernel (28M LOC) in 3 minutes, answers structural queries in <1ms. Builds a persistent knowledge graph with call chains, HTTP routes, and cross-service links across 66 languages. 120x fewer tokens. Single static binary, plug-and-play across 10 coding agents.
 - [isaacphi/mcp-language-server](https://github.com/isaacphi/mcp-language-server): Helps MCP enabled clients navigate codebases more easily by giving them access to semantic tools like get definition, references, rename, and diagnostics.
 - [dhylan01/MCP_OA](https://github.com/dhylan01/MCP_OA): Facilitates AI assistants in analyzing code by identifying function usage within Python and TypeScript/TSX files.
 - [angrysky56/ast-mcp-server](https://github.com/angrysky56/ast-mcp-server): Provides code structure and semantic analysis using AST and ASG for multiple programming languages, enhancing code analysis capabilities in Claude Desktop.


### PR DESCRIPTION
Fastest code intelligence MCP server — indexes the Linux kernel (28M LOC) in 3 minutes, sub-ms structural queries, persistent knowledge graph across 66 languages.

https://github.com/DeusData/codebase-memory-mcp