### PR TITLE
[codex] Add ResultRail MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,7 @@ Servers specifically designed to interact with CMS platforms.
 
 Servers connecting to data warehouses, data query engines, analytics platforms, or specific data APIs.
 
+- [LarryLemonBot/resultrail-mcp-server](https://github.com/LarryLemonBot/resultrail-mcp-server): Hosted ResultRail MCP metadata for pay-per-success public-data result packs with source URLs, confidence, receipt hashes, and x402 payment.
 - [Whatsonyourmind/oraclaw](https://github.com/Whatsonyourmind/oraclaw): Decision intelligence for AI agents — 19 algorithms (bandits, constraint solvers, Monte Carlo simulation, forecasting, anomaly detection, risk analysis), 12 MCP tools, sub-25ms, zero LLM cost. Install: `npx @oraclaw/mcp-server`.
 - [feriadosapi/mcp-server](https://mcp.feriadosapi.com): Brazilian holidays MCP server covering 5,570+ municipalities, 27 states, and national holidays. Returns holiday data by date, state, or city (IBGE code).
 - [rotatingshov/go-mcp-mysql](https://github.com/rotatingshov/go-mcp-mysql): Effortlessly manage MySQL databases with a Go-based MCP server, offering CRUD operations and automation without the need for Node.js or Python.

--- a/docs/data-analysis--business-intelligence.md
+++ b/docs/data-analysis--business-intelligence.md
@@ -2,6 +2,7 @@
 
 Servers connecting to data warehouses, data query engines, analytics platforms, or specific data APIs.
 
+- [LarryLemonBot/resultrail-mcp-server](https://github.com/LarryLemonBot/resultrail-mcp-server): Hosted ResultRail MCP metadata for pay-per-success public-data result packs with source URLs, confidence, receipt hashes, and x402 payment.
 - [us-all/openmetadata-mcp-server](https://github.com/us-all/openmetadata-mcp-server) - OpenMetadata MCP server with 170 tools across metadata, lineage, search, data quality, sample data, and OM 1.12+ Data Contracts. Includes `lineage-impact` and `quality-rollup` aggregations.
 - [us-all/dbt-mcp-server](https://github.com/us-all/dbt-mcp-server): dbt MCP server with 22 read-only tools across `manifest.json` / `run_results.json` / `sources.json` / `catalog.json` (model/test/source introspection, run-history analysis, slow models, per-column test coverage, lineage walks) plus 5 DQ result-table tools (BigQuery + Postgres lazy peer imports). 4 triage Prompts and 4 aggregations.
 - [us-all/airflow-mcp-server](https://github.com/us-all/airflow-mcp-server): Airflow MCP for the Airflow 3.x `/api/v2` REST API with JWT auth (SimpleAuthManager). 7 tools (DAG list, runs, task instances, log tails, trigger, clear) plus `dag-health-rollup` aggregation and 2 triage Prompts. Read-only by default; trigger/clear gated by `AIRFLOW_ALLOW_WRITE`.


### PR DESCRIPTION
## Summary
- add ResultRail to the Data Analysis & Business Intelligence category
- include the public ResultRail metadata repository in both README.md and the category doc

## Validation
- ran `git diff --check`
- confirmed the ResultRail metadata repository is public: https://github.com/LarryLemonBot/resultrail-mcp-server