### PR TITLE
Add md-redline to Developer Productivity & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,6 +553,7 @@ Servers enhancing developer workflows, integrating with IDEs, accessing document
 - [saurav61091/mcp-openapi](https://github.com/saurav61091/mcp-openapi): Turn any OpenAPI 3.x spec into MCP tools for Claude — zero config, instant API access.
 
 - [mcp-lint](https://github.com/robert19001-cmyk/mcp-lint): CLI linting tool that validates MCP server tool schemas for cross-client compatibility across Claude, Cursor, Gemini, and VS Code Copilot. Features 13 rules, auto-fix for safe issues, JSON/Markdown output, and support for static files and live MCP servers via stdio/SSE.
+- [dejuknow/md-redline](https://github.com/dejuknow/md-redline): Inline review comments for markdown specs and design docs. Agents request human review mid-task via MCP and pause until you send feedback. Comments stored as invisible HTML markers in the markdown file itself.
 ## 📁 Filesystems
 
 Servers focused on interacting with local or remote file systems for reading, writing, editing, listing, or managing files and directories.

--- a/docs/developer-productivity--utilities.md
+++ b/docs/developer-productivity--utilities.md
@@ -2,6 +2,7 @@
 
 Servers enhancing developer workflows, integrating with IDEs, accessing documentation, API exploration, code generation helpers, or general dev utilities.
 
+- [dejuknow/md-redline](https://github.com/dejuknow/md-redline): Inline review comments for markdown specs and design docs. Agents request human review mid-task via MCP and pause until you send feedback. Comments stored as invisible HTML markers in the markdown file itself.
 - [walkojas-boop/regexforge](https://github.com/walkojas-boop/regexforge): Deterministic regex synthesis. Send labeled examples, get a battle-tested regex + test matrix + backtracking-risk analysis. Zero LLM at serve time. $0.002/call. Live at https://regexforge.jason-12c.workers.dev/.
 - [walkojas-boop/ghostdom](https://github.com/walkojas-boop/ghostdom): Headless-browser-as-JSON for AI agents. POST a URL, get rendered DOM + text + screenshot from real Chromium. Memorymarket pricing: first agent to render a URL earns 90% of cache-hit fees from subsequent agents within a 10-min TTL. Stack: Cloudflare Workers + Durable Objects + KV + x402. Live at https://ghostdom.jason-12c.workers.dev/.
 - [walkojas-boop/linkpulse](https://github.com/walkojas-boop/linkpulse): URL reality check for AI agents. Returns status, SHA-256 content hash, classification, readability score, title, and wayback-machine fallback when dead. Cached 10 min, $0.001 per call. Live at https://linkpulse-neon.vercel.app/.


### PR DESCRIPTION
Adds [md-redline](https://github.com/dejuknow/md-redline) under 🛠️ Developer Productivity & Utilities.

Local-first tool for inline review of markdown specs and design docs. Built-in stdio MCP server (`mdr mcp`) exposes `mdr_request_review`, which lets agents request a human review mid-task and pause until the user sends feedback. Useful for the human-in-the-loop pattern when working with Claude Code, Codex, Gemini CLI, and other MCP clients.

- Repo: https://github.com/dejuknow/md-redline
- npm: https://www.npmjs.com/package/md-redline
- License: MIT
- Platforms: macOS, Linux, Windows
- Install: `npx md-redline /path/to/spec.md`

Comments are stored as invisible HTML markers in the markdown itself, so the same `.md` file is the source of truth for both human and agent (no sidecar files, no database).