### PR TITLE
Add nylas/cli under Communication & Messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ Servers for interacting with email, chat platforms, SMS, or notification service
 - [commune-sh/commune-mcp](https://github.com/commune-sh/commune-mcp): Provides email infrastructure for AI agents, enabling programmatic inbox creation, send/receive email, thread management across concurrent conversations, custom domains, structured extraction on inbound mail, and SMS.
 - [wazionapps/mcp-server](https://github.com/wazionapps/mcp-server): WAzion - WhatsApp Business platform with 244 MCP tools for messaging, CRM, campaigns, workflows, and AI automation. Supports Streamable HTTP and stdio transports.
 - [littlebearapps/outlook-assistant](https://github.com/littlebearapps/outlook-assistant): MCP server for Microsoft Outlook with 20 consolidated tools for email, calendar, contacts, and mailbox management via Graph API. Features dry-run preview, session rate limiting, and recipient allowlists for safe email sending.
+- [nylas/cli](https://github.com/nylas/cli): MCP server for email, calendar, and contacts. 16 tools across Gmail, Outlook, Exchange, Yahoo, iCloud, and IMAP via a single auth flow. JSON output, install with `nylas mcp install`, works with Claude Code, Cursor, Codex, and Windsurf. Docs at https://cli.nylas.com.
 
 ## 📝 Content Management Systems
 

--- a/docs/communication--messaging.md
+++ b/docs/communication--messaging.md
@@ -2,6 +2,7 @@
 
 Servers for interacting with email, chat platforms, SMS, or notification services.
 
+- [nylas/cli](https://github.com/nylas/cli): MCP server for email, calendar, and contacts. 16 tools across Gmail, Outlook, Exchange, Yahoo, iCloud, and IMAP via a single auth flow. JSON output, install with `nylas mcp install`, works with Claude Code, Cursor, Codex, and Windsurf. Docs at https://cli.nylas.com.
 - [Rich627/whatsapp-claude-plugin](https://github.com/Rich627/whatsapp-claude-plugin): WhatsApp channel plugin for Claude Code. Connect WhatsApp as a native channel to your Claude Code session — send/receive messages, voice transcription, access control, and remote tool approval. Uses Baileys (no API keys needed).
 - [jamesacklin/tlon-mcp-server](https://github.com/jamesacklin/tlon-mcp-server): Facilitates interaction with Tlon agents through direct messaging, contact management, and natural language support.
 - [varunwahi-plivo/plivo-mcp-server](https://github.com/varunwahi-plivo/plivo-mcp-server): Facilitates SMS messaging through Plivo's API using the Message Control Protocol.


### PR DESCRIPTION
Adds nylas/cli to the Communication & Messaging section.

**What it is:** Email, calendar, and contacts CLI with built-in MCP server. 16 tools across Gmail, Outlook, Exchange, Yahoo, iCloud, and IMAP — one auth flow covers all six providers.

**Why this section:** Email/calendar/contacts MCP. Fits next to outlook-assistant, mcp_email_reader, and Gmail-related entries.

**Source:** https://github.com/nylas/cli
**Docs:** https://cli.nylas.com
**Install:** `brew install nylas/nylas-cli/nylas` then `nylas mcp install`