### PR TITLE
Add olo-dot-io/Uni-CLI to Developer Productivity & Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,6 +560,7 @@ Servers enhancing developer workflows, integrating with IDEs, accessing document
 
 - [mcp-lint](https://github.com/robert19001-cmyk/mcp-lint): CLI linting tool that validates MCP server tool schemas for cross-client compatibility across Claude, Cursor, Gemini, and VS Code Copilot. Features 13 rules, auto-fix for safe issues, JSON/Markdown output, and support for static files and live MCP servers via stdio/SSE.
 - [dejuknow/md-redline](https://github.com/dejuknow/md-redline): Inline review comments for markdown specs and design docs. Agents request human review mid-task via MCP and pause until you send feedback. Comments stored as invisible HTML markers in the markdown file itself.
+- [olo-dot-io/Uni-CLI](https://github.com/olo-dot-io/Uni-CLI): Self-repairing CLI catalog that exposes 237+ websites, desktop apps, and external CLIs as one MCP server via 920 declarative YAML adapters and structured error envelopes; agents fix failing adapters and retry to converge on a working call. Median ~80 tokens per call.
 ## 📁 Filesystems
 
 Servers focused on interacting with local or remote file systems for reading, writing, editing, listing, or managing files and directories.

--- a/README.md
+++ b/README.md
@@ -560,7 +560,7 @@ Servers enhancing developer workflows, integrating with IDEs, accessing document
 
 - [mcp-lint](https://github.com/robert19001-cmyk/mcp-lint): CLI linting tool that validates MCP server tool schemas for cross-client compatibility across Claude, Cursor, Gemini, and VS Code Copilot. Features 13 rules, auto-fix for safe issues, JSON/Markdown output, and support for static files and live MCP servers via stdio/SSE.
 - [dejuknow/md-redline](https://github.com/dejuknow/md-redline): Inline review comments for markdown specs and design docs. Agents request human review mid-task via MCP and pause until you send feedback. Comments stored as invisible HTML markers in the markdown file itself.
-- [olo-dot-io/Uni-CLI](https://github.com/olo-dot-io/Uni-CLI): Self-repairing CLI catalog exposing 238 sites and 1,458 commands across web, desktop apps, Electron apps, and bridge CLIs through one MCP server (counts from the repo's live STATS counters). Declarative YAML adapters with structured error envelopes let agents fix failing adapters and retry; per-call token budget published in `docs/BENCHMARK.md`.
+- [olo-dot-io/Uni-CLI](https://github.com/olo-dot-io/Uni-CLI): Self-repairing CLI catalog that exposes web, desktop apps, Electron apps, and bridge CLIs as deterministic commands through one MCP server. Declarative YAML adapters with structured error envelopes let agents fix failing adapters and retry. Live catalog size and per-call token budget tracked in the repo's README and `docs/BENCHMARK.md`.
 ## 📁 Filesystems
 
 Servers focused on interacting with local or remote file systems for reading, writing, editing, listing, or managing files and directories.

--- a/README.md
+++ b/README.md
@@ -560,7 +560,7 @@ Servers enhancing developer workflows, integrating with IDEs, accessing document
 
 - [mcp-lint](https://github.com/robert19001-cmyk/mcp-lint): CLI linting tool that validates MCP server tool schemas for cross-client compatibility across Claude, Cursor, Gemini, and VS Code Copilot. Features 13 rules, auto-fix for safe issues, JSON/Markdown output, and support for static files and live MCP servers via stdio/SSE.
 - [dejuknow/md-redline](https://github.com/dejuknow/md-redline): Inline review comments for markdown specs and design docs. Agents request human review mid-task via MCP and pause until you send feedback. Comments stored as invisible HTML markers in the markdown file itself.
-- [olo-dot-io/Uni-CLI](https://github.com/olo-dot-io/Uni-CLI): Self-repairing CLI catalog that exposes 237+ websites, desktop apps, and external CLIs as one MCP server via 920 declarative YAML adapters and structured error envelopes; agents fix failing adapters and retry to converge on a working call. Median ~80 tokens per call.
+- [olo-dot-io/Uni-CLI](https://github.com/olo-dot-io/Uni-CLI): Self-repairing CLI catalog exposing 238 sites and 1,458 commands across web, desktop apps, Electron apps, and bridge CLIs through one MCP server (counts from the repo's live STATS counters). Declarative YAML adapters with structured error envelopes let agents fix failing adapters and retry; per-call token budget published in `docs/BENCHMARK.md`.
 ## 📁 Filesystems
 
 Servers focused on interacting with local or remote file systems for reading, writing, editing, listing, or managing files and directories.

--- a/docs/developer-productivity--utilities.md
+++ b/docs/developer-productivity--utilities.md
@@ -2,6 +2,7 @@
 
 Servers enhancing developer workflows, integrating with IDEs, accessing documentation, API exploration, code generation helpers, or general dev utilities.
 
+- [olo-dot-io/Uni-CLI](https://github.com/olo-dot-io/Uni-CLI): Self-repairing CLI catalog exposing 238 sites and 1,458 commands across web, desktop apps, Electron apps, and bridge CLIs through one MCP server (counts from the repo's live STATS counters). Declarative YAML adapters with structured error envelopes let agents fix failing adapters and retry; per-call token budget published in `docs/BENCHMARK.md`.
 - [sarveshsea/m-moire](https://github.com/sarveshsea/m-moire): MCP server and CLI for shadcn-native Design CI. Diagnose UI debt, extract Tailwind tokens, export shadcn registries, and plan safe UI fixes.
 - [dejuknow/md-redline](https://github.com/dejuknow/md-redline): Inline review comments for markdown specs and design docs. Agents request human review mid-task via MCP and pause until you send feedback. Comments stored as invisible HTML markers in the markdown file itself.
 - [walkojas-boop/regexforge](https://github.com/walkojas-boop/regexforge): Deterministic regex synthesis. Send labeled examples, get a battle-tested regex + test matrix + backtracking-risk analysis. Zero LLM at serve time. $0.002/call. Live at https://regexforge.jason-12c.workers.dev/.

--- a/docs/developer-productivity--utilities.md
+++ b/docs/developer-productivity--utilities.md
@@ -2,7 +2,7 @@
 
 Servers enhancing developer workflows, integrating with IDEs, accessing documentation, API exploration, code generation helpers, or general dev utilities.
 
-- [olo-dot-io/Uni-CLI](https://github.com/olo-dot-io/Uni-CLI): Self-repairing CLI catalog exposing 238 sites and 1,458 commands across web, desktop apps, Electron apps, and bridge CLIs through one MCP server (counts from the repo's live STATS counters). Declarative YAML adapters with structured error envelopes let agents fix failing adapters and retry; per-call token budget published in `docs/BENCHMARK.md`.
+- [olo-dot-io/Uni-CLI](https://github.com/olo-dot-io/Uni-CLI): Self-repairing CLI catalog that exposes web, desktop apps, Electron apps, and bridge CLIs as deterministic commands through one MCP server. Declarative YAML adapters with structured error envelopes let agents fix failing adapters and retry. Live catalog size and per-call token budget tracked in the repo's README and `docs/BENCHMARK.md`.
 - [sarveshsea/m-moire](https://github.com/sarveshsea/m-moire): MCP server and CLI for shadcn-native Design CI. Diagnose UI debt, extract Tailwind tokens, export shadcn registries, and plan safe UI fixes.
 - [dejuknow/md-redline](https://github.com/dejuknow/md-redline): Inline review comments for markdown specs and design docs. Agents request human review mid-task via MCP and pause until you send feedback. Comments stored as invisible HTML markers in the markdown file itself.
 - [walkojas-boop/regexforge](https://github.com/walkojas-boop/regexforge): Deterministic regex synthesis. Send labeled examples, get a battle-tested regex + test matrix + backtracking-risk analysis. Zero LLM at serve time. $0.002/call. Live at https://regexforge.jason-12c.workers.dev/.


### PR DESCRIPTION
## What
Adds [olo-dot-io/Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) under **🛠️ Developer Productivity & Utilities**.

## Why
Uni-CLI ships an MCP server that aggregates **237+ websites, desktop apps, and external CLIs** as 3,319 commands. 920 declarative YAML adapters + 216 TS adapters drive it. Sits naturally next to entries like `Dave-London/Pare` (CLI dev-tool wrapper) and `jsnanigans/mcpm` (MCP server manager).

The differentiator is **self-repair**: every error response is a structured envelope (`code`, `adapter_path`, `step`, `suggestion`, `retryable`, `alternatives`), so when a website rotates a selector or auth, the agent edits the YAML at `adapter_path` and retries. Median ~80 tokens per call.

## Format
- Brief description, colon separator, placed at end of Developer Productivity & Utilities (consistent with the section's append-style).
- One server per line.

## Project signals
- Apache-2.0, TypeScript strict, Node ≥ 20.
- npm: [`@zenalexa/unicli`](https://www.npmjs.com/package/@zenalexa/unicli).
- Latest release: v0.218.0 (2026-05-05).
- Docs: https://olo-dot-io.github.io/Uni-CLI/