### PR TITLE
Add Safari MCP to Browser Automation & Web Scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Servers using tools for browser control, automation, and extracting content from
 - [NexusX-MCP/data-mcp-server](https://github.com/NexusX-MCP/data-mcp-server): Facilitates web scraping, data extraction, and browser automation with integration for agents like OpenAI's CUA and Anthropic's Claude.
 - [korwabs/playwright-trace-mcp](https://github.com/korwabs/playwright-trace-mcp): Enhances browser automation with Playwright by adding trace viewer and video recording capabilities, enabling LLMs to interact with web pages through structured data.
 - [bzsasson/screaming-frog-mcp](https://github.com/bzsasson/screaming-frog-mcp): Screaming Frog SEO Spider integration for crawling websites, exporting SEO data, and managing crawl storage through AI assistants.
+- [achiya-automation/safari-mcp](https://github.com/achiya-automation/safari-mcp): Native Safari browser automation for AI agents with 80+ tools, dual-engine architecture (Extension + AppleScript), and zero Chrome overhead.
 
 ## 🏗️ Build & Deployment Tools
 


### PR DESCRIPTION
## What

Adds [Safari MCP](https://github.com/achiya-automation/safari-mcp) to the **Browser Automation & Web Scraping** section.

## About Safari MCP

- **Native Safari browser automation** for AI agents — no Chrome/Chromium required
- **80+ tools** covering navigation, interaction, forms, network capture, storage, accessibility, and more
- **Dual-engine architecture**: Safari Extension (preferred, ~5-20ms) + AppleScript daemon (fallback, ~5ms)
- Uses your real Safari with all existing logins and cookies
- **MIT licensed**
- Published on npm: `safari-mcp`

## Why it belongs here

Safari MCP is the only MCP server providing native Safari automation. All other browser MCP servers require Chrome/Chromium. It fills a gap for macOS users who want browser automation without the overhead of a separate browser process.