### PR TITLE
Add Émile (wine cellar MCP) to Art, Culture & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Servers interacting with APIs for museums, media databases, image/video hosting,
 - [opensourcedev90s/uk-science-museum-group-mcp](https://github.com/opensourcedev90s/uk-science-museum-group-mcp): Facilitates data retrieval from the UK Science Museum Group API for LLMs via a Python-based MCP server.
 - [AnshulDalua/illustrator-mcp](https://github.com/AnshulDalua/illustrator-mcp): Facilitates script execution in Adobe Illustrator via MCP, leveraging JavaScript and AppleScript on MacOS.
 - [hugeicons/mcp-server](https://github.com/hugeicons/mcp-server): Facilitates seamless integration of Hugeicons across various platforms by providing tools, resources, and platform-specific guides for AI assistants.
-- [SebastienGal/emile-app](https://github.com/SebastienGal/emile-app/tree/main/mcp): Émile — personal wine cellar MCP. 10 tools to list, add, recommend, scan and search across a 100k+ wine catalog. Stdio via `npx @emile-wine/mcp-server` or OAuth-protected remote at https://mcp.emile.wine/mcp. Listed on the Official MCP Registry as `io.github.SebastienGal/emile-wine`.
+- [emile-wine/mcp-server](https://emile.wine/mcp/): Émile — personal wine cellar MCP. 10 tools to list, add, recommend, scan and search across a 100k+ wine catalog. Stdio via [`npx @emile-wine/mcp-server`](https://www.npmjs.com/package/@emile-wine/mcp-server) or OAuth-protected remote at https://mcp.emile.wine/mcp. Listed on the Official MCP Registry as `io.github.SebastienGal/emile-wine`.
 
 ## 🌐 Browser Automation & Web Scraping
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Servers interacting with APIs for museums, media databases, image/video hosting,
 - [opensourcedev90s/uk-science-museum-group-mcp](https://github.com/opensourcedev90s/uk-science-museum-group-mcp): Facilitates data retrieval from the UK Science Museum Group API for LLMs via a Python-based MCP server.
 - [AnshulDalua/illustrator-mcp](https://github.com/AnshulDalua/illustrator-mcp): Facilitates script execution in Adobe Illustrator via MCP, leveraging JavaScript and AppleScript on MacOS.
 - [hugeicons/mcp-server](https://github.com/hugeicons/mcp-server): Facilitates seamless integration of Hugeicons across various platforms by providing tools, resources, and platform-specific guides for AI assistants.
+- [SebastienGal/emile-app](https://github.com/SebastienGal/emile-app/tree/main/mcp): Émile — personal wine cellar MCP. 10 tools to list, add, recommend, scan and search across a 100k+ wine catalog. Stdio via `npx @emile-wine/mcp-server` or OAuth-protected remote at https://mcp.emile.wine/mcp. Listed on the Official MCP Registry as `io.github.SebastienGal/emile-wine`.
 
 ## 🌐 Browser Automation & Web Scraping
 


### PR DESCRIPTION
Adds [Émile](https://emile.wine), a personal wine cellar MCP server, to the **Art, Culture & Media** section (wine = culinary culture; closest fit alongside hotpepper-gourmet).

**What it does** — 10 tools to manage a personal wine cellar from any MCP client:
- `search_wines` — fuzzy search against a 100k+ wine catalog
- `list_cellars` / `list_bottles` — inventory queries
- `recommend_bottles` — sommelier-style pairing recommendations from the user's *own* bottles
- `add_bottle` / `add_bottles_batch` / `update_bottle` / `delete_bottle` — inventory writes
- `scan_label` / `scan_labels_batch` — identify wines from photos (vision LLM)

**Distribution**:
- Local stdio: `npx -y @emile-wine/mcp-server` ([npm](https://www.npmjs.com/package/@emile-wine/mcp-server))
- Remote streamable-HTTP: `https://mcp.emile.wine/mcp` (OAuth 2.1 + PKCE + DCR)
- Docs + install instructions: https://emile.wine/mcp/

**Note on the link target**: source code is closed-source for now, so the entry points to the product/docs page rather than a GitHub repo. The npm package is fully published and inspectable. Same approach as several other proprietary MCP entries in the list.

**Also**:
- Listed on the [Official MCP Registry](https://registry.modelcontextprotocol.io) as `io.github.SebastienGal/emile-wine`
- All 10 tools declare `outputSchema` and accurate `readOnlyHint` / `destructiveHint` / `openWorldHint` annotations
- Submitted to Anthropic Connectors Directory + ChatGPT Apps (in review)
- Privacy policy: https://api.emile.wine/privacy
- License: MIT

Happy to move to a different category if Art/Culture isn't the right fit — let me know.