### PR TITLE
Add mailbox.bot MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,7 @@ Servers for interacting with email, chat platforms, SMS, or notification service
 - [wazionapps/mcp-server](https://github.com/wazionapps/mcp-server): WAzion - WhatsApp Business platform with 244 MCP tools for messaging, CRM, campaigns, workflows, and AI automation. Supports Streamable HTTP and stdio transports.
 - [littlebearapps/outlook-assistant](https://github.com/littlebearapps/outlook-assistant): MCP server for Microsoft Outlook with 20 consolidated tools for email, calendar, contacts, and mailbox management via Graph API. Features dry-run preview, session rate limiting, and recipient allowlists for safe email sending.
 - [nylas/cli](https://github.com/nylas/cli): MCP server for email, calendar, and contacts. 16 tools across Gmail, Outlook, Exchange, Yahoo, iCloud, and IMAP via a single auth flow. JSON output, install with `nylas mcp install`, works with Claude Code, Cursor, Codex, and Windsurf. Docs at https://cli.nylas.com.
+- [mailbox.bot](https://mailbox.bot/mcp-install): Remote MCP server for AI agents to send physical postal mail, certified mail, postcards, and batch mailings with cost previews, approval controls, tracking, webhooks, and proof workflows.
 
 ## 📝 Content Management Systems
 

--- a/docs/communication--messaging.md
+++ b/docs/communication--messaging.md
@@ -325,4 +325,4 @@ Servers for interacting with email, chat platforms, SMS, or notification service
 - [speakeasy-api/bluesky-ts](https://github.com/speakeasy-api/bluesky-ts): A TypeScript SDK for Bluesky API, offering a developer-friendly, type-safe interface with MCP server capabilities for AI applications.
 - [wazionapps/mcp-server](https://github.com/wazionapps/mcp-server): WAzion - WhatsApp Business platform with 244 MCP tools for messaging, CRM, campaigns, workflows, and AI automation. Supports Streamable HTTP and stdio transports.
 - [littlebearapps/outlook-assistant](https://github.com/littlebearapps/outlook-assistant): MCP server for Microsoft Outlook with 20 consolidated tools for email, calendar, contacts, and mailbox management via Graph API. Features dry-run preview, session rate limiting, and recipient allowlists for safe email sending.
-
+- [mailbox.bot](https://mailbox.bot/mcp-install): Remote MCP server for AI agents to send physical postal mail, certified mail, postcards, and batch mailings with cost previews, approval controls, tracking, webhooks, and proof workflows.


### PR DESCRIPTION
Adds mailbox.bot to Communication & Messaging. It is a hosted remote MCP server for AI agents to send physical postal mail, certified mail, postcards, and batch mailings with cost previews, approval controls, tracking, webhooks, and proof workflows.