### PR TITLE
Add hlpun/Train-in-Silence to AI & LLM Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Servers integrating with other AI models, AI platforms, RAG tools, prompt manage
 - [tangshuang/mcp-bone](https://github.com/tangshuang/mcp-bone): Facilitates connection to MCP Bone for tool registration and parsing LLM completion text into tool calls.
 - [belljustin/spotify-mcp](https://github.com/belljustin/spotify-mcp): Facilitates playlist creation on Spotify through a Model Context Protocol server, integrating seamlessly with Cursor for enhanced user interaction.
 - [Zerg00s/server-sharepoint](https://github.com/Zerg00s/server-sharepoint): Facilitates interaction with SharePoint Online through Claude Desktop using the SharePoint REST API.
+- [hlpun/Train-in-Silence](https://github.com/hlpun/Train-in-Silence): Task-aware MCP server for LLM fine-tuning providing VRAM/runtime/cost estimation and live multi-cloud GPU sniping.
 
 ## 🎨 Art, Culture & Media
 

--- a/docs/ai--llm-integration.md
+++ b/docs/ai--llm-integration.md
@@ -1611,3 +1611,4 @@ Servers integrating with other AI models, AI platforms, RAG tools, prompt manage
 - [aidenmi8/aiservers](https://github.com/aidenmi8/aiservers): Showcases diverse MCP server implementations for secure LLM access to tools and data sources.
 
 - [hol-org/hashnet-mcp](https://github.com/hashgraph-online/hashnet-mcp-js): MCP server for discovering AI agents across NANDA, MCP, Virtuals, A2A, and ERC-8004 registries using the Registry Broker API.
+- [hlpun/Train-in-Silence](https://github.com/hlpun/Train-in-Silence): Task-aware MCP server for LLM fine-tuning providing VRAM/runtime/cost estimation and live multi-cloud GPU sniping.


### PR DESCRIPTION
Adds Train-in-Silence to AI & LLM Integration (applies to README.md and docs/ai--llm-integration.md).

Train in Silence is a task-aware MCP server for LLM fine-tuning hardware planning. It accepts a workload description or code and automatically calculates VRAM, runtime, and cost estimations, while sniping the cheapest and fastest multi-cloud GPU options across 10+ providers (Vast.ai, RunPod, AWS, GCP, etc.).

Install: pip install train-in-silence
Repo: https://github.com/hlpun/Train-in-Silence
API Info: Integrates with 10+ GPU clouds. Provider API keys (e.g., Vast.ai, RunPod) are strictly optional; it seamlessly falls back to free live aggregators if no keys are provided.

Works with Claude Desktop, Claude Code, Cursor, Windsurf, and any MCP-compatible client.

Entry placed at the bottom of the category. Format matches existing entries.