### PR TITLE
Add AI Skill Store (garasegae/aiskillstore) to AI & LLM Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Servers integrating with other AI models, AI platforms, RAG tools, prompt manage
 - [hlpun/Train-in-Silence](https://github.com/hlpun/Train-in-Silence): Task-aware MCP server for LLM fine-tuning providing VRAM/runtime/cost estimation and live multi-cloud GPU sniping.
 - [us-all/mlflow-mcp-server](https://github.com/us-all/mlflow-mcp-server) - MLflow MCP server with 82 tools across experiments, runs, registered models, model versions, traces, and assessments. MLflow 3 GenAI traces support and 5 workflow Prompts.
 - [tolegm/astranl-mcp](https://github.com/tolegm/astranl-mcp) - AI inference dispatch aggregator routing tasks to Anthropic, OpenAI, Gemini, and xAI Grok. Flat per-task pricing (€0.005-€0.05). 9 MCP tools.
+- [garasegae/aiskillstore](https://github.com/garasegae/aiskillstore) - Agent-first AI skill marketplace with open USK standard. Search, install, and share reusable skills across 7 platforms (Claude Code, Cursor, Codex CLI, Windsurf, Cline, Roo Code) via MCP. Features skill vetting, agent-autonomous upload, and cross-platform discovery.
 
 ## 🎨 Art, Culture & Media
 

--- a/docs/ai--llm-integration.md
+++ b/docs/ai--llm-integration.md
@@ -1615,5 +1615,6 @@ Servers integrating with other AI models, AI platforms, RAG tools, prompt manage
 - [aidenmi8/aiservers](https://github.com/aidenmi8/aiservers): Showcases diverse MCP server implementations for secure LLM access to tools and data sources.
 
 - [hol-org/hashnet-mcp](https://github.com/hashgraph-online/hashnet-mcp-js): MCP server for discovering AI agents across NANDA, MCP, Virtuals, A2A, and ERC-8004 registries using the Registry Broker API.
+- [garasegae/aiskillstore](https://github.com/garasegae/aiskillstore) - Agent-first AI skill marketplace with open USK standard. Search, install, and share reusable skills across 7 platforms (Claude Code, Cursor, Codex CLI, Windsurf, Cline, Roo Code) via MCP. Features skill vetting, agent-autonomous upload, and cross-platform discovery.
 - [hlpun/Train-in-Silence](https://github.com/hlpun/Train-in-Silence): Task-aware MCP server for LLM fine-tuning providing VRAM/runtime/cost estimation and live multi-cloud GPU sniping.
 - [tolegm/astranl-mcp](https://github.com/tolegm/astranl-mcp) - AI inference dispatch aggregator routing tasks to Anthropic, OpenAI, Gemini, and xAI Grok. Flat per-task pricing (€0.005-€0.05). 9 MCP tools.


### PR DESCRIPTION
## What is AI Skill Store?

AI Skill Store is an agent-first AI skill marketplace with an open USK (Universal Skill Kit) standard. It enables AI agents and developers to search, install, and share reusable skills across 7 platforms: Claude Code, Cursor, Codex CLI, Windsurf, Cline, and Roo Code.

**Key features:**
- Agent-autonomous skill discovery and installation via MCP
- - Open USK standard for cross-platform skill compatibility
- - Skill vetting and quality assurance
- - Agent-to-agent skill upload capability
**Links:**
- Website: https://www.aiskillstore.io
- - GitHub: https://github.com/garasegae/aiskillstore
- - MCP Server: Available on multiple registries (Smithery, mcp.so, Glama, etc.)
Closes #482