### PR TITLE
Add Content-to-Social MCP to Social Media & Content Platforms

### DIFF
--- a/docs/social-media--content-platforms.md
+++ b/docs/social-media--content-platforms.md
@@ -2,6 +2,7 @@
 
 Servers interacting with social networks, content platforms, or feed aggregators.
 
+- [Lebedinskas/content-to-social-mcp](https://github.com/Lebedinskas/content-to-social-mcp): Transforms any blog/article URL into ready-to-post social media content for Twitter/X, LinkedIn, Instagram, Facebook, and email newsletter. Hosted on Apify Standby — zero setup, pay-per-event ($0.07 all platforms).
 - [socialneuron/mcp-server](https://github.com/socialneuron/mcp-server): 64 MCP tools for end-to-end social media content lifecycle — ideation, creation, distribution, analytics, and optimization with closed-loop learning. Supports YouTube, Instagram, TikTok.
 - [NexusX-MCP/integrate-mcp-server](https://github.com/NexusX-MCP/integrate-mcp-server): An extensible server providing standardized access to social and onchain data, supporting platforms like Farcaster with plans for Twitter integration.
 - [sriramsowmithri9807/MCP_X](https://github.com/sriramsowmithri9807/MCP_X): Facilitates AI model interactions with Twitter/X API through a standardized MCP interface, enabling tweet management and data retrieval.


### PR DESCRIPTION
## Adding Content-to-Social MCP Server

Adding [content-to-social-mcp](https://github.com/Lebedinskas/content-to-social-mcp) to `docs/social-media--content-platforms.md`.

### What it does
Transforms any blog/article URL into ready-to-post social media content for **Twitter/X**, **LinkedIn**, **Instagram**, **Facebook**, and **email newsletter** — all from a single MCP call.

### Key differentiator
Unlike posting/scheduling MCPs, this handles content **generation** from existing content. Give it a URL → get platform-optimized posts.

### Details
- **Repo:** https://github.com/Lebedinskas/content-to-social-mcp
- **Apify Store:** https://apify.com/godberry/content-to-social-mcp
- **MCP endpoint:** `https://godberry--content-to-social-mcp.apify.actor/mcp`
- **Pricing:** $0.07/event (all 5 platforms) or $0.03 (single platform)
- **Tech stack:** TypeScript, Cheerio, Claude Sonnet, Apify Standby
- **License:** MIT