### PR TITLE
Refresh Xquik MCP listing metadata

### DIFF
--- a/docs/social-media--content-platforms.md
+++ b/docs/social-media--content-platforms.md
@@ -104,5 +104,4 @@ Servers interacting with social networks, content platforms, or feed aggregators
 - [laulauland/bluesky-context-server](https://github.com/laulauland/bluesky-context-server): Facilitates querying Bluesky instances through MCP client integration.
 - [Muralikrishankp/Twitter-MCP-Server-for-Claude](https://github.com/Muralikrishankp/Twitter-MCP-Server-for-Claude): Connects Twitter's trending topics with Claude's analysis capabilities to identify business opportunities.
 - [VibeMarketing](https://vibemarketing.ninja/mcp): Social media scheduling for X/Twitter and LinkedIn with AI-powered content generation. OAuth authentication, schedule posts, manage accounts, subscription tracking.
-- [Xquik-dev/x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper): X/Twitter data platform — MCP server with StreamableHTTP transport, 76 REST API endpoints, 20 extraction tools.
-
+- [Xquik-dev/x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper): X/Twitter automation platform with an MCP server, 100+ REST API endpoints, 23 extraction types, HMAC webhooks, and SDKs.


### PR DESCRIPTION
## Summary

- Refresh the existing Xquik listing with current public repo metadata.
- Keep the entry in Social Media & Content Platforms and avoid a duplicate listing.
- Follow the maintainer request in #501.

## Validation

- Ran `git diff --check`.
- Checked open Xquik issues and PRs in this repo before opening a new PR.
- Verified the current public Xquik repo metadata describes 100+ REST API endpoints, 23 extraction types, HMAC webhooks, SDKs, and MCP support.

Disclosure: I am affiliated with Xquik.
