### PR TITLE
Add MyCarTracks MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1332,6 +1332,7 @@ Servers providing access to sports-related APIs and analysis.
 Servers providing data or services related to flights, trains, transportation APIs, or travel planning.
 
 - [drivly/auto-dev-skill](https://github.com/drivly/auto-dev-skill): Automotive data APIs for AI agents — VIN decode, vehicle listings, payments, recalls, and specs.
+- [MyCarTracks](https://mycartracks.com/resources/connect-with-ai): Remote MCP server for app-based GPS vehicle tracking and automatic mileage tracking, exposing authorized trip, track, and vehicle data via `https://mycartracks.com/mcp`.
 - [RikGmee/searchAPI-mcp](https://github.com/RikGmee/searchAPI-mcp): Facilitates complex travel planning by integrating flight, hotel, and map services through a multi-context protocol server.
 - [achel-b8/rakuten-hotel-search-mcp](https://github.com/achel-b8/rakuten-hotel-search-mcp): Facilitates hotel availability searches using Rakuten Travel's API, providing results based on specified criteria such as check-in dates and location.
 - [ralf-boltshauser/sbb-mcp-server](https://github.com/ralf-boltshauser/sbb-mcp-server): A TypeScript starter project for building MCP servers with an echo server implementation, supporting both STDIO and SSE communication modes.

--- a/docs/travel--transportation.md
+++ b/docs/travel--transportation.md
@@ -3,6 +3,7 @@
 Servers providing data or services related to flights, trains, transportation APIs, or travel planning.
 
 - [drivly/auto-dev-skill](https://github.com/drivly/auto-dev-skill): Automotive data APIs for AI agents — VIN decode, vehicle listings, payments, recalls, and specs.
+- [MyCarTracks](https://mycartracks.com/resources/connect-with-ai): Remote MCP server for app-based GPS vehicle tracking and automatic mileage tracking, exposing authorized trip, track, and vehicle data via `https://mycartracks.com/mcp`.
 - [ckorhonen/mta-mcp](https://subwayinfo.nyc): Provides real-time NYC subway arrivals, service status, alerts, station search, and trip planning capabilities.
 - [RikGmee/searchAPI-mcp](https://github.com/RikGmee/searchAPI-mcp): Facilitates complex travel planning by integrating flight, hotel, and map services through a multi-context protocol server.
 - [achel-b8/rakuten-hotel-search-mcp](https://github.com/achel-b8/rakuten-hotel-search-mcp): Facilitates hotel availability searches using Rakuten Travel's API, providing results based on specified criteria such as check-in dates and location.


### PR DESCRIPTION
## Summary
- Adds MyCarTracks to the Travel & Transportation MCP category and generated category doc.
- Describes the hosted MCP endpoint for authorized trip, track, and vehicle data.

## Validation
- Confirmed `https://mycartracks.com/resources/connect-with-ai` returns HTTP 200.
- Confirmed `https://mycartracks.com/mcp` returns HTTP 401 for unauthenticated requests, consistent with an authenticated MCP endpoint.