### PR TITLE
Add Mnemo Cortex - cross-agent semantic memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -799,7 +799,7 @@ Servers or systems that deliver core runtime functionalities for MCP, such as pr
 
 Servers connecting to personal knowledge bases, flashcard apps, building/querying knowledge graphs, or providing persistent memory for LLMs.
 
-- [GuyMannDude/mnemo-cortex](https://github.com/GuyMannDude/mnemo-cortex): Persistent cross-agent semantic memory for AI agents. Multi-agent by design (isolated writes, shared reads), local-first with SQLite + FTS5, works with any LLM for compaction (local Ollama at $0 or cloud APIs like Gemini/OpenAI). DAG-based lineage with ~80% compression. Integrations for Claude Code, Claude Desktop, and OpenClaw.
+- [GuyMannDude/mnemo-cortex](https://github.com/GuyMannDude/mnemo-cortex): Persistent cross-agent semantic memory for AI agents (v2.0). Privacy-first share switch (separate/always/never + per-session toggle). Multi-agent with isolated writes and privacy-controlled reads. Local-first SQLite + FTS5, zero-cost compaction via local Ollama. Three integration paths: Claude Code, Claude Desktop, and OpenClaw MCP.
 - [Bpolat0/atlasmemory](https://github.com/Bpolat0/atlasmemory): Evidence-backed AI memory for codebases. Tree-sitter indexing (11 languages), proof system with line:hash anchors, token-budgeted context packs, drift detection, cross-session learning. 28 MCP tools, VS Code extension, zero config.
 - [gdcc/mcp-dataverse](https://github.com/gdcc/mcp-dataverse): Facilitates multilingual data integration and exploration in Dataverse using Croissant ML.
 - [digila/linear-mcp](https://github.com/digila/linear-mcp): A TypeScript-based MCP server for managing and summarizing text notes with URI-based access and LLM integration.


### PR DESCRIPTION
Adding [Mnemo Cortex v2.0](https://github.com/GuyMannDude/mnemo-cortex) to the Knowledge Management & Memory section.

**What it is:** Persistent cross-agent semantic memory MCP server for AI agents.

**What's new in v2.0:**
- **Share switch** — three-level privacy control (separate/always/never) + per-session toggle
- **Privacy-first default** — cross-agent search off by default, agent sees only its own memories
- **Hardened** — 10s request timeouts, health-gated tool calls, input validation, error sanitization

**What makes it different from existing memory entries:**
- **Multi-agent** — isolated writes, privacy-controlled reads across any number of agents
- **Local-first** — SQLite + FTS5, zero cloud dependency, runs on your hardware
- **Zero-cost compaction** — local Ollama ($0) or any cloud LLM provider
- **DAG lineage** — ~80% compression, full source traceability
- **Three integration paths** — Claude Code, Claude Desktop, OpenClaw MCP
- **Production-tested** — running since Feb 2026 with multiple agents

https://github.com/GuyMannDude/mnemo-cortex