### PR TITLE
feat: add llm-prices — MCP server for LLM API pricing (138 models, 22 providers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Servers integrating with other AI models, AI platforms, RAG tools, prompt manage
 - [hlpun/Train-in-Silence](https://github.com/hlpun/Train-in-Silence): Task-aware MCP server for LLM fine-tuning providing VRAM/runtime/cost estimation and live multi-cloud GPU sniping.
 - [us-all/mlflow-mcp-server](https://github.com/us-all/mlflow-mcp-server) - MLflow MCP server with 82 tools across experiments, runs, registered models, model versions, traces, and assessments. MLflow 3 GenAI traces support and 5 workflow Prompts.
 
+- [benbencodes/llm-prices](https://github.com/benbencodes/llm-prices) - Look up and compare LLM API pricing across 138 models from 22 providers. Built-in MCP server with tools for cost calculation, model comparison, and budget planning. Zero dependencies, works offline.
 ## 🎨 Art, Culture & Media
 
 Servers interacting with APIs for museums, media databases, image/video hosting, or creative content platforms.


### PR DESCRIPTION
**[llm-prices](https://github.com/benbencodes/llm-prices)** is a zero-dependency Python CLI and MCP server for looking up and comparing LLM API pricing across 138 models from 22 providers.

Added to the **AI & LLM Integration** section.

- 6 MCP tools: `get_model_pricing`, `calculate_api_cost`, `compare_models`, `find_cheapest_models`, `list_providers`, `search_llm_models`
- Covers OpenAI, Anthropic, Google, Groq, Mistral, DeepSeek, xAI, Together, and 14 more
- Pure Python stdlib, zero dependencies, works completely offline

```bash
pip install "git+https://github.com/benbencodes/llm-prices[mcp]"
```