### PR TITLE
Add ph-civic-data-mcp (Philippine government data)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1164,6 +1164,7 @@ Servers accessing scientific databases, research platforms, or providing tools f
 - [HuaLuAI/CAD-MCP](https://github.com/HuaLuAI/CAD-MCP): CAD-MCP enables natural language-driven CAD operations across multiple software platforms, streamlining drawing tasks through intuitive text commands.
 - [danimal141/arxiv-search-mcp](https://github.com/danimal141/arxiv-search-mcp): Facilitates searching and retrieving academic papers from arXiv.org with customizable parameters.
 - [sebastien-le-paris/project-rules](https://github.com/sebastien-le-paris/project-rules): Facilitates the integration of external tools and data sources with Cursor through the Model Context Protocol, enhancing AI project rule management and tool execution.
+- [xmpuspus/ph-civic-data-mcp](https://github.com/xmpuspus/ph-civic-data-mcp): Philippine government data as MCP tools — PHIVOLCS earthquakes + volcano alerts, PAGASA weather + typhoons, PhilGEPS procurement, PSA 2020 Census population + poverty, and AQICN air quality. 12 tools including a cross-source multi-hazard risk profiler. Install: `uvx ph-civic-data-mcp`.
 
 ## 🔎 Search
 

--- a/README.md
+++ b/README.md
@@ -1164,7 +1164,7 @@ Servers accessing scientific databases, research platforms, or providing tools f
 - [HuaLuAI/CAD-MCP](https://github.com/HuaLuAI/CAD-MCP): CAD-MCP enables natural language-driven CAD operations across multiple software platforms, streamlining drawing tasks through intuitive text commands.
 - [danimal141/arxiv-search-mcp](https://github.com/danimal141/arxiv-search-mcp): Facilitates searching and retrieving academic papers from arXiv.org with customizable parameters.
 - [sebastien-le-paris/project-rules](https://github.com/sebastien-le-paris/project-rules): Facilitates the integration of external tools and data sources with Cursor through the Model Context Protocol, enhancing AI project rule management and tool execution.
-- [xmpuspus/ph-civic-data-mcp](https://github.com/xmpuspus/ph-civic-data-mcp): Philippine government data as MCP tools — PHIVOLCS earthquakes + volcano alerts, PAGASA weather + typhoons, PhilGEPS procurement, PSA 2020 Census population + poverty, and AQICN air quality. 12 tools including a cross-source multi-hazard risk profiler. Install: `uvx ph-civic-data-mcp`.
+- [xmpuspus/ph-civic-data-mcp](https://github.com/xmpuspus/ph-civic-data-mcp): Philippine government data plus global Earth observation as MCP tools. Covers PHIVOLCS earthquakes and volcano alerts, PAGASA weather and typhoons, PhilGEPS procurement, PSA population and poverty, NASA POWER solar/climate, Open-Meteo air quality, NASA MODIS NDVI, USGS earthquakes, NOAA IBTrACS typhoon tracks, and World Bank indicators. 17 tools across 10 sources, zero required API keys, with a cross-source multi-hazard risk profiler. Install: `uvx ph-civic-data-mcp`.
 
 ## 🔎 Search
 

--- a/docs/science--research.md
+++ b/docs/science--research.md
@@ -2,6 +2,7 @@
 
 Servers accessing scientific databases, research platforms, or providing tools for scientific computation/simulation.
 
+- [xmpuspus/ph-civic-data-mcp](https://github.com/xmpuspus/ph-civic-data-mcp): Philippine government data plus global Earth observation as MCP tools. Covers PHIVOLCS earthquakes and volcano alerts, PAGASA weather and typhoons, PhilGEPS procurement, PSA population and poverty, NASA POWER solar/climate, Open-Meteo air quality, NASA MODIS NDVI, USGS earthquakes, NOAA IBTrACS typhoon tracks, and World Bank indicators. 17 tools across 10 sources, zero required API keys, with a cross-source multi-hazard risk profiler. Install: `uvx ph-civic-data-mcp`.
 - [connerlambden/bgpt-mcp](https://github.com/connerlambden/bgpt-mcp): Search scientific papers with structured experimental data extracted from full-text studies, returning 25+ fields per paper including methods, results, sample sizes, and quality scores.
 - [GreatApo/concrete-properties-mcp](https://github.com/GreatApo/concrete-properties-mcp): Facilitates AI-driven analysis of reinforced concrete sections by providing a unified API interface for calculating geometric and material properties.
 - [GooTec/NCBI-MCP](https://github.com/GooTec/NCBI-MCP): Facilitates access to NCBI Datasets through a modular MCP server with OpenAPI-driven endpoints for genome, gene, and taxonomy data.


### PR DESCRIPTION
Adds `ph-civic-data-mcp` to **Science & Research**.

First MCP server exposing Philippine government open data as agent-callable tools:
- **PHIVOLCS** — real-time earthquakes + volcano alert levels (WOVODAT bulletins)
- **PAGASA** — 10-day weather forecast (with Open-Meteo fallback when the PAGASA token isn't available), active typhoon tracking, alerts
- **PhilGEPS** — government procurement notices
- **PSA OpenSTAT** — 2020 Census population + 2023 Full-Year poverty (PXWeb API, discovered via browse — no hardcoded paths)
- **AQICN** — real-time air quality for PH cities

12 tools total, including a cross-source `assess_area_risk` that fans out to PHIVOLCS + PAGASA + AQICN in parallel.

- Install: `uvx ph-civic-data-mcp`
- PyPI: https://pypi.org/project/ph-civic-data-mcp/
- Repo: https://github.com/xmpuspus/ph-civic-data-mcp
- License: MIT
- Publicly accessible: ✅ open source (MIT) + published to PyPI

Entry placed at the bottom of **Science & Research** (per your "most recent 30" display convention).