### PR TITLE
Add Beever-AI/beever-atlas to Knowledge Management & Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -898,6 +898,7 @@ Servers connecting to personal knowledge bases, flashcard apps, building/queryin
 - [blackpilledsoftware-prog/migas-mcp](https://github.com/blackpilledsoftware-prog/migas-mcp): Query local meeting transcripts from Migas, a macOS meeting copilot with on-device transcription and realtime speaker labels. Search across meetings, get full transcripts, and find what anyone said. Read-only, local SQLite.
 - [superlowburn/agentrank](https://github.com/superlowburn/agentrank): Live, quality-scored index of 25,000+ MCP servers. Scores tools daily using real GitHub signals — freshness, issue health, contributors, dependents, and stars. Search and discover currently maintained tools via 3 MCP tools. Available as `agentrank-mcp-server` on npm.
 - [wazionapps/nexo](https://github.com/wazionapps/nexo): Cognitive memory architecture for Claude Code. Implements Atkinson-Shiffrin memory model, Ebbinghaus forgetting curves, semantic RAG with knowledge graph, trust scoring, and metacognitive error prevention. 100+ MCP tools. Install via `npx nexo-brain init`.
+- [Beever-AI/beever-atlas](https://github.com/Beever-AI/beever-atlas): Open-source LLM Wiki that distills team-chat corpora (Slack, Discord, Microsoft Teams, Mattermost, Telegram) into a 3-tier semantic schema and an entity graph. Exposes 16 MCP tools for cited Q&A from Claude Code and Cursor. Apache 2.0, runnable in 3 commands via `make demo`.
 
 ## 🗺️ Location & Maps
 

--- a/docs/knowledge-management--memory.md
+++ b/docs/knowledge-management--memory.md
@@ -2,6 +2,7 @@
 
 Servers connecting to personal knowledge bases, flashcard apps, building/querying knowledge graphs, or providing persistent memory for LLMs.
 
+- [Beever-AI/beever-atlas](https://github.com/Beever-AI/beever-atlas): Open-source LLM Wiki that distills team-chat corpora (Slack, Discord, Microsoft Teams, Mattermost, Telegram) into a 3-tier semantic schema and an entity graph. Exposes 16 MCP tools for cited Q&A from Claude Code and Cursor. Apache 2.0, runnable in 3 commands via `make demo`.
 - [novyxlabs/novyx-mcp](https://github.com/novyxlabs/novyx-mcp): Persistent memory for AI agents with 107 tools: remember, recall, rollback, audit, knowledge graph, governed actions, eval, cortex, and Runtime v2 agent orchestration. Local SQLite (zero-config) or Novyx Cloud. Install via `uvx novyx-mcp`. MIT licensed.
 - [yantrikos/yantrikdb-mcp](https://github.com/yantrikos/yantrikdb-mcp): Cognitive memory for AI agents — persistent semantic memory with knowledge graph, adaptive recall, conflict detection, entity relationships, and memory consolidation across sessions. 24 tools. Works with Claude Code, Cursor, Windsurf, and any MCP client.
 - [nicholasglazer/gnosis-mcp](https://github.com/nicholasglazer/gnosis-mcp): Zero-config MCP server that loads markdown docs into SQLite (FTS5 keyword search) or PostgreSQL (pgvector hybrid semantic+keyword search) and exposes 6 tools and 3 resources for AI agents to search, retrieve, and manage documentation.


### PR DESCRIPTION
## What

Adds [Beever-AI/beever-atlas](https://github.com/Beever-AI/beever-atlas) to the Knowledge Management & Memory section.

## Why this fits

Beever Atlas is an open-source LLM Wiki for team chat. It exposes a 16-tool MCP server backed by a 3-tier semantic schema (Channel / Topic / Fact) and an entity graph, populated by a six-stage extraction pipeline that distills Slack, Discord, Microsoft Teams, Mattermost, and Telegram conversations into queryable, cited knowledge.

Sits naturally next to existing entries in this section:
- `mkusaka/mcp-server-memory` — local knowledge graph memory
- `Arc-Computer/arc-mcp-server` — temporal knowledge graph
- `HendryAvila/Hoofy` — persistent memory + KG with typed relations
- `lyonzin/knowledge-rag` — hybrid semantic + BM25 search

Distinct angle: chat-corpus-specific extraction (cross-batch validation, scope-aware entity merging, temporal relationship props), exposed as MCP tools so Claude Code and Cursor consume the same memory.

## Quality criteria

- Open source: Apache 2.0
- Active: released April 19, 2026, daily commits
- Documented: https://docs.beever.ai/atlas
- Demo: `make demo` brings up the full stack in 3 commands

## Disclosure

I'm a maintainer of Beever Atlas (Beever AI Limited, Toronto).