### PR TITLE
Add Swagger MCP Bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Servers interacting with build systems, containerization, CI/CD, or deployment p
 - [aaomidi/mcp-bazel](https://github.com/aaomidi/mcp-bazel): Facilitates Bazel project interactions by providing build, test, and dependency analysis tools.
 - [ThomasRohde/mcp_server_manager](https://github.com/ThomasRohde/mcp_server_manager): A backend Python application offering a Model Context Protocol interface and FastAPI web interface for managing MCP servers integrated with Claude Desktop.
 - [addozhang/spring-rest-to-mcp](https://github.com/addozhang/spring-rest-to-mcp): Effortlessly transform Spring Web REST APIs into MCP server tools using OpenRewrite recipes for seamless AI integration.
+- [Swagger MCP Bridge](https://github.com/Neo1228/spring-boot-starter-swagger-mcp): A Spring Boot starter that exposes SpringDoc OpenAPI operations as MCP tools with validation, workflow orchestration, and guardrails.
 - [gunpal5/QuickMCP](https://github.com/gunpal5/QuickMCP): QuickMCP enables rapid creation and deployment of MCP servers using OpenAPI, Swagger, or Google Discovery specifications with .NET.
 - [Drew-Goddyn/buildkite-mcp](https://github.com/Drew-Goddyn/buildkite-mcp): Facilitates seamless integration with Buildkite by providing a microservice for retrieving and managing build information via MCP.
 - [thepragmatik/mcp-server-jvm-build-tools](https://github.com/thepragmatik/mcp-server-jvm-build-tools): Facilitates natural language interaction with Apache Maven through an MCP server for streamlined project builds.


### PR DESCRIPTION
## Summary

Adds **Swagger MCP Bridge** to the developer/build tooling area.

Swagger MCP Bridge is a Spring Boot starter that exposes SpringDoc OpenAPI operations as MCP tools, so existing Java API services can be made available to MCP clients without maintaining hand-written wrappers for every endpoint.

## Why it is relevant

- Focused on Spring Boot / Java API teams
- Converts OpenAPI operation metadata into MCP tool schemas
- Includes a minimal WebMVC example application
- Provides validation, workflow orchestration, and guardrails for risky operations
- Includes Docker/GHCR example server metadata for MCP Registry-style distribution
- Includes `llms-install.md` for agent/marketplace setup checks
- Exposes a static MCP server card from the example server for discovery-oriented clients/listings

## Evidence

- Latest CI on Java 17, 21, and 25: https://github.com/Neo1228/spring-boot-starter-swagger-mcp/actions/runs/25270086353
- Latest GHCR example image build workflow: https://github.com/Neo1228/spring-boot-starter-swagger-mcp/actions/runs/25270088431
- Cline Marketplace submission: https://github.com/cline/mcp-marketplace/issues/1497

## Links

- Project: https://github.com/Neo1228/spring-boot-starter-swagger-mcp
- Agent install guide: https://github.com/Neo1228/spring-boot-starter-swagger-mcp/blob/master/llms-install.md
- Docker-ready example: https://github.com/Neo1228/spring-boot-starter-swagger-mcp/blob/master/examples/minimal-webmvc-gradle/Dockerfile
- MCP Registry metadata: https://github.com/Neo1228/spring-boot-starter-swagger-mcp/blob/master/registry/server.json
- Static MCP server card: https://github.com/Neo1228/spring-boot-starter-swagger-mcp/blob/master/examples/minimal-webmvc-gradle/src/main/resources/static/.well-known/mcp/server-card.json
