### PR TITLE
Add opusforge/gorilla-mcp under Marketing, Sales & CRM

### DIFF
--- a/README.md
+++ b/README.md
@@ -987,6 +987,7 @@ Servers integrating with CRM platforms, marketing analytics, customer data platf
 - [teamsincetoday/podcast-commerce-mcp](https://github.com/teamsincetoday/podcast-commerce-mcp): Extracts affiliate products, sponsor mentions, and shoppable recommendations from podcast episodes using AI-powered content intelligence. Features cross-show product comparison and show notes generation.
 - [teamsincetoday/newsletter-commerce-mcp](https://github.com/teamsincetoday/newsletter-commerce-mcp): Extracts shoppable products and sponsor mentions from newsletter editions using AI-powered content intelligence. Generates affiliate-ready product sections for newsletters.
 - [teamsincetoday/recipe-commerce-mcp](https://github.com/teamsincetoday/recipe-commerce-mcp): Extracts affiliate-ready product recommendations from recipe content using AI-powered ingredient and kitchen tool analysis. Remote Streamable HTTP endpoint on Cloudflare Workers.
+- [opusforge/gorilla-mcp](https://github.com/opusforge/gorilla-mcp): Lead discovery for solo SaaS founders. One run searches Reddit, X, YouTube, and TikTok in parallel and ranks each post by buying intent. Tools for end-to-end acquisition: `leads.find`, `idea.refine`, `outreach.draft`, and `outreach.plan` (Week-1 cadence).
 
 ## 📡 Monitoring & Observability
 

--- a/docs/marketing-sales--crm.md
+++ b/docs/marketing-sales--crm.md
@@ -2,6 +2,7 @@
 
 Servers integrating with CRM platforms, marketing analytics, customer data platforms, or advertising platforms.
 
+- [opusforge/gorilla-mcp](https://github.com/opusforge/gorilla-mcp): Lead discovery for solo SaaS founders. One run searches Reddit, X, YouTube, and TikTok in parallel and ranks each post by buying intent. Tools for end-to-end acquisition: `leads.find`, `idea.refine`, `outreach.draft`, and `outreach.plan` (Week-1 cadence).
 - [edupoli/zapdelivery](https://github.com/edupoli/zapdelivery): ZapDelivery API facilitates self-service delivery projects with an integrated MCP endpoint for seamless operations.
 - [Meerkats-Ai/rocketreach-mcp-server](https://github.com/Meerkats-Ai/rocketreach-mcp-server): Integrates with RocketReach API to provide email, phone number finding, and company enrichment capabilities.
 - [Meerkats-Ai/prospeo-mcp-server](https://github.com/Meerkats-Ai/prospeo-mcp-server): Integrates with the Prospeo API to provide email finding and LinkedIn profile enrichment capabilities.


### PR DESCRIPTION
Adds Gorilla under Marketing.

What it is: a lead-discovery server for solo SaaS founders. One run searches Reddit, X, YouTube, and TikTok in parallel and ranks each post by how close someone is to buying. The agent-side tools (`leads.find`, `outreach.draft`, `outreach.plan`) let Claude follow up the search with drafts and a Week-1 plan, not just dump a CSV.

Hosted, paid per run. $0.99 / $3.99 weekly / $149.99 lifetime. Sign up at https://usegorilla.app.

Install: `npx -y github:opusforge/gorilla-mcp`
Repo: https://github.com/opusforge/gorilla-mcp