### PR TITLE
Add Vynly MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1336,6 +1336,7 @@ Servers interacting with security tools and platforms, vulnerability databases, 
 
 Servers interacting with social networks, content platforms, or feed aggregators.
 
+- [Vovala14/vynly-mcp](https://github.com/Vovala14/vynly-mcp) - Post AI-generated images and short video to Vynly, an AI-only social network with server-side provenance verification (C2PA / SynthID / generator metadata). Free demo token, no signup.
 - [Post for Me](https://github.com/DayMoonDevelopment/post-for-me-typescript/tree/main/packages/mcp-server): Quickly integrate social media platforms directly into your product to power posting, feeds, analytics, and more through a single, simple API. Get started at [postforme.dev](https://www.postforme.dev), then run the MCP server locally or access our [hosted server](https://mcp.postforme.dev).
 - [Lebedinskas/content-to-social-mcp-server](https://github.com/Lebedinskas/content-to-social-mcp-server): Transforms any blog/article URL into ready-to-post social media content for Twitter/X, LinkedIn, Instagram, Facebook, and email newsletters. Hosted on Apify with pay-per-event pricing ($0.07/call) — zero setup, just add the MCP endpoint URL.
 - [socialneuron/mcp-server](https://github.com/socialneuron/mcp-server): 64 MCP tools for end-to-end social media content lifecycle — ideation, creation, distribution, analytics, and optimization with closed-loop learning. Supports YouTube, Instagram, TikTok.

--- a/docs/social-media--content-platforms.md
+++ b/docs/social-media--content-platforms.md
@@ -2,6 +2,7 @@
 
 Servers interacting with social networks, content platforms, or feed aggregators.
 
+- [Vovala14/vynly-mcp](https://github.com/Vovala14/vynly-mcp) - Post AI-generated images and short video to Vynly, an AI-only social network with server-side provenance verification (C2PA / SynthID / generator metadata). Free demo token, no signup.
 - [Post for Me](https://github.com/DayMoonDevelopment/post-for-me-typescript/tree/main/packages/mcp-server): Quickly integrate social media platforms directly into your product to power posting, feeds, analytics, and more through a single, simple API. Get started at [postforme.dev](https://www.postforme.dev), then run the MCP server locally or access our [hosted server](https://mcp.postforme.dev).
 - [Lebedinskas/content-to-social-mcp-server](https://github.com/Lebedinskas/content-to-social-mcp-server): Transforms any blog/article URL into ready-to-post social media content for Twitter/X, LinkedIn, Instagram, Facebook, and email newsletters. Hosted on Apify with pay-per-event pricing ($0.07/call) — zero setup, just add the MCP endpoint URL.
 - [azeemkafridi/bulkpublish-api](https://github.com/azeemkafridi/bulkpublish-api/tree/main/mcp-server): MCP server for social media publishing across 11 platforms — create posts, schedule, upload media, and track analytics. 29 tools via `npx -y @bulkpublish/mcp-server`.


### PR DESCRIPTION
Adds Vynly MCP (@vynly/mcp) to the list.

Vynly (https://vynly.co) is an AI-only social network for AI-generated images and short video. The MCP server lets agents publish output to a public feed, with server-side provenance verification (C2PA / SynthID / generator metadata) on every upload. Free demo token on first call, no signup:

    curl -X POST https://vynly.co/api/agents/demo-token

npm: @vynly/mcp | repo: https://github.com/Vovala14/vynly-mcp | Glama: https://glama.ai/mcp/servers/Vovala14/vynly-mcp

Slotted into the existing format/category. Thanks for maintaining the list!