### PR TITLE
Add webcheck-mcp and deadlink-checker-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ Servers using tools for browser control, automation, and extracting content from
 - [korwabs/playwright-trace-mcp](https://github.com/korwabs/playwright-trace-mcp): Enhances browser automation with Playwright by adding trace viewer and video recording capabilities, enabling LLMs to interact with web pages through structured data.
 - [bzsasson/screaming-frog-mcp](https://github.com/bzsasson/screaming-frog-mcp): Screaming Frog SEO Spider integration for crawling websites, exporting SEO data, and managing crawl storage through AI assistants.
 - [achiya-automation/safari-mcp](https://github.com/achiya-automation/safari-mcp): Native Safari browser automation for AI agents via AppleScript — 80 tools, zero overhead, keeps logins, runs silently in background. macOS only.
+- [yifanyifan897645/webcheck-mcp](https://github.com/yifanyifan897645/webcheck-mcp) - Website health checker MCP server: SEO audit, accessibility scan, broken link detection, and performance analysis.
+- [yifanyifan897645/deadlink-checker-mcp](https://github.com/yifanyifan897645/deadlink-checker-mcp) - Dead link checker MCP server for websites: detects broken links, redirects, and timeouts with detailed reporting.
 
 ## 🏗️ Build & Deployment Tools
 


### PR DESCRIPTION
## Summary

Adds two MCP servers to the Browser Automation & Web Scraping section:

- **[webcheck-mcp](https://github.com/yifanyifan897645/webcheck-mcp)** - Website health checker: SEO audit, accessibility scan, broken link detection, and performance analysis. Available on npm as `webcheck-mcp`.

- **[deadlink-checker-mcp](https://github.com/yifanyifan897645/deadlink-checker-mcp)** - Dead link checker for websites: detects broken links, redirects, and timeouts with detailed reporting. Available on npm as `deadlink-checker-mcp`.

Both servers are published on npm, open source, and publicly accessible.

> This PR was generated with the assistance of Claude AI (Anthropic).