### PR TITLE
Add Alisammour/storyflo-mcp (Art, Culture & Media)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Servers interacting with APIs for museums, media databases, image/video hosting,
 
 - [spritecook/spritecook-mcp](https://github.com/spritecook/spritecook-mcp): Generates pixel art sprites and animations for game developers, turning text prompts into game-ready characters, items, and sprite sheet animations.
 - [ourongxing/newsnow-mcp-server](https://github.com/ourongxing/newsnow-mcp-server): Facilitates access to over 40 news sources through a dedicated MCP server for NewsNow.
+- [Alisammour/storyflo-mcp](https://github.com/Alisammour/storyflo-mcp): Curated audio-news MCP server. Searches trending articles, fetches narrated audio, subscribes topic feeds. Free tier; premium briefings via x402 over USDC on Base mainnet. OAuth 2.1 + RFC 7591 DCR. Hosted at https://api.storyflo.com/mcp/v1.
 - [trevhud/vibe-mcp](https://github.com/trevhud/vibe-mcp): Generates music based on coding context with support for multiple audio backends and seamless playback.
 - [eluc1a/mcp-news](https://github.com/eluc1a/mcp-news): Facilitates access to categorized news articles from a database, enabling clients to retrieve and summarize the latest content.
 - [Toos00/freepik-mcp-server](https://github.com/Toos00/freepik-mcp-server): Facilitates interaction with Freepik.com's API for image and vector searches using the Model Context Protocol.

--- a/docs/art-culture--media.md
+++ b/docs/art-culture--media.md
@@ -2,6 +2,7 @@
 
 Servers interacting with APIs for museums, media databases, image/video hosting, or creative content platforms.
 
+- [Alisammour/storyflo-mcp](https://github.com/Alisammour/storyflo-mcp): Curated audio-news MCP server. Searches trending articles, fetches narrated audio, subscribes topic feeds. Free tier; premium briefings via x402 over USDC on Base mainnet. OAuth 2.1 + RFC 7591 DCR. Hosted at https://api.storyflo.com/mcp/v1.
 - [spritecook/spritecook-mcp](https://github.com/spritecook/spritecook-mcp): Generates pixel art sprites and animations for game developers, turning text prompts into game-ready characters, items, and sprite sheet animations.
 - [ourongxing/newsnow-mcp-server](https://github.com/ourongxing/newsnow-mcp-server): Facilitates access to over 40 news sources through a dedicated MCP server for NewsNow.
 - [trevhud/vibe-mcp](https://github.com/trevhud/vibe-mcp): Generates music based on coding context with support for multiple audio backends and seamless playback.


### PR DESCRIPTION
Storyflo — hosted MCP server for audio news + listener-forwarded newsletters.

**Endpoint:** `https://api.storyflo.com/mcp/v1` (streamable-http)
**Tools:** search_articles, get_article, get_audio_url, subscribe_topic, list_subscriptions, digest, get_premium_briefing
**Auth:** OAuth 2.1 + RFC 7591 DCR — self-registers from Claude Desktop, Cursor, Continue, Cline, ChatGPT custom connectors
**Pricing:** free tier free; premium metered via x402 over USDC on Base mainnet

Inserted under **Art, Culture & Media** next to existing news/media servers (newsnow, mcp-news, etc.).

**Also listed:** cursor.directory · Cline marketplace (#1536) · punkpeye/awesome-mcp-servers PR #6133 · npm storyflo-sdk · PyPI storyflo · GitHub Alisammour/storyflo-mcp