### PR TITLE
Add saml7n/parbaked to Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -736,6 +736,7 @@ Toolkits, SDKs, starter templates, or code frameworks designed to help developer
 - [mgd1984/cursor-rules](https://github.com/mgd1984/cursor-rules): Facilitates the integration of Cursor Rules MCP server for consistent development guidance in Next.js applications with TypeScript.
 - [wewei/skill-set](https://github.com/wewei/skill-set): A Model Context Protocol server built with mcp-framework, enabling the creation and integration of custom tools for enhanced functionality.
 - [us-all/mcp-toolkit](https://github.com/us-all/mcp-toolkit) - Shared library for MCP server authors with token-efficient defaults: category toggles, extractFields response slimming, search-tools meta-tool, ToolRegistry, and runtime helper supporting stdio + Streamable HTTP transports.
+- [saml7n/parbaked](https://github.com/saml7n/parbaked) - Agent-native FastAPI scaffold for invite-only Python apps. 15 MCP tools to scaffold a project, add routes + SQLModel tables, run dev, manage users (approve/reject/reset), check email/deploy status, and ship to fly.io. Install: `uv tool install parbaked && parbaked mcp`.
 
 ## 🎮 Gaming
 

--- a/docs/frameworks.md
+++ b/docs/frameworks.md
@@ -244,4 +244,5 @@ Toolkits, SDKs, starter templates, or code frameworks designed to help developer
 - [ivo-toby/mcp-openapi-server](https://github.com/ivo-toby/mcp-openapi-server): Transforms OpenAPI specifications into MCP resources, enabling seamless interaction with REST APIs via the MCP protocol.
 - [masacento/mcp-go-example](https://github.com/masacento/mcp-go-example): A Go-based example server for the Model Context Protocol, designed for educational purposes with no security or multiuser support.
 - [Resources-cskwork/model-context-protocol-demo](https://github.com/Resources-cskwork/model-context-protocol-demo): Demonstrates the integration of Model Context Protocol with SQLite for database management in Claude Desktop.
+- [saml7n/parbaked](https://github.com/saml7n/parbaked) - Agent-native FastAPI scaffold for invite-only Python apps. 15 MCP tools to scaffold a project, add routes + SQLModel tables, run dev, manage users (approve/reject/reset), check email/deploy status, and ship to fly.io. Install: `uv tool install parbaked && parbaked mcp`.
 


### PR DESCRIPTION
Adds [parbaked](https://github.com/saml7n/parbaked) — an opinionated, agent-native FastAPI scaffold for invite-only Python apps — to the **🧰 Frameworks** category.

**Why Frameworks:** parbaked is a Python web framework whose primary user interface is its MCP server. An agent in Claude Desktop / Cursor / Codex installs it with `uv tool install parbaked && parbaked mcp`, then has 15 MCP tools to scaffold a project, add routes + SQLModel tables, run the dev server, manage users (approve/reject/reset), check email/deploy status, and ship to fly.io — without leaving the IDE.

**Tools exposed:** `scaffold`, `add_route`, `add_model`, `users_list`, `users_show`, `users_approve`, `users_reject`, `users_issue_reset`, `admin_signin`, `eject`, `email_setup_status`, `deploy_status`, `status`, `dev`, `deploy`.