### PR TITLE
Add adw0rd/awesome-mcp-tools-mcp to Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -852,6 +852,7 @@ Servers or systems that deliver core runtime functionalities for MCP, such as pr
 - [mcpjungle/MCPJungle](https://github.com/mcpjungle/MCPJungle): Self-hosted MCP Registry and Gateway for AI Agents
 - [stucchi/mcp-advisor](https://github.com/stucchi/mcp-advisor): Browse, search, and discover 7,000+ MCP servers from the official registry. Search by name, tag, or transport, get install instructions for any client, and view trending servers.
 - [kswap/consul-mcp](https://github.com/kswap/consul-mcp): Facilitates Consul service discovery and mesh integration through an MCP server interface.
+- [adw0rd/awesome-mcp-tools-mcp](https://github.com/adw0rd/awesome-mcp-tools-mcp): Hosted MCP server exposing the [awesome-mcp.tools](https://awesome-mcp.tools) catalog of 2,000+ MCP servers as searchable tools — search, compare, top, trending, hot. Refreshed every 6h. Includes a CLI (`npx awesome-mcp search postgres`) and a stdio↔HTTP bridge (`npx -y -p awesome-mcp awesome-mcp-bridge`) for clients without remote-URL support. Endpoint: `https://awesome-mcp.tools/mcp` (Streamable HTTP, no auth).
 
 ## 🧠 Knowledge Management & Memory
 

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -2,6 +2,7 @@
 
 Servers or systems that deliver core runtime functionalities for MCP, such as proxying, aggregation, orchestration, hosting, routing, or acting as gateways.
 
+- [adw0rd/awesome-mcp-tools-mcp](https://github.com/adw0rd/awesome-mcp-tools-mcp): Hosted MCP server exposing the [awesome-mcp.tools](https://awesome-mcp.tools) catalog of 2,000+ MCP servers as searchable tools — search, compare, top, trending, hot. Refreshed every 6h. Includes a CLI (`npx awesome-mcp search postgres`) and a stdio↔HTTP bridge (`npx -y -p awesome-mcp awesome-mcp-bridge`) for clients without remote-URL support. Endpoint: `https://awesome-mcp.tools/mcp` (Streamable HTTP, no auth).
 - [lijian-ui/vcenter-mcp-server](https://github.com/lijian-ui/vcenter-mcp-server): Facilitates seamless integration with vCenter Server for efficient virtual machine management, including migration and information retrieval.
 - [chris-sun-star/mcp-server-k8s](https://github.com/chris-sun-star/mcp-server-k8s): Facilitates Kubernetes integration with Claude Desktop through a simple MCP server setup.
 - [Michael98671/agentbay](https://github.com/Michael98671/agentbay): AgentBay MCP Server offers a serverless cloud infrastructure for AI Agents, enabling rapid integration and execution of AI tasks with Alibaba Cloud's Wuying platform.


### PR DESCRIPTION
Adds [adw0rd/awesome-mcp-tools-mcp](https://github.com/adw0rd/awesome-mcp-tools-mcp) to the 🏛️ Infrastructure section.

A hosted MCP server that exposes the [awesome-mcp.tools](https://awesome-mcp.tools) catalog of 2,000+ MCP servers as searchable tools — search, compare, top, trending, hot. Same conceptual category as `stucchi/mcp-advisor` already listed in this section, but sourced from a multi-source catalog (refreshed every 6h from the open-source ecosystem rather than only the official registry).

The npm package `awesome-mcp` ships two binaries:
- **CLI** for terminal use: `npx awesome-mcp search postgres`, `awesome-mcp top --language Python`, `awesome-mcp info markitdown`
- **stdio↔Streamable-HTTP bridge** for MCP clients without native remote-URL support (older Claude Desktop, etc.): `npx -y -p awesome-mcp awesome-mcp-bridge`

Resources:
- npm: [`awesome-mcp@0.2.0`](https://www.npmjs.com/package/awesome-mcp) (zero-dep, Node 18+, MIT)
- MCP endpoint: `https://awesome-mcp.tools/mcp` (Streamable HTTP, MCP `2025-06-18`, no auth)
- Server card: `https://awesome-mcp.tools/.well-known/mcp/server-card.json`
- Glama listing: [tools.awesome-mcp/awesome-mcptools](https://glama.ai/mcp/connectors/tools.awesome-mcp/awesome-mcptools)
- Catalog stats: [/api/stats](https://awesome-mcp.tools/api/stats)

Inserted at the end of the Infrastructure section to match the apparent append-order in the file. No duplicates checked across the list.