### PR TITLE
Add Bernstein to AI & LLM Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Servers integrating with other AI models, AI platforms, RAG tools, prompt manage
 - [tangshuang/mcp-bone](https://github.com/tangshuang/mcp-bone): Facilitates connection to MCP Bone for tool registration and parsing LLM completion text into tool calls.
 - [belljustin/spotify-mcp](https://github.com/belljustin/spotify-mcp): Facilitates playlist creation on Spotify through a Model Context Protocol server, integrating seamlessly with Cursor for enhanced user interaction.
 - [Zerg00s/server-sharepoint](https://github.com/Zerg00s/server-sharepoint): Facilitates interaction with SharePoint Online through Claude Desktop using the SharePoint REST API.
+- [sipyourdrink-ltd/bernstein](https://github.com/sipyourdrink-ltd/bernstein): Multi-agent orchestrator with first-class MCP server; coordinates 37 CLI coding agents (Claude Code, Codex, Gemini CLI, OpenHands, Aider, and 32 more) through MCP tool calls. Apache 2.0.
 - [hlpun/Train-in-Silence](https://github.com/hlpun/Train-in-Silence): Task-aware MCP server for LLM fine-tuning providing VRAM/runtime/cost estimation and live multi-cloud GPU sniping.
 
 ## 🎨 Art, Culture & Media

--- a/docs/ai--llm-integration.md
+++ b/docs/ai--llm-integration.md
@@ -2,6 +2,7 @@
 
 Servers integrating with other AI models, AI platforms, RAG tools, prompt management, or agent frameworks.
 
+- [sipyourdrink-ltd/bernstein](https://github.com/sipyourdrink-ltd/bernstein): Multi-agent orchestrator with first-class MCP server; coordinates 37 CLI coding agents (Claude Code, Codex, Gemini CLI, OpenHands, Aider, and 32 more) through MCP tool calls. Apache 2.0.
 - [bh-rat/context-awesome](https://github.com/bh-rat/context-awesome) - MCP server for querying 8,500+ curated awesome lists (1M+ items) and fetching the best resources for your agent.
 - [spranab/brainstorm-mcp](https://github.com/spranab/brainstorm-mcp) - Multi-round AI brainstorming debates between multiple models (GPT, DeepSeek, Groq, Ollama, etc.). Pit different LLMs against each other to explore ideas from diverse perspectives.
 - [deadpixel/roundtable-dashboard](https://github.com/deadpixel/roundtable-dashboard): Multi-model AI debate platform with remote MCP server. GPT-4o, Claude, Gemini and 200+ models discuss prompts in structured rounds and synthesize collective insight via Streamable HTTP at `https://mcp.roundtable.now/mcp`.


### PR DESCRIPTION
Adds Bernstein under **AI & LLM Integration**.

[Bernstein](https://github.com/sipyourdrink-ltd/bernstein) is an open-source multi-agent orchestrator with a first-class MCP server. It exposes orchestration primitives (run, status, stop, tasks, cost, approve, create_subtask, load_skill, health) as MCP tools so any MCP-compatible client can drive a fleet of CLI coding agents (Claude Code, Codex, Gemini CLI, OpenHands, Aider, Amp, Goose, Qwen, Ollama, GitHub Copilot CLI, and 27 more) running in parallel git worktrees.

- License: Apache 2.0
- Repo: https://github.com/sipyourdrink-ltd/bernstein
- Disclosure: I am a maintainer.