### PR TITLE
Add safari-mcp to Browser Automation & Web Scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Servers using tools for browser control, automation, and extracting content from
 - [NexusX-MCP/data-mcp-server](https://github.com/NexusX-MCP/data-mcp-server): Facilitates web scraping, data extraction, and browser automation with integration for agents like OpenAI's CUA and Anthropic's Claude.
 - [korwabs/playwright-trace-mcp](https://github.com/korwabs/playwright-trace-mcp): Enhances browser automation with Playwright by adding trace viewer and video recording capabilities, enabling LLMs to interact with web pages through structured data.
 - [bzsasson/screaming-frog-mcp](https://github.com/bzsasson/screaming-frog-mcp): Screaming Frog SEO Spider integration for crawling websites, exporting SEO data, and managing crawl storage through AI assistants.
+- [achiya-automation/safari-mcp](https://github.com/achiya-automation/safari-mcp): Native Safari browser automation for AI agents via AppleScript — 80 tools, zero overhead, keeps logins, runs silently in background. macOS only.
 
 ## 🏗️ Build & Deployment Tools
 


### PR DESCRIPTION
## Summary
- Adds [safari-mcp](https://github.com/achiya-automation/safari-mcp) to the Browser Automation & Web Scraping section
- Native Safari browser automation MCP server for AI agents — 80 tools via AppleScript, zero Chrome overhead, keeps logins, runs silently in background. macOS only. MIT licensed.

## Checklist
- [x] Placed in the correct category (Browser Automation & Web Scraping)
- [x] Follows existing entry format
- [x] Repository is public and has a README