### PR TITLE
Add Claude Omakase

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,6 +522,7 @@ Servers providing interfaces to various database types like SQL, NoSQL, Vector D
 Servers enhancing developer workflows, integrating with IDEs, accessing documentation, API exploration, code generation helpers, or general dev utilities.
 
 - [incultnitollc/mcp-probe](https://github.com/incultnitollc/mcp-probe) - CLI health-check for MCP servers. Enumerates tools/resources/prompts, calls them, validates schemas, prints pass/fail scorecard. CI-friendly (exits 0/1).
+- [gyuch-an02/claude-omakase](https://github.com/gyuch-an02/claude-omakase) - MCP server plus bundled Claude skill that recommends and installs Claude Code skills from a federated catalog after explicit user approval.
 - [lazymac2x/lazymac-mcp](https://github.com/lazymac2x/lazymac-mcp) — Unified MCP server exposing 42+ developer tools (qr, ip-geo, ai-cost, llm-router, k-privacy, korean-nlp) backed by Cloudflare Workers. `npx -y @lazymac/mcp`
 - [lazymac2x/lazymac-k-mcp](https://github.com/lazymac2x/lazymac-k-mcp) — Korean wedge MCP — PIPA compliance, KRW + BOK rates, 사업자등록번호 lookup, address geocoding, NLP. `npx -y @lazymac/k-mcp`
 - [cafeTechne/antigravity-link-extension](https://github.com/cafeTechne/antigravity-link-extension): MCP server + OpenAPI API to control Antigravity IDE instances (snapshot, send, stop generation, switch instance, task/walkthrough/plan retrieval) with a mobile companion UI.

--- a/README.md
+++ b/README.md
@@ -522,7 +522,7 @@ Servers providing interfaces to various database types like SQL, NoSQL, Vector D
 Servers enhancing developer workflows, integrating with IDEs, accessing documentation, API exploration, code generation helpers, or general dev utilities.
 
 - [incultnitollc/mcp-probe](https://github.com/incultnitollc/mcp-probe) - CLI health-check for MCP servers. Enumerates tools/resources/prompts, calls them, validates schemas, prints pass/fail scorecard. CI-friendly (exits 0/1).
-- [gyuch-an02/claude-omakase](https://github.com/gyuch-an02/claude-omakase) - MCP server plus bundled Claude skill that recommends and installs Claude Code skills from a federated catalog after explicit user approval.
+- [gyuch-an02/claude-omakase](https://github.com/gyuch-an02/claude-omakase) — MCP server plus bundled Claude skill that recommends and installs Claude Code skills from a federated catalog after explicit user approval.
 - [lazymac2x/lazymac-mcp](https://github.com/lazymac2x/lazymac-mcp) — Unified MCP server exposing 42+ developer tools (qr, ip-geo, ai-cost, llm-router, k-privacy, korean-nlp) backed by Cloudflare Workers. `npx -y @lazymac/mcp`
 - [lazymac2x/lazymac-k-mcp](https://github.com/lazymac2x/lazymac-k-mcp) — Korean wedge MCP — PIPA compliance, KRW + BOK rates, 사업자등록번호 lookup, address geocoding, NLP. `npx -y @lazymac/k-mcp`
 - [cafeTechne/antigravity-link-extension](https://github.com/cafeTechne/antigravity-link-extension): MCP server + OpenAPI API to control Antigravity IDE instances (snapshot, send, stop generation, switch instance, task/walkthrough/plan retrieval) with a mobile companion UI.

--- a/docs/developer-productivity--utilities.md
+++ b/docs/developer-productivity--utilities.md
@@ -3,6 +3,7 @@
 Servers enhancing developer workflows, integrating with IDEs, accessing documentation, API exploration, code generation helpers, or general dev utilities.
 
 - [incultnitollc/mcp-probe](https://github.com/incultnitollc/mcp-probe) - CLI health-check for MCP servers. Enumerates tools/resources/prompts, calls them, validates schemas, prints pass/fail scorecard. CI-friendly (exits 0/1).
+- [gyuch-an02/claude-omakase](https://github.com/gyuch-an02/claude-omakase) — MCP server plus bundled Claude skill that recommends and installs Claude Code skills from a federated catalog after explicit user approval.
 - [olo-dot-io/Uni-CLI](https://github.com/olo-dot-io/Uni-CLI): Self-repairing CLI catalog that exposes web, desktop apps, Electron apps, and bridge CLIs as deterministic commands through one MCP server. Declarative YAML adapters with structured error envelopes let agents fix failing adapters and retry. Live catalog size and per-call token budget tracked in the repo's README and `docs/BENCHMARK.md`.
 - [sarveshsea/m-moire](https://github.com/sarveshsea/m-moire): MCP server and CLI for shadcn-native Design CI. Diagnose UI debt, extract Tailwind tokens, export shadcn registries, and plan safe UI fixes.
 - [dejuknow/md-redline](https://github.com/dejuknow/md-redline): Inline review comments for markdown specs and design docs. Agents request human review mid-task via MCP and pause until you send feedback. Comments stored as invisible HTML markers in the markdown file itself.


### PR DESCRIPTION
Adds Claude Omakase to the Developer Productivity & Utilities section.

Claude Omakase is a small MCP server plus bundled Claude skill that helps Claude recommend and install Claude Code skills from a federated catalog, with explicit user approval before writing to `~/.claude/skills/`.

Why it belongs in this list:

- It is an MCP server intended for Claude users and Claude Code workflows.
- It focuses on developer productivity: repeated-task detection, skill discovery, and approved skill installation.
- Its catalog is federated through adapter modules rather than maintained only as a static list.
- The project now includes a contributor quickstart for adding a new catalog adapter in about 30 minutes.

Hackathon validation notes:

- The adapter onboarding path was tested through the G10 timing/DX pass in `gyuch-an02/claude-omakase#26`.
- The resulting DX PR added `npm run scaffold:adapter -- <source-name>` so first-time contributors can generate an adapter module and beside-file test from one command.
- Final CI for that PR passed in 16 seconds.
- Local validation passed with 20 tests.
- The adapter smoke report showed 3 entries, 3 passed, 0 failed, and 0 skipped.

This follows the list format with a single repository link and one-sentence description.
