### PR TITLE
Add Dominion Observatory to Monitoring & Observability section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1048,6 +1048,7 @@ Servers connecting to monitoring systems, logging platforms, or providing system
 - [gkhays/mcp-sbom-server](https://github.com/gkhays/mcp-sbom-server): Generates a Software Bill of Materials (SBOM) using Trivy scans, outputting in CycloneDX format.
 - [smigolsmigol/llmkit](https://github.com/smigolsmigol/llmkit): AI cost tracking and budget enforcement MCP server with 11 tools for monitoring spend, session costs, and token usage across Claude Code, Cursor, and Cline.
 - [us-all/datadog-mcp-server](https://github.com/us-all/datadog-mcp-server) - Datadog observability MCP server with 165 tools across metrics, monitors, logs, APM, RUM, incidents, status pages, and fleet automation. 4 workflow Prompts and `incident-triage-snapshot` aggregation tool.
+- - [vdineshk/dominion-observatory](https://github.com/vdineshk/dominion-observatory): Behavioral trust scoring for MCP servers using runtime telemetry from real agent interactions. Tracks 4,586+ servers; provides trust_score (0–100), CTEF v0.3.2 §4.5 conformance validation, and behavioral drift detection via a free Cloudflare Workers API.
 
 ## 🖼️ Multimedia Processing
 


### PR DESCRIPTION
## What

Adds [Dominion Observatory](https://github.com/vdineshk/dominion-observatory) to the Monitoring & Observability section.

## Why

Dominion Observatory provides **behavioral trust scoring** for MCP servers — a capability not covered by any existing entry in this section. While current entries focus on log aggregation, error tracking, cost monitoring, and uptime checks, Observatory scores servers based on runtime telemetry from real agent interactions:

- **trust_score (0-100)** computed from actual agent call patterns, not static repo metadata
- - **CTEF v0.3.2 Section 4.5 conformance validation** — the only open tool implementing this emerging trust evaluation framework
- - **Behavioral drift detection** — flags servers whose runtime behavior deviates from declared capabilities
- - Tracks 4,586+ MCP servers via a free Cloudflare Workers API
## Category fit

Monitoring & Observability is the correct category: Observatory monitors MCP server behavior at runtime and provides observability into trust/compliance signals that static analysis cannot capture.

Drafted with AI assistance; reviewed and authored by vdineshk.