### PR TITLE
Add registry API MVP

### DIFF
--- a/.github/workflows/deploy-registry-api.yml
+++ b/.github/workflows/deploy-registry-api.yml
@@ -1,0 +1,76 @@
+name: Deploy Registry API
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/deploy-registry-api.yml"
+      - "README.md"
+      - "data/**"
+      - "docs/**"
+      - "package-lock.json"
+      - "package.json"
+      - "packages/**"
+      - "railway.json"
+      - "schemas/**"
+      - "tsconfig.base.json"
+      - "vitest.config.ts"
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Build and deploy registry API
+    runs-on: ubuntu-latest
+    env:
+      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+      RAILWAY_PROJECT_ID: d0179e2b-95d8-47cc-be7b-abc178a80948
+      RAILWAY_SERVICE_ID: ca56cfa7-79a4-4fd1-8ef2-6a918cba40bb
+      RAILWAY_ENVIRONMENT: production
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate catalog
+        run: npm run catalog:build
+
+      - name: Generate profiles
+        run: npm run profiles:build
+
+      - name: Test
+        run: npm test
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy to Railway
+        if: env.RAILWAY_TOKEN != ''
+        run: >
+          railway up
+          --project "$RAILWAY_PROJECT_ID"
+          --service "$RAILWAY_SERVICE_ID"
+          --environment "$RAILWAY_ENVIRONMENT"
+          --detach
+          --message "Deploy registry API from ${GITHUB_SHA}"
+
+      - name: Missing Railway token
+        if: env.RAILWAY_TOKEN == ''
+        run: |
+          echo "RAILWAY_TOKEN secret is required to deploy the registry API."
+          exit 1

--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@
 
 <div style="text-align: left; margin: 20px 0;">
     <a href="https://discord.com/invite/Ej5NmeHFf2" style="display: inline-block; padding: 10px 20px; background-color: #5865F2; color: white; text-decoration: none; border-radius: 5px; font-weight: bold;">
-        Join our Discord to learn more about what we're building ↗
+        Join the TensorBlock Discord
     </a>
 </div>
 <div style="text-align: left; margin: 20px 0;">
     <a href="https://github.com/TensorBlock/forge" style="display: inline-block; padding: 10px 20px; background-color: #24292e; color: white; text-decoration: none; border-radius: 5px; font-weight: bold;">
-         ✨✨✨ Learn more about Forge - an open-source middleware service that simplifies AI model provider management. ✨✨✨
+        Explore Forge, our open-source middleware for AI model provider management
     </a>
 </div>
-A comprehensive, community-curated collection of [Model Context Protocol (MCP)](https://modelcontextprotocol.io) servers — covering AI assistants, browser automation, databases, cloud platforms, developer tools, and much more.
+TensorBlock MCP Index turns this community-curated MCP server directory into a hosted, searchable registry for agents and applications. Contributors add servers in markdown; TensorBlock normalizes the entries, generates structured profiles and install-config previews, and serves the index through a free public API.
 
-> **What is MCP?** The Model Context Protocol is an open standard that lets AI models securely connect to external tools, APIs, databases, and filesystems. Think of it as a USB-C port for AI — a universal interface that any model can use to interact with the world.
+**Hosted API:** [https://mcp-index.tensorblock.co](https://mcp-index.tensorblock.co)
 
 ## Coverage
 
@@ -28,13 +28,49 @@ This repo currently indexes **7,493 unique MCP server links** from the category 
 
 This repo is both a community directory and an agent-ready index. Humans add MCP servers in markdown category pages; the indexer turns those entries into structured data that agents can search, inspect, and use to draft install configs.
 
-How it works:
+### Hosted MCP Index API
+
+TensorBlock provides the MCP Index API as free community infrastructure. We contribute the compute, hosting, data normalization, and ongoing maintenance needed to make this directory usable by agents and applications without requiring every user to clone the repo or parse markdown.
+
+Base URL:
+
+```text
+https://mcp-index.tensorblock.co
+```
+
+Useful endpoints:
+
+- `GET /` - discover available endpoints and current catalog size.
+- `GET /v1/categories` - list categories with entry counts and source docs.
+- `GET /v1/servers?query=postgres&limit=5` - search servers by name, description, category, or URL.
+- `GET /v1/servers?category=Databases&transport=stdio` - filter by category, transport, auth type, and result limit.
+- `GET /v1/servers/{id}` - fetch the normalized profile for one MCP server.
+- `GET /v1/servers/{id}/install-config?client=claude-desktop` - generate an MCP client config for Claude Desktop, Cursor, Codex, or VS Code.
+
+What the API supports today:
+
+- Search MCP servers by keyword.
+- Filter by category, transport, auth type, and result limit.
+- Browse all categories with entry counts.
+- Fetch a normalized server profile by stable server id.
+- Generate install-config previews for Claude Desktop, Cursor, Codex, and VS Code.
+
+We want this registry to support more MCP clients and installation formats over time. If you want another client, package manager, transport, auth flow, or metadata field supported, please open an issue or PR with the expected config shape and examples.
+
+We plan to keep investing in this hosted registry: improving metadata quality, expanding install-config coverage, adding verification signals, and keeping the service available for the MCP community. Contributors are welcome to help build the registry by adding servers, improving metadata, reporting bad entries, and proposing better search or verification workflows. When changes land on `main`, the deploy workflow rebuilds the catalog and profiles before publishing, so newly merged server entries become searchable after the Railway deployment succeeds.
+
+How entries become index data:
 
 1. The source of truth is the category markdown under `docs/*.md`.
 2. Each server entry is parsed from a markdown bullet with a link and description.
 3. `npm run catalog:build` generates `data/catalog.json` with normalized server metadata.
 4. `npm run profiles:build` generates `data/profiles/*.json` for stable per-server profiles.
-5. `npm run registry:mcp` starts a local registry MCP server with `search_servers`, `get_server_profile`, and `get_install_config` tools.
+5. The deploy workflow publishes the refreshed catalog to the hosted API after changes land on `main`.
+
+For local development:
+
+- `npm run registry:mcp` starts a local registry MCP server with `search_servers`, `get_server_profile`, and `get_install_config` tools.
+- `npm run registry:api:dev` starts a local HTTP API for search, category browsing, profiles, and install configs. See [TensorBlock MCP Index API](docs/index-api.md).
 
 That means contributors still submit a normal awesome-list entry, but better metadata makes the entry more useful to agents. When possible, include install command, transport, auth type, supported clients, tool count, license, docs URL, and public remote endpoint. See the [MCP Index Metadata Contribution Guide](docs/index-alpha/contribution-guide.md) for examples.
 
@@ -68,6 +104,7 @@ npm run catalog:build
 npm run profiles:build
 npm test
 npm run typecheck
+npm run build
 ```
 
 ## Browse by Category

--- a/docs/index-api.md
+++ b/docs/index-api.md
@@ -1,0 +1,77 @@
+# TensorBlock MCP Index API
+
+The TensorBlock MCP Index API exposes the generated catalog as HTTP JSON. It is intended for agents, clients, and lightweight integrations that need to search MCP servers or generate install configs without parsing markdown.
+
+Hosted API:
+
+```text
+https://mcp-index.tensorblock.co
+```
+
+## Endpoints
+
+```text
+GET /
+GET /health
+GET /v1
+GET /v1/categories
+GET /v1/servers?query=&category=&transport=&auth=&limit=
+GET /v1/servers/{id}
+GET /v1/servers/{id}/install-config?client=claude-desktop|cursor|codex|vscode
+```
+
+## Examples
+
+Discover available endpoints:
+
+```bash
+curl "$MCP_INDEX_API_URL/"
+```
+
+Search for Postgres servers:
+
+```bash
+curl "$MCP_INDEX_API_URL/v1/servers?query=postgres&limit=5"
+```
+
+Filter by category and transport:
+
+```bash
+curl "$MCP_INDEX_API_URL/v1/servers?category=Databases&transport=stdio"
+```
+
+Fetch a full server profile:
+
+```bash
+curl "$MCP_INDEX_API_URL/v1/servers/postgres-mcp"
+```
+
+Generate an install config:
+
+```bash
+curl "$MCP_INDEX_API_URL/v1/servers/postgres-mcp/install-config?client=claude-desktop"
+```
+
+## Railway Deployment
+
+The API is designed to run as a Railway service from this repository.
+
+Build command:
+
+```bash
+npm run catalog:build && npm run profiles:build && npm run build
+```
+
+Start command:
+
+```bash
+npm run start
+```
+
+The service reads `data/catalog.json` on startup and keeps it in memory. Every deploy includes the latest generated catalog from the repository. No database is required for the MVP.
+
+## Automatic Refresh
+
+The deployment workflow runs on every push to `main` that touches the catalog, docs, API package, schema, or Railway config. It rebuilds `data/catalog.json` and `data/profiles/*.json` before deploying, so newly merged server entries are reflected by the live API after the Railway deployment succeeds.
+
+The workflow requires a GitHub repository secret named `RAILWAY_TOKEN` with deploy access to the Railway project.

--- a/package.json
+++ b/package.json
@@ -6,12 +6,16 @@
     "packages/*"
   ],
   "scripts": {
+    "build": "tsc -p tsconfig.base.json",
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc -p tsconfig.base.json --noEmit",
     "catalog:build": "tsx packages/catalog-builder/src/cli.ts",
     "profiles:build": "tsx packages/profile-renderer/src/cli.ts",
     "config:generate": "tsx packages/config-generator/src/cli.ts",
-    "registry:mcp": "tsx packages/registry-mcp/src/server.ts"
+    "registry:mcp": "tsx packages/registry-mcp/src/server.ts",
+    "registry:api": "node dist-ts/packages/registry-api/src/server.js",
+    "registry:api:dev": "tsx packages/registry-api/src/server.ts",
+    "start": "npm run registry:api"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/registry-api/src/search.ts
+++ b/packages/registry-api/src/search.ts
@@ -1,0 +1,176 @@
+import type { CatalogEntry, AuthType, Transport } from "../../catalog-builder/src/types.js";
+
+export interface CatalogSearchFilters {
+  query?: string;
+  category?: string;
+  transport?: Transport;
+  auth?: AuthType;
+  limit?: number;
+}
+
+export interface ServerSummary {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  transport: Transport[];
+  auth: AuthType;
+  installConfidence: CatalogEntry["install"]["confidence"];
+  primaryUrl: string;
+  profilePath: string;
+}
+
+export interface CategorySummary {
+  name: string;
+  count: number;
+  path: string | null;
+}
+
+interface ScoredEntry {
+  entry: CatalogEntry;
+  score: number;
+}
+
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 100;
+
+export const summarizeServer = (entry: CatalogEntry): ServerSummary => ({
+  id: entry.id,
+  name: entry.name,
+  description: entry.description,
+  category: entry.category,
+  transport: entry.transport,
+  auth: entry.auth.type,
+  installConfidence: entry.install.confidence,
+  primaryUrl: entry.links.primary,
+  profilePath: `/v1/servers/${entry.id}`,
+});
+
+export const listCategories = (catalog: CatalogEntry[]): CategorySummary[] => {
+  const categories = new Map<string, { count: number; path: string | null }>();
+
+  for (const entry of catalog) {
+    const current = categories.get(entry.category) ?? {
+      count: 0,
+      path: entry.source.docsPath,
+    };
+
+    current.count += 1;
+    current.path ??= entry.source.docsPath;
+    categories.set(entry.category, current);
+  }
+
+  return Array.from(categories.entries())
+    .map(([name, summary]) => ({
+      name,
+      count: summary.count,
+      path: summary.path,
+    }))
+    .sort((left, right) => left.name.localeCompare(right.name));
+};
+
+export const searchCatalog = (
+  catalog: CatalogEntry[],
+  filters: CatalogSearchFilters
+): ServerSummary[] => {
+  const limit = normalizeLimit(filters.limit);
+  const query = filters.query?.trim() ?? "";
+  const terms = tokenize(query);
+
+  const filtered = catalog.filter((entry) => matchesFilters(entry, filters));
+  const ranked = terms.length > 0
+    ? filtered
+        .map((entry) => ({
+          entry,
+          score: scoreEntry(entry, terms),
+        }))
+        .filter(({ score }) => score > 0)
+        .sort(sortScoredEntries)
+        .map(({ entry }) => entry)
+    : filtered.sort(sortEntries);
+
+  return ranked.slice(0, limit).map(summarizeServer);
+};
+
+export const findServer = (
+  catalog: CatalogEntry[],
+  serverId: string
+): CatalogEntry | null => catalog.find((entry) => entry.id === serverId) ?? null;
+
+export const normalizeLimit = (rawLimit: number | undefined): number => {
+  if (!rawLimit || Number.isNaN(rawLimit) || rawLimit < 1) {
+    return DEFAULT_LIMIT;
+  }
+
+  return Math.min(Math.floor(rawLimit), MAX_LIMIT);
+};
+
+const matchesFilters = (entry: CatalogEntry, filters: CatalogSearchFilters): boolean => {
+  if (filters.category && entry.category !== filters.category) {
+    return false;
+  }
+
+  if (filters.transport && !entry.transport.includes(filters.transport)) {
+    return false;
+  }
+
+  if (filters.auth && entry.auth.type !== filters.auth) {
+    return false;
+  }
+
+  return true;
+};
+
+const scoreEntry = (entry: CatalogEntry, terms: string[]): number => {
+  const name = normalizeText(entry.name);
+  const description = normalizeText(entry.description);
+  const category = normalizeText(entry.category);
+  const primaryUrl = normalizeText(entry.links.primary);
+  let matchedTerms = 0;
+
+  const score = terms.reduce((currentScore, term) => {
+    let nextScore = currentScore;
+    let matched = false;
+
+    if (name.includes(term)) {
+      nextScore += name === term ? 60 : 30;
+      matched = true;
+    }
+
+    if (primaryUrl.includes(term)) {
+      nextScore += 20;
+      matched = true;
+    }
+
+    if (description.includes(term)) {
+      nextScore += 12;
+      matched = true;
+    }
+
+    if (category.includes(term)) {
+      nextScore += 6;
+      matched = true;
+    }
+
+    if (matched) {
+      matchedTerms += 1;
+    }
+
+    return nextScore;
+  }, 0);
+
+  return score + matchedTerms * 10 + (matchedTerms === terms.length ? 100 : 0);
+};
+
+const sortScoredEntries = (left: ScoredEntry, right: ScoredEntry): number =>
+  right.score - left.score || sortEntries(left.entry, right.entry);
+
+const sortEntries = (left: CatalogEntry, right: CatalogEntry): number =>
+  left.category.localeCompare(right.category) || left.name.localeCompare(right.name);
+
+const tokenize = (query: string): string[] =>
+  normalizeText(query)
+    .split(/\s+/)
+    .filter((term) => term.length > 0);
+
+const normalizeText = (value: string): string => value.toLowerCase();

--- a/packages/registry-api/src/server.ts
+++ b/packages/registry-api/src/server.ts
@@ -1,0 +1,275 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { CatalogEntry, AuthType, Transport } from "../../catalog-builder/src/types.js";
+import {
+  generateClientConfig,
+  type ClientName,
+} from "../../config-generator/src/generateConfig.js";
+import {
+  findServer,
+  listCategories,
+  normalizeLimit,
+  searchCatalog,
+} from "./search.js";
+
+const CLIENT_ALIASES: Record<string, ClientName> = {
+  "claude": "claude",
+  "claude-desktop": "claude",
+  "cursor": "cursor",
+  "codex": "codex",
+  "vscode": "vscode",
+  "vs-code": "vscode",
+};
+
+const TRANSPORTS = new Set<Transport>(["stdio", "streamable-http", "sse", "unknown"]);
+const AUTH_TYPES = new Set<AuthType>(["none", "api-key", "oauth", "bearer", "unknown"]);
+
+interface RegistryApiState {
+  catalog: CatalogEntry[];
+  loadedAt: string;
+}
+
+const startedAt = new Date();
+
+export const loadCatalog = (catalogPath = process.env.CATALOG_PATH ?? "data/catalog.json"): CatalogEntry[] =>
+  JSON.parse(readFileSync(resolve(catalogPath), "utf8")) as CatalogEntry[];
+
+export const createRegistryApiServer = (state: RegistryApiState) =>
+  createServer((request, response) => {
+    void handleRequest(request, response, state);
+  });
+
+const handleRequest = async (
+  request: IncomingMessage,
+  response: ServerResponse,
+  state: RegistryApiState
+): Promise<void> => {
+  const method = request.method ?? "GET";
+
+  if (method === "OPTIONS") {
+    sendJson(response, 204, null);
+    return;
+  }
+
+  if (method !== "GET") {
+    sendError(response, 405, "Method not allowed");
+    return;
+  }
+
+  const url = new URL(request.url ?? "/", "http://localhost");
+  const segments = url.pathname.split("/").filter(Boolean);
+
+  try {
+    if (url.pathname === "/" || url.pathname === "/v1" || url.pathname === "/v1/") {
+      sendJson(response, 200, discoveryPayload(state));
+      return;
+    }
+
+    if (url.pathname === "/health") {
+      sendJson(response, 200, {
+        status: "ok",
+        catalogEntries: state.catalog.length,
+        loadedAt: state.loadedAt,
+        uptimeSeconds: Math.floor((Date.now() - startedAt.getTime()) / 1000),
+      });
+      return;
+    }
+
+    if (segments[0] !== "v1") {
+      sendError(response, 404, "Not found");
+      return;
+    }
+
+    if (segments[1] === "categories" && segments.length === 2) {
+      const categories = listCategories(state.catalog);
+      sendJson(response, 200, {
+        count: categories.length,
+        categories,
+      });
+      return;
+    }
+
+    if (segments[1] === "servers" && segments.length === 2) {
+      handleSearch(url, response, state.catalog);
+      return;
+    }
+
+    if (segments[1] === "servers" && segments.length === 3) {
+      const entry = findServer(state.catalog, segments[2]);
+
+      if (!entry) {
+        sendError(response, 404, `Server not found: ${segments[2]}`);
+        return;
+      }
+
+      sendJson(response, 200, entry);
+      return;
+    }
+
+    if (segments[1] === "servers" && segments[3] === "install-config" && segments.length === 4) {
+      handleInstallConfig(url, response, state.catalog, segments[2]);
+      return;
+    }
+
+    sendError(response, 404, "Not found");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    sendError(response, 500, message);
+  }
+};
+
+const discoveryPayload = (state: RegistryApiState) => ({
+  name: "TensorBlock MCP Index API",
+  version: "v1",
+  description: "Search MCP servers, inspect catalog profiles, and generate MCP client install configs.",
+  catalogEntries: state.catalog.length,
+  endpoints: {
+    health: "/health",
+    categories: "/v1/categories",
+    searchServers: "/v1/servers?query=postgres&limit=5",
+    getServer: "/v1/servers/{id}",
+    getInstallConfig: "/v1/servers/{id}/install-config?client=claude-desktop",
+  },
+  docs: "https://github.com/TensorBlock/awesome-mcp-servers/blob/main/docs/index-api.md",
+});
+
+const handleSearch = (
+  url: URL,
+  response: ServerResponse,
+  catalog: CatalogEntry[]
+): void => {
+  const transport = optionalTransport(url.searchParams.get("transport"));
+  const auth = optionalAuthType(url.searchParams.get("auth"));
+
+  if (transport instanceof Error) {
+    sendError(response, 400, transport.message);
+    return;
+  }
+
+  if (auth instanceof Error) {
+    sendError(response, 400, auth.message);
+    return;
+  }
+
+  const rawLimit = url.searchParams.get("limit");
+  const limit = normalizeLimit(rawLimit ? Number(rawLimit) : undefined);
+  const servers = searchCatalog(catalog, {
+    query: url.searchParams.get("query") ?? undefined,
+    category: url.searchParams.get("category") ?? undefined,
+    transport,
+    auth,
+    limit,
+  });
+
+  sendJson(response, 200, {
+    count: servers.length,
+    limit,
+    query: url.searchParams.get("query") ?? "",
+    filters: {
+      category: url.searchParams.get("category"),
+      transport: transport ?? null,
+      auth: auth ?? null,
+    },
+    servers,
+  });
+};
+
+const handleInstallConfig = (
+  url: URL,
+  response: ServerResponse,
+  catalog: CatalogEntry[],
+  serverId: string
+): void => {
+  const entry = findServer(catalog, serverId);
+
+  if (!entry) {
+    sendError(response, 404, `Server not found: ${serverId}`);
+    return;
+  }
+
+  const client = normalizeClientName(url.searchParams.get("client") ?? "claude-desktop");
+
+  if (!client) {
+    sendError(response, 400, "Unsupported client. Use claude-desktop, cursor, codex, or vscode.");
+    return;
+  }
+
+  sendJson(response, 200, generateClientConfig(entry, client));
+};
+
+const normalizeClientName = (client: string): ClientName | null =>
+  CLIENT_ALIASES[client.toLowerCase()] ?? null;
+
+const optionalTransport = (transport: string | null): Transport | undefined | Error => {
+  if (!transport) {
+    return undefined;
+  }
+
+  return TRANSPORTS.has(transport as Transport)
+    ? transport as Transport
+    : new Error(`Unsupported transport: ${transport}`);
+};
+
+const optionalAuthType = (auth: string | null): AuthType | undefined | Error => {
+  if (!auth) {
+    return undefined;
+  }
+
+  return AUTH_TYPES.has(auth as AuthType)
+    ? auth as AuthType
+    : new Error(`Unsupported auth type: ${auth}`);
+};
+
+const sendJson = (response: ServerResponse, statusCode: number, value: unknown): void => {
+  response.writeHead(statusCode, {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+    "Cache-Control": statusCode === 200 ? "public, max-age=60" : "no-store",
+    "Content-Type": "application/json; charset=utf-8",
+  });
+
+  if (statusCode === 204) {
+    response.end();
+    return;
+  }
+
+  response.end(`${JSON.stringify(value, null, 2)}\n`);
+};
+
+const sendError = (response: ServerResponse, statusCode: number, message: string): void => {
+  sendJson(response, statusCode, {
+    error: {
+      message,
+      statusCode,
+    },
+  });
+};
+
+export const main = (): void => {
+  const catalog = loadCatalog();
+  const port = Number(process.env.PORT ?? 3000);
+  const host = process.env.HOST ?? "0.0.0.0";
+  const server = createRegistryApiServer({
+    catalog,
+    loadedAt: new Date().toISOString(),
+  });
+
+  server.listen(port, host, () => {
+    console.log(`TensorBlock MCP Index API listening on ${host}:${port}`);
+    console.log(`Loaded ${catalog.length} catalog entries`);
+  });
+};
+
+const isDirectRun = (): boolean => {
+  if (!process.argv[1]) {
+    return false;
+  }
+
+  return import.meta.url === new URL(`file://${resolve(process.argv[1])}`).href;
+};
+
+if (isDirectRun()) {
+  main();
+}

--- a/packages/registry-api/test/search.test.ts
+++ b/packages/registry-api/test/search.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+import type { CatalogEntry } from "../../catalog-builder/src/types.js";
+import {
+  findServer,
+  listCategories,
+  normalizeLimit,
+  searchCatalog,
+  summarizeServer,
+} from "../src/search.js";
+
+const baseEntry: CatalogEntry = {
+  id: "base",
+  name: "Base",
+  description: "Base server",
+  category: "Utilities & Helpers",
+  source: {
+    readmePath: null,
+    docsPath: "docs/utilities--helpers.md",
+    featuredInReadme: false,
+  },
+  links: {
+    primary: "https://example.com/base",
+    repo: null,
+    homepage: "https://example.com/base",
+    docs: null,
+    endpoint: null,
+  },
+  install: {
+    commands: [],
+    env: [],
+    confidence: "low",
+  },
+  transport: ["unknown"],
+  auth: {
+    type: "unknown",
+    notes: [],
+  },
+  clients: [],
+  tools: {
+    count: null,
+    names: [],
+    source: "unknown",
+  },
+  license: "unknown",
+  health: {
+    repoPublic: null,
+    packageFound: null,
+    endpointReachable: null,
+    lastCheckedAt: null,
+  },
+  verification: {
+    status: "unknown",
+    notes: [],
+  },
+  community: {
+    maintainedBy: [],
+    verifiedBy: [],
+    claimed: false,
+  },
+};
+
+const entry = (overrides: Partial<CatalogEntry>): CatalogEntry => ({
+  ...baseEntry,
+  ...overrides,
+  source: {
+    ...baseEntry.source,
+    ...overrides.source,
+  },
+  links: {
+    ...baseEntry.links,
+    ...overrides.links,
+  },
+  install: {
+    ...baseEntry.install,
+    ...overrides.install,
+  },
+  auth: {
+    ...baseEntry.auth,
+    ...overrides.auth,
+  },
+  tools: {
+    ...baseEntry.tools,
+    ...overrides.tools,
+  },
+  health: {
+    ...baseEntry.health,
+    ...overrides.health,
+  },
+  verification: {
+    ...baseEntry.verification,
+    ...overrides.verification,
+  },
+  community: {
+    ...baseEntry.community,
+    ...overrides.community,
+  },
+});
+
+const catalog: CatalogEntry[] = [
+  entry({
+    id: "postgres-mcp",
+    name: "Postgres MCP",
+    description: "Query PostgreSQL databases from agents.",
+    category: "Databases",
+    transport: ["stdio"],
+    auth: {
+      type: "api-key",
+      notes: [],
+    },
+    install: {
+      commands: ["npx postgres-mcp"],
+      env: ["DATABASE_URL"],
+      confidence: "high",
+    },
+    links: {
+      primary: "https://github.com/example/postgres-mcp",
+      repo: "https://github.com/example/postgres-mcp",
+    },
+  }),
+  entry({
+    id: "browser-tools",
+    name: "Browser Tools",
+    description: "Automate browser workflows and screenshots.",
+    category: "Browser Automation & Web Scraping",
+    transport: ["streamable-http"],
+    auth: {
+      type: "none",
+      notes: [],
+    },
+    links: {
+      primary: "https://browser.example.com",
+      endpoint: "https://browser.example.com/mcp",
+    },
+  }),
+];
+
+describe("searchCatalog", () => {
+  it("ranks matching entries and returns summaries", () => {
+    expect(searchCatalog(catalog, { query: "postgres", limit: 10 })).toEqual([
+      summarizeServer(catalog[0]),
+    ]);
+  });
+
+  it("filters by category, transport, and auth", () => {
+    expect(searchCatalog(catalog, {
+      category: "Browser Automation & Web Scraping",
+      transport: "streamable-http",
+      auth: "none",
+    })).toEqual([summarizeServer(catalog[1])]);
+  });
+
+  it("returns sorted entries when no query is provided", () => {
+    expect(searchCatalog(catalog, {}).map((server) => server.id)).toEqual([
+      "browser-tools",
+      "postgres-mcp",
+    ]);
+  });
+});
+
+describe("catalog helpers", () => {
+  it("lists category counts", () => {
+    expect(listCategories(catalog)).toEqual([
+      {
+        name: "Browser Automation & Web Scraping",
+        count: 1,
+        path: "docs/utilities--helpers.md",
+      },
+      {
+        name: "Databases",
+        count: 1,
+        path: "docs/utilities--helpers.md",
+      },
+    ]);
+  });
+
+  it("finds servers by id", () => {
+    expect(findServer(catalog, "postgres-mcp")?.name).toBe("Postgres MCP");
+    expect(findServer(catalog, "missing")).toBeNull();
+  });
+
+  it("normalizes limits", () => {
+    expect(normalizeLimit(undefined)).toBe(25);
+    expect(normalizeLimit(0)).toBe(25);
+    expect(normalizeLimit(101)).toBe(100);
+    expect(normalizeLimit(7.8)).toBe(7);
+  });
+});

--- a/packages/registry-api/test/server.test.ts
+++ b/packages/registry-api/test/server.test.ts
@@ -1,0 +1,113 @@
+import { once } from "node:events";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import type { CatalogEntry } from "../../catalog-builder/src/types.js";
+import { createRegistryApiServer } from "../src/server.js";
+
+const catalog: CatalogEntry[] = [
+  {
+    id: "postgres-mcp",
+    name: "Postgres MCP",
+    description: "Query PostgreSQL databases from agents.",
+    category: "Databases",
+    source: {
+      readmePath: null,
+      docsPath: "docs/databases.md",
+      featuredInReadme: false,
+    },
+    links: {
+      primary: "https://github.com/example/postgres-mcp",
+      repo: "https://github.com/example/postgres-mcp",
+      homepage: null,
+      docs: null,
+      endpoint: null,
+    },
+    install: {
+      commands: ["npx postgres-mcp"],
+      env: ["DATABASE_URL"],
+      confidence: "high",
+    },
+    transport: ["stdio"],
+    auth: {
+      type: "api-key",
+      notes: [],
+    },
+    clients: [],
+    tools: {
+      count: null,
+      names: [],
+      source: "unknown",
+    },
+    license: "unknown",
+    health: {
+      repoPublic: null,
+      packageFound: null,
+      endpointReachable: null,
+      lastCheckedAt: null,
+    },
+    verification: {
+      status: "unknown",
+      notes: [],
+    },
+    community: {
+      maintainedBy: [],
+      verifiedBy: [],
+      claimed: false,
+    },
+  },
+];
+
+const servers: Array<ReturnType<typeof createRegistryApiServer>> = [];
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => new Promise<void>((resolve, reject) => {
+    server.closeAllConnections();
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  })));
+});
+
+describe("registry API server", () => {
+  it("returns API discovery from the root path", async () => {
+    const baseUrl = await startServer();
+    const response = await fetch(baseUrl);
+    const body = await response.json() as {
+      name: string;
+      catalogEntries: number;
+      endpoints: Record<string, string>;
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.name).toBe("TensorBlock MCP Index API");
+    expect(body.catalogEntries).toBe(1);
+    expect(body.endpoints.searchServers).toBe("/v1/servers?query=postgres&limit=5");
+  });
+
+  it("keeps the version discovery path available", async () => {
+    const baseUrl = await startServer();
+    const response = await fetch(`${baseUrl}/v1`);
+    const body = await response.json() as { version: string };
+
+    expect(response.status).toBe(200);
+    expect(body.version).toBe("v1");
+  });
+});
+
+const startServer = async (): Promise<string> => {
+  const server = createRegistryApiServer({
+    catalog,
+    loadedAt: "2026-06-06T00:00:00.000Z",
+  });
+  servers.push(server);
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+
+  const address = server.address() as AddressInfo;
+  return `http://127.0.0.1:${address.port}`;
+};

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,12 @@
+{
+  "build": {
+    "builder": "NIXPACKS",
+    "buildCommand": "npm run catalog:build && npm run profiles:build && npm run build"
+  },
+  "deploy": {
+    "startCommand": "npm run start",
+    "healthcheckPath": "/health",
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}


### PR DESCRIPTION
## Summary

- Add a Railway-ready TensorBlock MCP Index HTTP API.
- Add endpoints for health, categories, server search, server profiles, and install config generation.
- Add keyword search/filter helpers with tests.
- Add Railway build/start config and API docs with the production MVP URL.
- Add GitHub Actions deployment workflow so pushes to main rebuild catalog/profile data and deploy the API to Railway.
- Refresh the README intro copy and link to the HTTP API docs.

## Production MVP

- https://mcp-index-api-production.up.railway.app

## Automatic Refresh

- Railway build command runs `npm run catalog:build && npm run profiles:build && npm run build`.
- `.github/workflows/deploy-registry-api.yml` deploys on relevant pushes to `main`.
- The workflow requires a repo secret named `RAILWAY_TOKEN`.

## Validation

- npm test
- npm run typecheck
- npm run build
- npm run catalog:build && npm run profiles:build && npm run build
- git diff --check
- Verified production /health, /v1/categories, /v1/servers, /v1/servers/{id}, and /install-config endpoints with curl.
