### PR TITLE
Add mcpproxy-go to Infrastructure

### DIFF
--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -155,4 +155,5 @@ Servers or systems that deliver core runtime functionalities for MCP, such as pr
 - [Flux159/mcp-server-kubernetes](https://github.com/Flux159/mcp-server-kubernetes): Facilitates Kubernetes cluster management through a robust MCP server, enabling seamless interaction with Kubernetes resources and Helm charts.
 - [netcaster1/e2b-mcp](https://github.com/netcaster1/e2b-mcp): A secure sandbox environment for executing code using the Model Context Protocol, tailored for integration with Claude Desktop.
 - [kswap/consul-mcp](https://github.com/kswap/consul-mcp): Facilitates Consul service discovery and mesh integration through an MCP server interface.
+- [smart-mcp-proxy/mcpproxy-go](https://github.com/smart-mcp-proxy/mcpproxy-go): Local-first MCP proxy/gateway with BM25 tool discovery (~99% token savings), security quarantine (tool-poisoning protection), sensitive-data scanning, Docker isolation, OAuth 2.1, and a web UI.
 


### PR DESCRIPTION
## What

Adds [mcpproxy-go](https://github.com/smart-mcp-proxy/mcpproxy-go) to the Infrastructure section.

## Entry

```
- [smart-mcp-proxy/mcpproxy-go](https://github.com/smart-mcp-proxy/mcpproxy-go): Local-first MCP proxy/gateway with BM25 tool discovery (~99% token savings), security quarantine (tool-poisoning protection), sensitive-data scanning, Docker isolation, OAuth 2.1, and a web UI.
```

## Why Infrastructure

mcpproxy-go acts as a local proxy/gateway that sits between MCP clients and upstream MCP servers — exactly the proxying/aggregation/routing use case the Infrastructure category describes.

## Project details

- Repo: https://github.com/smart-mcp-proxy/mcpproxy-go
- Website: https://mcpproxy.app
- Language: Go
- License: MIT
- Version: v0.33.1
- Stars: 229