### PR TITLE
Add tolegm/astranl-mcp aggregator

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ A comprehensive, community-curated collection of [Model Context Protocol (MCP)](
 
 This repo currently includes coverage for **7260 MCP servers as of May 30, 2025**. Due to the limited space, we only show the most recent 30 servers in each category.
 
+- [tolegm/astranl-mcp](https://github.com/tolegm/astranl-mcp) - AI inference dispatch aggregator routing tasks to Anthropic, OpenAI, Gemini, and xAI Grok. Flat per-task pricing (€0.005-€0.05). 9 MCP tools.
+
 ## Contributing
 
 We welcome submissions! To add your MCP server:

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ A comprehensive, community-curated collection of [Model Context Protocol (MCP)](
 
 This repo currently includes coverage for **7260 MCP servers as of May 30, 2025**. Due to the limited space, we only show the most recent 30 servers in each category.
 
-- [tolegm/astranl-mcp](https://github.com/tolegm/astranl-mcp) - AI inference dispatch aggregator routing tasks to Anthropic, OpenAI, Gemini, and xAI Grok. Flat per-task pricing (€0.005-€0.05). 9 MCP tools.
-
 ## Contributing
 
 We welcome submissions! To add your MCP server:
@@ -123,6 +121,7 @@ Servers integrating with other AI models, AI platforms, RAG tools, prompt manage
 - [sipyourdrink-ltd/bernstein](https://github.com/sipyourdrink-ltd/bernstein): Multi-agent orchestrator with first-class MCP server; coordinates 37 CLI coding agents (Claude Code, Codex, Gemini CLI, OpenHands, Aider, and 32 more) through MCP tool calls. Apache 2.0.
 - [hlpun/Train-in-Silence](https://github.com/hlpun/Train-in-Silence): Task-aware MCP server for LLM fine-tuning providing VRAM/runtime/cost estimation and live multi-cloud GPU sniping.
 - [us-all/mlflow-mcp-server](https://github.com/us-all/mlflow-mcp-server) - MLflow MCP server with 82 tools across experiments, runs, registered models, model versions, traces, and assessments. MLflow 3 GenAI traces support and 5 workflow Prompts.
+- [tolegm/astranl-mcp](https://github.com/tolegm/astranl-mcp) - AI inference dispatch aggregator routing tasks to Anthropic, OpenAI, Gemini, and xAI Grok. Flat per-task pricing (€0.005-€0.05). 9 MCP tools.
 
 ## 🎨 Art, Culture & Media
 

--- a/docs/ai--llm-integration.md
+++ b/docs/ai--llm-integration.md
@@ -1616,3 +1616,4 @@ Servers integrating with other AI models, AI platforms, RAG tools, prompt manage
 
 - [hol-org/hashnet-mcp](https://github.com/hashgraph-online/hashnet-mcp-js): MCP server for discovering AI agents across NANDA, MCP, Virtuals, A2A, and ERC-8004 registries using the Registry Broker API.
 - [hlpun/Train-in-Silence](https://github.com/hlpun/Train-in-Silence): Task-aware MCP server for LLM fine-tuning providing VRAM/runtime/cost estimation and live multi-cloud GPU sniping.
+- [tolegm/astranl-mcp](https://github.com/tolegm/astranl-mcp) - AI inference dispatch aggregator routing tasks to Anthropic, OpenAI, Gemini, and xAI Grok. Flat per-task pricing (€0.005-€0.05). 9 MCP tools.


### PR DESCRIPTION
Adds [tolegm/astranl-mcp](https://github.com/tolegm/astranl-mcp) - AI inference dispatch aggregator routing tasks across Anthropic, OpenAI, Gemini, and xAI Grok via measured decomposition strategies. Flat per-task pricing (€0.005-€0.05). 9 MCP tools.

Already listed on:
- [Smithery Registry](https://smithery.ai/server/t-oleg-m/astranl)
- [MCP Registry](https://registry.modelcontextprotocol.io/v0/servers?search=astranl) (active since 2026-04-29)
- [Glama](https://glama.ai/mcp/servers/vxwvj77twe)

_Submitted by automated registry distribution (operational, not commercial outreach)._