### PR TITLE
Add memory-core — unified memory layer for AI agents (Knowledge Management & Memory)

### DIFF
--- a/README.md
+++ b/README.md
@@ -812,6 +812,7 @@ Servers or systems that deliver core runtime functionalities for MCP, such as pr
 
 Servers connecting to personal knowledge bases, flashcard apps, building/querying knowledge graphs, or providing persistent memory for LLMs.
 
+- [Evanyuan-builder/memory-core](https://github.com/Evanyuan-builder/memory-core): Unified memory layer for AI agents and teams. Provides semantic search, temporal fact tracking (Graphiti/FalkorDB), and shared memory via REST API, Python SDK, and MCP server. Supports local Ollama — no cloud API key required.
 - [GuyMannDude/mnemo-cortex](https://github.com/GuyMannDude/mnemo-cortex): Persistent cross-agent semantic memory for AI agents (v2.0). Privacy-first share switch (separate/always/never + per-session toggle). Multi-agent with isolated writes and privacy-controlled reads. Local-first SQLite + FTS5, zero-cost compaction via local Ollama. Three integration paths: Claude Code, Claude Desktop, and OpenClaw MCP.
 - [Bpolat0/atlasmemory](https://github.com/Bpolat0/atlasmemory): Evidence-backed AI memory for codebases. Tree-sitter indexing (11 languages), proof system with line:hash anchors, token-budgeted context packs, drift detection, cross-session learning. 28 MCP tools, VS Code extension, zero config.
 - [gdcc/mcp-dataverse](https://github.com/gdcc/mcp-dataverse): Facilitates multilingual data integration and exploration in Dataverse using Croissant ML.


### PR DESCRIPTION
## memory-core

**Repo:** https://github.com/Evanyuan-builder/memory-core

**Category:** 🧠 Knowledge Management & Memory

A unified memory layer for AI agents and teams.

**What it provides:**
- Single REST API over shared memory backends
- Temporal memory via Graphiti/FalkorDB — facts carry `valid_at`/`invalid_at`, contradictions auto-invalidate
- MCP server with 5 tools (`memory_store`, `memory_search`, `memory_recall`, `memory_delete`, `memory_health`)
- Python SDK (sync + async)
- Local Ollama support — no cloud API key required
- MIT licensed, 84 tests passing