### PR TITLE
Add KanseiLink - MCP intelligence layer for SaaS discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Servers integrating with other AI models, AI platforms, RAG tools, prompt manage
 - [tangshuang/mcp-bone](https://github.com/tangshuang/mcp-bone): Facilitates connection to MCP Bone for tool registration and parsing LLM completion text into tool calls.
 - [belljustin/spotify-mcp](https://github.com/belljustin/spotify-mcp): Facilitates playlist creation on Spotify through a Model Context Protocol server, integrating seamlessly with Cursor for enhanced user interaction.
 - [Zerg00s/server-sharepoint](https://github.com/Zerg00s/server-sharepoint): Facilitates interaction with SharePoint Online through Claude Desktop using the SharePoint REST API.
+- [kansei-link/kansei-mcp-server](https://github.com/kansei-link/kansei-mcp-server): MCP intelligence layer for discovering and evaluating 156 SaaS/API services with trust scores from real agent usage, 120 workflow recipes, intent-based search, and Agent Voice feedback comparing Claude, GPT, and Gemini perspectives.
 
 ## 🎨 Art, Culture & Media
 

--- a/README.md
+++ b/README.md
@@ -1159,6 +1159,7 @@ Servers accessing scientific databases, research platforms, or providing tools f
 Servers providing web search capabilities or interfacing with specialized search APIs/platforms.
 
 - [AgentGrade](https://agentgrade.com): Scan any website for AI agent readiness — scores 80+ checks across payments, MCP, OpenAPI, and discovery. Remote MCP server at agentgrade.com/mcp.
+- [kansei-link/kansei-mcp-server](https://github.com/kansei-link/kansei-mcp-server): Intelligence layer for AI agents to discover and evaluate 156+ SaaS/API services with trust scores, 120 workflow recipes, intent-based search, and Agent Voice feedback from real agent usage.
 - [kokilabo/pdf-researcher](https://github.com/kokilabo/pdf-researcher): A specialized MCP server designed for searching PDF documents using the Brave Search API.
 - [joaomj/deep-search-mcp](https://github.com/joaomj/deep-search-mcp): Facilitates deep web searches using the LinkUp API, offering structured results and customizable search parameters.
 - [jarondonp/portfolio-mcp-server](https://github.com/jarondonp/portfolio-mcp-server): Integrates the Brave Search API to offer web and local search capabilities with flexible filtering and smart fallbacks.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ Servers integrating with other AI models, AI platforms, RAG tools, prompt manage
 - [tangshuang/mcp-bone](https://github.com/tangshuang/mcp-bone): Facilitates connection to MCP Bone for tool registration and parsing LLM completion text into tool calls.
 - [belljustin/spotify-mcp](https://github.com/belljustin/spotify-mcp): Facilitates playlist creation on Spotify through a Model Context Protocol server, integrating seamlessly with Cursor for enhanced user interaction.
 - [Zerg00s/server-sharepoint](https://github.com/Zerg00s/server-sharepoint): Facilitates interaction with SharePoint Online through Claude Desktop using the SharePoint REST API.
-- [kansei-link/kansei-mcp-server](https://github.com/kansei-link/kansei-mcp-server): MCP intelligence layer for discovering and evaluating 156 SaaS/API services with trust scores from real agent usage, 120 workflow recipes, intent-based search, and Agent Voice feedback comparing Claude, GPT, and Gemini perspectives.
 
 ## 🎨 Art, Culture & Media
 

--- a/docs/search.md
+++ b/docs/search.md
@@ -3,6 +3,7 @@
 Servers providing web search capabilities or interfacing with specialized search APIs/platforms.
 
 - [AgentGrade](https://agentgrade.com): Scan any website for AI agent readiness — scores 80+ checks across payments, MCP, OpenAPI, and discovery. Remote MCP server at agentgrade.com/mcp.
+- [kansei-link/kansei-mcp-server](https://github.com/kansei-link/kansei-mcp-server): Intelligence layer for AI agents to discover and evaluate 156+ SaaS/API services with trust scores, 120 workflow recipes, intent-based search, and Agent Voice feedback from real agent usage.
 - [kokilabo/pdf-researcher](https://github.com/kokilabo/pdf-researcher): A specialized MCP server designed for searching PDF documents using the Brave Search API.
 - [joaomj/deep-search-mcp](https://github.com/joaomj/deep-search-mcp): Facilitates deep web searches using the LinkUp API, offering structured results and customizable search parameters.
 - [jarondonp/portfolio-mcp-server](https://github.com/jarondonp/portfolio-mcp-server): Integrates the Brave Search API to offer web and local search capabilities with flexible filtering and smart fallbacks.


### PR DESCRIPTION
Adds KanseiLink to the AI & LLM Integration section.

KanseiLink is an MCP intelligence layer that helps agents discover and evaluate 156 SaaS/API services through:
- Trust scores aggregated from real agent usage
- 120 workflow recipes (cross-service automation patterns)
- Intent-based search (no keyword guessing)
- Agent Voice feedback comparing Claude, GPT, and Gemini perspectives on each service

Repo: https://github.com/kansei-link/kansei-mcp-server
Live registry: https://registry.modelcontextprotocol.io (search 'kansei-link')

Entry added alphabetically in AI & LLM Integration category.