### PR TITLE
Add Helium MCP (Finance & Crypto)

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,6 +579,7 @@ Servers focused on interacting with local or remote file systems for reading, wr
 
 Servers dealing with financial data, stock markets, cryptocurrency exchanges/data, trading bots, banking APIs, accounting software, or blockchain interactions.
 
+- [Helium MCP](https://github.com/connerlambden/helium-mcp) - Remote MCP server for real-time news intelligence with bias scoring (3.2M+ articles, 5000+ sources, 15+ dimensions), financial market data (stocks, ETFs, crypto, AI bull/bear cases), ML options pricing (probability ITM, Greeks, fair value), balanced news synthesis, trending topics, and meme search. [Documentation](https://heliumtrades.com/mcp-page/)
 - [FinancialData.Net MCP Server](https://financialdata.net/mcp-server) - Get real-time stock prices, fundamentals, institutional trading insights, and other financial data delivered through a universal Model Context Protocol (MCP) server.
 - [grahammccain/chart-library-mcp](https://github.com/grahammccain/chart-library-mcp) - Historical chart pattern search engine — search 24M+ pre-computed embeddings across 15K+ symbols for similar patterns and forward returns.
 - [cnghockey/sats4ai-mcp-server](https://github.com/cnghockey/sats4ai-mcp-server) - Bitcoin Lightning-powered AI tools marketplace. 20+ tools for image, video, audio, text generation, TTS (467 voices), web search, document conversion, and phone calls. Pay per use with sats, no signup. Install: `npx sats4ai-mcp`.

--- a/docs/finance--crypto.md
+++ b/docs/finance--crypto.md
@@ -2,6 +2,7 @@
 
 Servers dealing with financial data, stock markets, cryptocurrency exchanges/data, trading bots, banking APIs, accounting software, or blockchain interactions.
 
+- [Helium MCP](https://github.com/connerlambden/helium-mcp) - Remote MCP server for real-time news intelligence with bias scoring (3.2M+ articles, 5000+ sources, 15+ dimensions), financial market data (stocks, ETFs, crypto, AI bull/bear cases), ML options pricing (probability ITM, Greeks, fair value), balanced news synthesis, trending topics, and meme search. [Documentation](https://heliumtrades.com/mcp-page/)
 - [FinancialData.Net MCP Server](https://financialdata.net/mcp-server) - Get real-time stock prices, fundamentals, institutional trading insights, and other financial data delivered through a universal Model Context Protocol (MCP) server.
 - [SignalFuse MCP](https://github.com/hypeprinter007-stack/signalfuse-mcp) - Fused crypto trading signals (sentiment, macro regime, and Hyperliquid market structure) as MCP tools for AI coding agents.
 - [grahammccain/chart-library-mcp](https://github.com/grahammccain/chart-library-mcp) - Historical chart pattern search engine — search 24M+ pre-computed embeddings across 15K+ symbols for similar patterns and forward returns.


### PR DESCRIPTION
## Summary

Adds **[Helium MCP](https://github.com/connerlambden/helium-mcp)** to the **Finance & Crypto** section — a remote MCP server for research and trading workflows.

## Capabilities

- **News intelligence:** real-time coverage with bias scoring (3.2M+ articles, 5000+ sources, 15+ dimensions), balanced synthesis, and trending topics
- **Markets:** stocks, ETFs, crypto, and AI bull/bear cases
- **Options:** ML-based pricing (probability ITM, Greeks, fair value)
- **Meme search** for social/context signals

## Links

- **GitHub:** https://github.com/connerlambden/helium-mcp
- **Documentation:** https://heliumtrades.com/mcp-page/

## Placement

Finance & Crypto is the best fit because the server centers on market data and options tooling alongside news and sentiment used for financial research.

## Checklist

- [x] Follows the README bullet format used in this category
- [x] No duplicate entry for Helium MCP