### PR TITLE
Add Content-to-Social MCP to Social Media & Content Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1247,6 +1247,7 @@ Servers interacting with security tools and platforms, vulnerability databases, 
 
 Servers interacting with social networks, content platforms, or feed aggregators.
 
+- [Lebedinskas/content-to-social-mcp-server](https://github.com/Lebedinskas/content-to-social-mcp-server): Transforms any blog/article URL into ready-to-post social media content for Twitter/X, LinkedIn, Instagram, Facebook, and email newsletters. Hosted on Apify with pay-per-event pricing ($0.07/call) — zero setup, just add the MCP endpoint URL.
 - [socialneuron/mcp-server](https://github.com/socialneuron/mcp-server): 64 MCP tools for end-to-end social media content lifecycle — ideation, creation, distribution, analytics, and optimization with closed-loop learning. Supports YouTube, Instagram, TikTok.
 - [NexusX-MCP/integrate-mcp-server](https://github.com/NexusX-MCP/integrate-mcp-server): An extensible server providing standardized access to social and onchain data, supporting platforms like Farcaster with plans for Twitter integration.
 - [sriramsowmithri9807/MCP_X](https://github.com/sriramsowmithri9807/MCP_X): Facilitates AI model interactions with Twitter/X API through a standardized MCP interface, enabling tweet management and data retrieval.

--- a/docs/social-media--content-platforms.md
+++ b/docs/social-media--content-platforms.md
@@ -2,6 +2,7 @@
 
 Servers interacting with social networks, content platforms, or feed aggregators.
 
+- [Lebedinskas/content-to-social-mcp-server](https://github.com/Lebedinskas/content-to-social-mcp-server): Transforms any blog/article URL into ready-to-post social media content for Twitter/X, LinkedIn, Instagram, Facebook, and email newsletters. Hosted on Apify with pay-per-event pricing ($0.07/call) — zero setup, just add the MCP endpoint URL.
 - [azeemkafridi/bulkpublish-api](https://github.com/azeemkafridi/bulkpublish-api/tree/main/mcp-server): MCP server for social media publishing across 11 platforms — create posts, schedule, upload media, and track analytics. 29 tools via `npx -y @bulkpublish/mcp-server`.
 - [socialneuron/mcp-server](https://github.com/socialneuron/mcp-server): 64 MCP tools for end-to-end social media content lifecycle — ideation, creation, distribution, analytics, and optimization with closed-loop learning. Supports YouTube, Instagram, TikTok.
 - [NexusX-MCP/integrate-mcp-server](https://github.com/NexusX-MCP/integrate-mcp-server): An extensible server providing standardized access to social and onchain data, supporting platforms like Farcaster with plans for Twitter integration.


### PR DESCRIPTION
Adding Content-to-Social MCP — a hosted MCP server that transforms any blog/article URL into platform-optimized social media content.

**What it does:** Give it a URL → get ready-to-post content for Twitter/X threads, LinkedIn posts, Instagram captions, Facebook posts, and email newsletter snippets.

**Key differentiator:** Unlike posting/scheduling MCPs, this handles content *generation* from existing content. Hosted on Apify Standby (zero setup — just add the MCP endpoint URL).

- Store page: https://apify.com/godberry/content-to-social-mcp
- GitHub: https://github.com/Lebedinskas/content-to-social-mcp-server
- MCP endpoint: https://godberry--content-to-social-mcp.apify.actor/mcp
- Pricing: $0.07/event (all platforms) or $0.03 (single platform)
- Built with: TypeScript, Cheerio, Claude Sonnet, Apify Standby