### PR TITLE
Add Toolradar MCP - software discovery server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1162,6 +1162,7 @@ Servers providing web search capabilities or interfacing with specialized search
 - [Pattyboi101/indiestack](https://github.com/Pattyboi101/indiestack): Open-source supply chain for AI agents — search and discover 3,000+ indie creations across 25 categories. 15 MCP tools including find_tools, build_stack, scan_project, compare_tools, and analyze_dependencies. Install via `uvx --from indiestack indiestack-mcp`.
 
 - [entire-vc/evc-spark-mcp](https://github.com/entire-vc/evc-spark-mcp): MCP server for discovering, searching, and installing curated AI agent workflows from the Spark catalog - search 200+ tools, get install configs, browse curated bundles.
+- [Nadeus/toolradar-mcp](https://github.com/Nadeus/toolradar-mcp): Search, compare, and get pricing for 8,600+ software tools with verified data, editorial scores, and real alternatives.
 
 ## 🔒 Security
 


### PR DESCRIPTION
## Summary

Adds [Toolradar MCP](https://github.com/Nadeus/toolradar-mcp) to the **Search** category.

Toolradar MCP lets AI agents search, compare, and get pricing for 8,600+ software tools with verified data, editorial scores, and real alternatives. Available on npm as `toolradar-mcp`.

**Tools provided:**
- `search_tools` — search by keyword, category, or use case
- `get_tool` — get detailed info on a specific tool
- `compare_tools` — side-by-side comparison of 2-4 tools
- `get_pricing` — pricing details and plan breakdowns
- `get_alternatives` — find alternatives to any tool

The server is open source (MIT), published on npm, and documented at [toolradar.com/for-agents](https://toolradar.com/for-agents).