### PR TITLE
feat: add willow-mcp to Knowledge Management & Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -885,6 +885,7 @@ Servers connecting to personal knowledge bases, flashcard apps, building/queryin
 - [blackpilledsoftware-prog/migas-mcp](https://github.com/blackpilledsoftware-prog/migas-mcp): Query local meeting transcripts from Migas, a macOS meeting copilot with on-device transcription and realtime speaker labels. Search across meetings, get full transcripts, and find what anyone said. Read-only, local SQLite.
 - [superlowburn/agentrank](https://github.com/superlowburn/agentrank): Live, quality-scored index of 25,000+ MCP servers. Scores tools daily using real GitHub signals — freshness, issue health, contributors, dependents, and stars. Search and discover currently maintained tools via 3 MCP tools. Available as `agentrank-mcp-server` on npm.
 - [wazionapps/nexo](https://github.com/wazionapps/nexo): Cognitive memory architecture for Claude Code. Implements Atkinson-Shiffrin memory model, Ebbinghaus forgetting curves, semantic RAG with knowledge graph, trust scoring, and metacognitive error prevention. 100+ MCP tools. Install via `npx nexo-brain init`.
+- [rudi193-cmd/willow-mcp](https://github.com/rudi193-cmd/willow-mcp) 🐍 🏠 🐧 - Agent-neutral MCP server with SOIL local store, Postgres knowledge base, Kart sandboxed task queue, and SAP authorization. 30+ tools for knowledge management, file routing, multi-agent dispatch, and task execution. Portless stdio transport.
 
 ## 🗺️ Location & Maps
 


### PR DESCRIPTION
## Summary

Adds [willow-mcp](https://github.com/rudi193-cmd/willow-mcp) to the Knowledge Management & Memory section.

**willow-mcp** is an agent-neutral MCP server with:

- **SOIL local store** — SQLite-backed key/value + FTS store with 30+ tools
- **Postgres knowledge base** — semantic and full-text knowledge graph
- **Kart task queue** — sandboxed task executor for shell commands and scripts
- **SAP authorization** — SAFE Authorization Protocol, filesystem-based identity gate

Portless stdio transport. Works with any MCP client. MIT licensed.

`pip install willow-mcp` or `git clone https://github.com/rudi193-cmd/willow-mcp`