### PR TITLE
Add VEROQ MCP to Finance & Crypto section

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,6 +624,7 @@ Servers dealing with financial data, stock markets, cryptocurrency exchanges/dat
 - [xpaysh/awesome-x402](https://github.com/xpaysh/awesome-x402): A curated directory of x402 payment protocol MCP servers, tools, and resources for HTTP-native cryptocurrency payments using USDC on Base, Arbitrum, and other EVM chains.
 - [arcadia-finance/mcp-server](https://github.com/arcadia-finance/mcp-server): Manage Uniswap and Aerodrome liquidity positions with leverage, tomated rebalancing, and yield optimization on Base and Unichain.
 - [whitmorelabs/polymarket-mcp](https://github.com/whitmorelabs/polymarket-mcp): Trading intelligence tools for Polymarket prediction markets: slippage estimation, liquidity depth scanning, arbitrage detection, multi-source price feeds, and on-chain wallet intelligence.
+- [Veroq-api/veroq-mcp](https://github.com/Veroq-api/veroq-mcp): Financial intelligence MCP server with 52 tools for verified market data, trading signals, sentiment analysis, and fact-checking across 1,061+ tickers (equities, crypto, ETFs, commodities, indices). Multi-provider architecture with failover. Install via `npx veroq-mcp`.
 
 ## 🧰 Frameworks
 


### PR DESCRIPTION
## What is VEROQ MCP?

[veroq-mcp](https://github.com/Veroq-api/veroq-mcp) is a financial intelligence MCP server published on npm. It provides **52 tools** for AI agents to access verified market data, trading signals, sentiment analysis, and fact-checking with evidence chains.

## Why it belongs in Finance & Crypto

- **52 MCP tools** covering prices, technicals, screener, earnings, insider trades, analyst ratings, news, sentiment, and more
- **1,061+ tickers** — equities, crypto, ETFs, commodities, indices
- Multi-provider architecture (Yahoo, Twelve Data, FMP) with failover
- Works with Claude Desktop, Cursor, VS Code, and any MCP-compatible client
- Published on npm: `npx veroq-mcp`

## Links

- GitHub: https://github.com/Veroq-api/veroq-mcp
- npm: https://www.npmjs.com/package/veroq-mcp