### PR TITLE
Add prompt-to-asset to Multimedia Processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1059,6 +1059,7 @@ Servers focused on generating or manipulating images, processing video, audio tr
 - [fasuizu-br/speech-ai-examples](https://github.com/fasuizu-br/speech-ai-examples): Speech AI MCP server with pronunciation assessment (phoneme-level scoring, 17MB model, <300ms), text-to-speech, and speech-to-text. 8 tools for AI agents building language learning, accessibility, and voice applications.
 - [ssembleinc/ssemble-mcp-server](https://github.com/ssembleinc/ssemble-mcp-server) - Create AI-generated short-form video clips from YouTube with captions, music, gameplay overlays, meme hooks, and viral scoring.
 - [neugence/whipscribe-mcp](https://github.com/neugence/whipscribe-mcp): MCP server for audio/video transcription via the Whipscribe API. Transcribes from a URL (YouTube, podcasts, direct media links) or local file; returns txt/json/srt/vtt/docx with optional speaker diarization and word timestamps. Hosted remote endpoint at `https://whipscribe.com/mcp` (Bearer auth) or local install via `uvx whipscribe-mcp`.
+- [MohamedAbdallah-14/prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset): Generates production-ready visual assets (app icons, favicons, OG images, logos, wordmarks) by routing each request across 30+ image generation models to the best fit. Zero-key first run via free-tier providers (Pollinations, Stable Horde, HuggingFace). MIT licensed.
 
 ## 🖥️ Operating System & Command Line
 

--- a/docs/multimedia-processing.md
+++ b/docs/multimedia-processing.md
@@ -2,6 +2,7 @@
 
 Servers focused on generating or manipulating images, processing video, audio transcription, text-to-speech, or document conversion.
 
+- [MohamedAbdallah-14/prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset): Generates production-ready visual assets (app icons, favicons, OG images, logos, wordmarks) by routing each request across 30+ image generation models to the best fit. Zero-key first run via free-tier providers (Pollinations, Stable Horde, HuggingFace). MIT licensed.
 - [AIDC-AI/Pixelle-MCP](https://github.com/AIDC-AI/Pixelle-MCP): An omnimodal AIGC framework that seamlessly converts ComfyUI workflows into MCP tools with zero code, enabling full-modal support for Text, Image, Sound, and Video generation with Chainlit-based web interface.
 - [aimino/imagemagic-mcp](https://github.com/aimino/imagemagic-mcp): Enhance images with binarization, color adjustment, and resizing using ImageMagick via the MCP protocol.
 - [SkyworkAI/Mureka-mcp](https://github.com/SkyworkAI/Mureka-mcp): Facilitates the creation of lyrics, songs, and background music through an MCP server, enabling seamless integration with platforms like Claude Desktop and OpenAI Agents.


### PR DESCRIPTION
## Description

Adding [prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) to the 🖼️ Multimedia Processing section.

**prompt-to-asset** is an MCP server that generates production-ready visual assets (app icons, favicons, OG images, logos, wordmarks) by routing each request across 30+ image generation models to the best fit for the task.

Key features:
- Routes across 30+ image models (OpenAI DALL-E, Stability AI, Pollinations, HuggingFace, FAL.ai, etc.)
- Zero API key required for first run (free-tier providers)
- Three execution modes: inline SVG, external prompt, full API
- Output validation: WCAG contrast, OCR accuracy, palette consistency
- MIT licensed, npm package `prompt-to-asset` v0.4.2

This fits the Multimedia Processing section as it's specifically focused on generating visual assets via MCP.