### PR TITLE
Add protect-mcp security gateway to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1214,6 +1214,7 @@ Servers interacting with security tools and platforms, vulnerability databases, 
 - [microsoft/agent-governance-toolkit](https://github.com/microsoft/agent-governance-toolkit): Kernel-level governance MCP server for AI agents — enforces deterministic policies (tool filtering, budget caps, rate limits, audit logging) instead of prompt-based guardrails. Part of microsoft/agent-lightning (14k★). Run via `npx agentos-mcp-server`.
 
 - [operantlabs/operant-mcp](https://github.com/operantlabs/operant-mcp): Security testing MCP server with 51 tools for penetration testing, network forensics, memory analysis, and vulnerability assessment. Install via `npx operant-mcp`.
+- [scopeblind/scopeblind-gateway](https://github.com/scopeblind/scopeblind-gateway): Security gateway for MCP servers — per-tool policies (Cedar + JSON), Ed25519-signed decision receipts, human approval gates, trust tiers. Shadow mode by default. Install via `npx protect-mcp`.
 
 - [shadoprizm/cyberlens-mcp-server](https://github.com/shadoprizm/cyberlens-mcp-server): Security scanning MCP server for AI assistants — scan websites for missing headers and HTTPS issues, scan GitHub repos for secrets and CVE vulnerabilities, and scan Claw Hub skills for malicious code before installing. Free tier with local quick-scan (no account needed). `npx -y @shadoprizm/cyberlens-mcp-server`
 ## 📱 Social Media & Content Platforms


### PR DESCRIPTION
## Summary

Adds [protect-mcp](https://github.com/scopeblind/scopeblind-gateway) to the Security section.

**protect-mcp** is a security gateway for MCP servers that enforces per-tool access policies before tool calls reach the underlying server.

- **Policy engines:** Cedar (WASM) and JSON policy formats
- **Ed25519-signed decision receipts** — every allow/deny produces a cryptographically signed, portable proof
- **Human approval gates** — configurable per-tool approval workflows
- **Trust tiers** — graduated permissions based on caller identity
- **Shadow mode by default** — observe and log without blocking, then switch to enforce

- npm: [`protect-mcp`](https://www.npmjs.com/package/protect-mcp)
- License: MIT
- Install: `npx protect-mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)