### PR TITLE
chore(vaultpilot): lead description with "Safety first."

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,7 +592,7 @@ Servers focused on interacting with local or remote file systems for reading, wr
 
 Servers dealing with financial data, stock markets, cryptocurrency exchanges/data, trading bots, banking APIs, accounting software, or blockchain interactions.
 
-- [szhygulin/vaultpilot-mcp](https://github.com/szhygulin/vaultpilot-mcp) - Hardware-verified DeFi for AI agents. The agent proposes, you approve on your Ledger — designed for when the AI can be compromised.
+- [szhygulin/vaultpilot-mcp](https://github.com/szhygulin/vaultpilot-mcp) - Safety first. Hardware-verified DeFi for AI agents. The agent proposes, you approve on your Ledger — designed for when the AI can be compromised.
 - [FXMacroData](https://github.com/fxmacrodata/fxmacrodata) - Macroeconomic indicators, central bank policy rates, FX spot rates, COT positioning data, and economic release calendars for 18+ currencies via a remote MCP server at https://fxmacrodata.com/mcp
 - [Helium MCP](https://github.com/connerlambden/helium-mcp) - Remote MCP server for real-time news intelligence with bias scoring (3.2M+ articles, 5000+ sources, 15+ dimensions), financial market data (stocks, ETFs, crypto, AI bull/bear cases), ML options pricing (probability ITM, Greeks, fair value), balanced news synthesis, trending topics, and meme search. [Documentation](https://heliumtrades.com/mcp-page/)
 - [FinancialData.Net MCP Server](https://financialdata.net/mcp-server) - Get real-time stock prices, fundamentals, institutional trading insights, and other financial data delivered through a universal Model Context Protocol (MCP) server.

--- a/docs/finance--crypto.md
+++ b/docs/finance--crypto.md
@@ -2,7 +2,7 @@
 
 Servers dealing with financial data, stock markets, cryptocurrency exchanges/data, trading bots, banking APIs, accounting software, or blockchain interactions.
 
-- [szhygulin/vaultpilot-mcp](https://github.com/szhygulin/vaultpilot-mcp) - Hardware-verified DeFi for AI agents. The agent proposes, you approve on your Ledger — designed for when the AI can be compromised.
+- [szhygulin/vaultpilot-mcp](https://github.com/szhygulin/vaultpilot-mcp) - Safety first. Hardware-verified DeFi for AI agents. The agent proposes, you approve on your Ledger — designed for when the AI can be compromised.
 - [Chain.Love MCP](https://github.com/Chain-Love/chain.love-mcp) – Hosted MCP gateway that enables AI agents to discover and compare Web3 infra services (RPCs, indexing, oracles, storage, compute, dev tools, and more) across 50+ networks via a single endpoint.
 - [horustechltd/horus-flow-mcp](https://github.com/horustechltd/horus-flow-mcp): Institutional crypto & equity orderflow engine for AI agents. Detects spoofing, BUY_ABSORPTION, and LIQUIDITY_EVENT signals with sub-second lead time over price action. Glama A-Tier verified.
 - [vdalhambra/financekit-mcp](https://github.com/vdalhambra/financekit-mcp): Financial market intelligence MCP with 17 tools for AI agents — stock quotes, technical analysis (RSI, MACD, Bollinger, ADX, Stochastic + Golden/Death Cross detection with structured verdicts), crypto via CoinGecko, risk metrics (VaR, Sharpe, Sortino, Beta), correlation matrix, options chains, earnings calendar, sector rotation, and portfolio analysis. No API keys required. FastMCP 3.2, MIT.


### PR DESCRIPTION
Maintainer of [vaultpilot-mcp](https://github.com/szhygulin/vaultpilot-mcp) here — updating my own listing's description in this list.

Reason: the threat-model clause ("designed for when the AI can be compromised") is what distinguishes VaultPilot from every adjacent crypto / agent / wallet tool. Leading with "Safety first." puts that posture in the first two words of the listing rather than after a feature description.

The same change is rolling out across our other public surfaces (GitHub repo description, README, npm, MCP registry, vaultpilot-site landing page). One-line description-only update; no other content touched.