### PR TITLE
Add osc-bridge to Hardware & IoT

### DIFF
--- a/README.md
+++ b/README.md
@@ -796,6 +796,7 @@ Servers controlling hardware devices, interacting with embedded systems, serial 
 - [zerubeus/elektron-mcp](https://github.com/zerubeus/elektron-mcp): Facilitates interaction between LLMs and Elektron synthesizers via MIDI for real-time sound control and design.
 - [noboru-i/nature-remo-mcp-server](https://github.com/noboru-i/nature-remo-mcp-server): Facilitates automation and management of Nature Remo devices through the Model Context Protocol SDK.
 - [octoco-ltd/sheetsdata-mcp](https://github.com/octoco-ltd/sheetsdata-mcp): Instant access to electronic component datasheets for AI agents — specs, pinouts, package info, absolute max ratings extracted from manufacturer PDFs on demand.
+- [roomi-fields/osc-bridge](https://github.com/roomi-fields/osc-bridge): OSC ↔ MIDI/SysEx bridge for 849 hardware synthesizers plus music software (Ableton, Bitwig, Reaper, SuperCollider…). A MIDI MCP and OSC MCP — discover devices, read their named control surface, and send OSC to drive them. `npx -y @roomi-fields/osc-bridge mcp`
 
 ## ❤️ Healthcare & Life Sciences
 

--- a/docs/hardware--iot.md
+++ b/docs/hardware--iot.md
@@ -60,4 +60,5 @@ Servers controlling hardware devices, interacting with embedded systems, serial 
 - [miguelg719/home-assistant-mcp](https://github.com/miguelg719/home-assistant-mcp): Integrates with Home Assistant to enable smart home control through an MCP server, supporting functionalities like lighting, climate, and security system management.
 - [allenporter/mcp-server-home-assistant](https://github.com/allenporter/mcp-server-home-assistant): Facilitates seamless integration of Home Assistant with the Model Context Protocol for enhanced smart home automation.
 - [octoco-ltd/sheetsdata-mcp](https://github.com/octoco-ltd/sheetsdata-mcp): Instant access to electronic component datasheets for AI agents — specs, pinouts, package info, absolute max ratings extracted from manufacturer PDFs on demand.
+- [roomi-fields/osc-bridge](https://github.com/roomi-fields/osc-bridge): OSC ↔ MIDI/SysEx bridge for 849 hardware synthesizers plus music software (Ableton, Bitwig, Reaper, SuperCollider…). A MIDI MCP and OSC MCP — discover devices, read their named control surface, and send OSC to drive them. `npx -y @roomi-fields/osc-bridge mcp`
 


### PR DESCRIPTION
Adds **osc-bridge** under ⚙️ Hardware & IoT.

[roomi-fields/osc-bridge](https://github.com/roomi-fields/osc-bridge) is an OSC ↔ MIDI/SysEx bridge: a declarative driver catalogue covering **849 hardware synthesizers** plus music software (Ableton, Bitwig, Reaper, Sonic Pi, SuperCollider, Pure Data, TouchDesigner, VCV Rack). Its built-in MCP server (`npx -y @roomi-fields/osc-bridge mcp`) lets an LLM discover devices, read each one's named OSC control surface, and send OSC to drive them — a MIDI MCP and an OSC MCP.

- Open source (GPL-3.0), published on npm and the official MCP registry.
- Searched the list — no existing entry.
- Placed in Hardware & IoT alongside `zerubeus/elektron-mcp` (the closest neighbour).