### PR TITLE
Add shareable MCP server profile pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Useful endpoints:
 - `GET /v1/servers?category=Databases&transport=stdio` - filter by category, transport, auth type, and result limit.
 - `GET /v1/servers/{id}` - fetch the normalized profile for one MCP server.
 - `GET /v1/servers/{id}/install-config?client=claude-desktop` - generate an MCP client config for Claude Desktop, Cursor, Codex, or VS Code.
+- `https://tensorblock.co/mcp/servers/{id}` - share a public website profile for an indexed server.
 
 What the API supports today:
 

--- a/docs/index-api.md
+++ b/docs/index-api.md
@@ -17,6 +17,7 @@ GET /v1
 GET /v1/categories
 GET /v1/servers?query=&category=&transport=&auth=&limit=
 GET /v1/servers/{id}
+GET /servers/{id}
 GET /v1/servers/{id}/install-config?client=claude-desktop|cursor|codex|vscode
 ```
 
@@ -44,6 +45,12 @@ Fetch a full server profile:
 
 ```bash
 curl "$MCP_INDEX_API_URL/v1/servers/postgres-mcp"
+```
+
+Open a shareable server profile page:
+
+```text
+https://mcp-index.tensorblock.co/servers/postgres-mcp
 ```
 
 Generate an install config:

--- a/docs/index-api.md
+++ b/docs/index-api.md
@@ -17,7 +17,6 @@ GET /v1
 GET /v1/categories
 GET /v1/servers?query=&category=&transport=&auth=&limit=
 GET /v1/servers/{id}
-GET /servers/{id}
 GET /v1/servers/{id}/install-config?client=claude-desktop|cursor|codex|vscode
 ```
 
@@ -47,11 +46,13 @@ Fetch a full server profile:
 curl "$MCP_INDEX_API_URL/v1/servers/postgres-mcp"
 ```
 
-Open a shareable server profile page:
+Open a shareable website profile page:
 
 ```text
-https://mcp-index.tensorblock.co/servers/postgres-mcp
+https://tensorblock.co/mcp/servers/postgres-mcp
 ```
+
+The API also keeps `GET /servers/{id}` as a lightweight HTML fallback, but the canonical community profile is hosted on the TensorBlock website.
 
 Generate an install config:
 

--- a/packages/profile-renderer/src/cli.ts
+++ b/packages/profile-renderer/src/cli.ts
@@ -3,7 +3,7 @@ import type { CatalogEntry } from "../../catalog-builder/src/types.js";
 import { writeProfiles } from "./renderProfiles.js";
 
 const catalog = JSON.parse(readFileSync("data/catalog.json", "utf8")) as CatalogEntry[];
-const baseUrl = process.env.MCP_INDEX_BASE_URL ?? "https://mcp-index.tensorblock.co/servers";
+const baseUrl = process.env.MCP_INDEX_BASE_URL ?? "https://tensorblock.co/mcp/servers";
 const outputDir = "data/profiles";
 
 const written = writeProfiles(catalog, baseUrl, outputDir);

--- a/packages/profile-renderer/src/cli.ts
+++ b/packages/profile-renderer/src/cli.ts
@@ -3,7 +3,7 @@ import type { CatalogEntry } from "../../catalog-builder/src/types.js";
 import { writeProfiles } from "./renderProfiles.js";
 
 const catalog = JSON.parse(readFileSync("data/catalog.json", "utf8")) as CatalogEntry[];
-const baseUrl = process.env.MCP_INDEX_BASE_URL ?? "https://tensorblock.co/mcp";
+const baseUrl = process.env.MCP_INDEX_BASE_URL ?? "https://mcp-index.tensorblock.co/servers";
 const outputDir = "data/profiles";
 
 const written = writeProfiles(catalog, baseUrl, outputDir);

--- a/packages/registry-api/src/profilePage.ts
+++ b/packages/registry-api/src/profilePage.ts
@@ -1,4 +1,5 @@
 import type { CatalogEntry } from "../../catalog-builder/src/types.js";
+import { webProfileUrl } from "./webProfile.js";
 
 const CLIENTS = ["claude-desktop", "cursor", "codex", "vscode"] as const;
 
@@ -195,6 +196,7 @@ export const renderServerProfilePage = (entry: CatalogEntry): string => {
         ${optionalLink("Docs", entry.links.docs)}
         ${optionalLink("Homepage", entry.links.homepage)}
         ${optionalLink("Remote endpoint", entry.links.endpoint)}
+        <a class="button" href="${escapeAttribute(webProfileUrl(entry.id))}">Website profile</a>
         <a class="button" href="/v1/servers/${encodeURIComponent(entry.id)}">JSON profile</a>
       </div>
     </section>

--- a/packages/registry-api/src/profilePage.ts
+++ b/packages/registry-api/src/profilePage.ts
@@ -1,0 +1,274 @@
+import type { CatalogEntry } from "../../catalog-builder/src/types.js";
+
+const CLIENTS = ["claude-desktop", "cursor", "codex", "vscode"] as const;
+
+export const renderServerProfilePage = (entry: CatalogEntry): string => {
+  const title = `${entry.name} - TensorBlock MCP Index`;
+  const installCommands = entry.install.commands.length > 0
+    ? entry.install.commands.map((command) => `<code>${escapeHtml(command)}</code>`).join("")
+    : "<p>No install command has been indexed yet.</p>";
+  const envVars = entry.install.env.length > 0
+    ? entry.install.env.map((name) => `<code>${escapeHtml(name)}</code>`).join(" ")
+    : "<span>None indexed</span>";
+  const tools = entry.tools.count === null
+    ? "Unknown"
+    : `${entry.tools.count}`;
+  const sourceLink = entry.source.docsPath
+    ? `<a href="${githubSourceUrl(entry.source.docsPath)}">${escapeHtml(entry.source.docsPath)}</a>`
+    : "Not indexed";
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${escapeHtml(title)}</title>
+  <meta name="description" content="${escapeAttribute(entry.description)}">
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f7f8fb;
+      --panel: #ffffff;
+      --text: #17202a;
+      --muted: #5d6978;
+      --line: #dde3ea;
+      --accent: #2457d6;
+      --accent-soft: #eef3ff;
+      --code: #111827;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.55;
+    }
+    main {
+      width: min(960px, calc(100% - 32px));
+      margin: 0 auto;
+      padding: 40px 0 56px;
+    }
+    header {
+      margin-bottom: 24px;
+    }
+    .eyebrow {
+      color: var(--accent);
+      font-size: 13px;
+      font-weight: 700;
+      letter-spacing: 0;
+      margin: 0 0 10px;
+      text-transform: uppercase;
+    }
+    h1 {
+      font-size: clamp(30px, 5vw, 48px);
+      line-height: 1.05;
+      letter-spacing: 0;
+      margin: 0 0 14px;
+    }
+    p {
+      margin: 0 0 14px;
+    }
+    a {
+      color: var(--accent);
+      text-decoration: none;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+    .summary {
+      color: var(--muted);
+      font-size: 18px;
+      max-width: 760px;
+    }
+    .badges {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 18px;
+    }
+    .badge {
+      background: var(--accent-soft);
+      border: 1px solid #dbe6ff;
+      border-radius: 999px;
+      color: #173f9f;
+      display: inline-flex;
+      font-size: 13px;
+      font-weight: 650;
+      padding: 5px 10px;
+      white-space: nowrap;
+    }
+    section {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      margin-top: 16px;
+      padding: 20px;
+    }
+    h2 {
+      font-size: 18px;
+      margin: 0 0 14px;
+      letter-spacing: 0;
+    }
+    dl {
+      display: grid;
+      gap: 14px;
+      grid-template-columns: minmax(140px, 220px) 1fr;
+      margin: 0;
+    }
+    dt {
+      color: var(--muted);
+      font-weight: 650;
+    }
+    dd {
+      margin: 0;
+      min-width: 0;
+      overflow-wrap: anywhere;
+    }
+    code {
+      background: #f3f5f8;
+      border: 1px solid #e1e6ee;
+      border-radius: 6px;
+      color: var(--code);
+      display: inline-block;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+      font-size: 13px;
+      margin: 0 6px 6px 0;
+      padding: 3px 6px;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+    .links {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin-top: 6px;
+    }
+    .button {
+      align-items: center;
+      border: 1px solid var(--line);
+      border-radius: 7px;
+      display: inline-flex;
+      font-weight: 650;
+      min-height: 38px;
+      padding: 7px 11px;
+    }
+    .footer {
+      color: var(--muted);
+      font-size: 14px;
+      margin-top: 24px;
+    }
+    @media (max-width: 640px) {
+      main {
+        width: min(100% - 24px, 960px);
+        padding-top: 28px;
+      }
+      dl {
+        grid-template-columns: 1fr;
+        gap: 4px;
+      }
+      dd {
+        margin-bottom: 12px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <p class="eyebrow">TensorBlock MCP Index</p>
+      <h1>${escapeHtml(entry.name)}</h1>
+      <p class="summary">${escapeHtml(entry.description)}</p>
+      <div class="badges">
+        <span class="badge">${escapeHtml(entry.category)}</span>
+        <span class="badge">Install confidence: ${escapeHtml(entry.install.confidence)}</span>
+        <span class="badge">Auth: ${escapeHtml(entry.auth.type)}</span>
+        <span class="badge">Transport: ${escapeHtml(entry.transport.join(", "))}</span>
+      </div>
+    </header>
+
+    <section>
+      <h2>Links</h2>
+      <div class="links">
+        <a class="button" href="${escapeAttribute(safeHref(entry.links.primary))}">Primary link</a>
+        ${optionalLink("Repository", entry.links.repo)}
+        ${optionalLink("Docs", entry.links.docs)}
+        ${optionalLink("Homepage", entry.links.homepage)}
+        ${optionalLink("Remote endpoint", entry.links.endpoint)}
+        <a class="button" href="/v1/servers/${encodeURIComponent(entry.id)}">JSON profile</a>
+      </div>
+    </section>
+
+    <section>
+      <h2>Install Metadata</h2>
+      <dl>
+        <dt>Commands</dt>
+        <dd>${installCommands}</dd>
+        <dt>Environment</dt>
+        <dd>${envVars}</dd>
+        <dt>Generated configs</dt>
+        <dd>${CLIENTS.map((client) => `<a href="/v1/servers/${encodeURIComponent(entry.id)}/install-config?client=${client}">${client}</a>`).join(" · ")}</dd>
+      </dl>
+    </section>
+
+    <section>
+      <h2>Indexed Metadata</h2>
+      <dl>
+        <dt>Server ID</dt>
+        <dd><code>${escapeHtml(entry.id)}</code></dd>
+        <dt>Category</dt>
+        <dd>${escapeHtml(entry.category)}</dd>
+        <dt>Transport</dt>
+        <dd>${escapeHtml(entry.transport.join(", "))}</dd>
+        <dt>Auth</dt>
+        <dd>${escapeHtml(entry.auth.type)}</dd>
+        <dt>Tools</dt>
+        <dd>${escapeHtml(tools)}</dd>
+        <dt>License</dt>
+        <dd>${escapeHtml(entry.license)}</dd>
+        <dt>Verification</dt>
+        <dd>${escapeHtml(entry.verification.status)}</dd>
+        <dt>Claimed</dt>
+        <dd>${entry.community.claimed ? "Yes" : "No"}</dd>
+        <dt>Source</dt>
+        <dd>${sourceLink}</dd>
+      </dl>
+    </section>
+
+    <p class="footer">This profile is generated from the community-maintained <a href="https://github.com/TensorBlock/awesome-mcp-servers">TensorBlock MCP Index</a>.</p>
+  </main>
+</body>
+</html>`;
+};
+
+const optionalLink = (label: string, href: string | null | undefined): string =>
+  href
+    ? `<a class="button" href="${escapeAttribute(safeHref(href))}">${escapeHtml(label)}</a>`
+    : "";
+
+const githubSourceUrl = (path: string): string =>
+  `https://github.com/TensorBlock/awesome-mcp-servers/blob/main/${encodeURIComponent(path).replace(/%2F/g, "/")}`;
+
+const escapeAttribute = (value: string): string =>
+  escapeHtml(value).replace(/"/g, "&quot;");
+
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+
+const safeHref = (href: string): string => {
+  if (href.startsWith("/") && !href.startsWith("//")) {
+    return href;
+  }
+
+  try {
+    const url = new URL(href);
+    return url.protocol === "https:" || url.protocol === "http:"
+      ? href
+      : "#";
+  } catch {
+    return "#";
+  }
+};

--- a/packages/registry-api/src/search.ts
+++ b/packages/registry-api/src/search.ts
@@ -18,6 +18,7 @@ export interface ServerSummary {
   installConfidence: CatalogEntry["install"]["confidence"];
   primaryUrl: string;
   profilePath: string;
+  webProfilePath: string;
 }
 
 export interface CategorySummary {
@@ -44,6 +45,7 @@ export const summarizeServer = (entry: CatalogEntry): ServerSummary => ({
   installConfidence: entry.install.confidence,
   primaryUrl: entry.links.primary,
   profilePath: `/v1/servers/${entry.id}`,
+  webProfilePath: `/servers/${entry.id}`,
 });
 
 export const listCategories = (catalog: CatalogEntry[]): CategorySummary[] => {

--- a/packages/registry-api/src/search.ts
+++ b/packages/registry-api/src/search.ts
@@ -1,4 +1,5 @@
 import type { CatalogEntry, AuthType, Transport } from "../../catalog-builder/src/types.js";
+import { webProfileUrl } from "./webProfile.js";
 
 export interface CatalogSearchFilters {
   query?: string;
@@ -45,7 +46,7 @@ export const summarizeServer = (entry: CatalogEntry): ServerSummary => ({
   installConfidence: entry.install.confidence,
   primaryUrl: entry.links.primary,
   profilePath: `/v1/servers/${entry.id}`,
-  webProfilePath: `/servers/${entry.id}`,
+  webProfilePath: webProfileUrl(entry.id),
 });
 
 export const listCategories = (catalog: CatalogEntry[]): CategorySummary[] => {

--- a/packages/registry-api/src/server.ts
+++ b/packages/registry-api/src/server.ts
@@ -12,6 +12,7 @@ import {
   normalizeLimit,
   searchCatalog,
 } from "./search.js";
+import { renderServerProfilePage } from "./profilePage.js";
 
 const CLIENT_ALIASES: Record<string, ClientName> = {
   "claude": "claude",
@@ -76,6 +77,18 @@ const handleRequest = async (
       return;
     }
 
+    if (segments[0] === "servers" && segments.length === 2) {
+      const entry = findServer(state.catalog, segments[1]);
+
+      if (!entry) {
+        sendError(response, 404, `Server not found: ${segments[1]}`);
+        return;
+      }
+
+      sendHtml(response, 200, renderServerProfilePage(entry));
+      return;
+    }
+
     if (segments[0] !== "v1") {
       sendError(response, 404, "Not found");
       return;
@@ -129,6 +142,7 @@ const discoveryPayload = (state: RegistryApiState) => ({
     categories: "/v1/categories",
     searchServers: "/v1/servers?query=postgres&limit=5",
     getServer: "/v1/servers/{id}",
+    serverProfile: "/servers/{id}",
     getInstallConfig: "/v1/servers/{id}/install-config?client=claude-desktop",
   },
   docs: "https://github.com/TensorBlock/awesome-mcp-servers/blob/main/docs/index-api.md",
@@ -245,6 +259,18 @@ const sendError = (response: ServerResponse, statusCode: number, message: string
       statusCode,
     },
   });
+};
+
+const sendHtml = (response: ServerResponse, statusCode: number, value: string): void => {
+  response.writeHead(statusCode, {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+    "Cache-Control": statusCode === 200 ? "public, max-age=300" : "no-store",
+    "Content-Type": "text/html; charset=utf-8",
+  });
+
+  response.end(value);
 };
 
 export const main = (): void => {

--- a/packages/registry-api/src/server.ts
+++ b/packages/registry-api/src/server.ts
@@ -13,6 +13,7 @@ import {
   searchCatalog,
 } from "./search.js";
 import { renderServerProfilePage } from "./profilePage.js";
+import { webProfileTemplate } from "./webProfile.js";
 
 const CLIENT_ALIASES: Record<string, ClientName> = {
   "claude": "claude",
@@ -142,7 +143,8 @@ const discoveryPayload = (state: RegistryApiState) => ({
     categories: "/v1/categories",
     searchServers: "/v1/servers?query=postgres&limit=5",
     getServer: "/v1/servers/{id}",
-    serverProfile: "/servers/{id}",
+    serverProfile: webProfileTemplate(),
+    apiHtmlProfile: "/servers/{id}",
     getInstallConfig: "/v1/servers/{id}/install-config?client=claude-desktop",
   },
   docs: "https://github.com/TensorBlock/awesome-mcp-servers/blob/main/docs/index-api.md",

--- a/packages/registry-api/src/webProfile.ts
+++ b/packages/registry-api/src/webProfile.ts
@@ -1,0 +1,10 @@
+const DEFAULT_WEB_PROFILE_BASE_URL = "https://tensorblock.co/mcp/servers";
+
+export const webProfileBaseUrl = (): string =>
+  (process.env.MCP_WEB_PROFILE_BASE_URL ?? DEFAULT_WEB_PROFILE_BASE_URL).replace(/\/+$/, "");
+
+export const webProfileUrl = (serverId: string): string =>
+  `${webProfileBaseUrl()}/${encodeURIComponent(serverId)}`;
+
+export const webProfileTemplate = (): string =>
+  `${webProfileBaseUrl()}/{id}`;

--- a/packages/registry-api/test/profilePage.test.ts
+++ b/packages/registry-api/test/profilePage.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import type { CatalogEntry } from "../../catalog-builder/src/types.js";
+import { renderServerProfilePage } from "../src/profilePage.js";
+
+const entry: CatalogEntry = {
+  id: "unsafe-demo",
+  name: "Unsafe <Demo>",
+  description: "Server with \"quoted\" metadata and <script>alert(1)</script>.",
+  category: "Utilities & Helpers",
+  source: {
+    readmePath: null,
+    docsPath: "docs/utilities--helpers.md",
+    featuredInReadme: false,
+  },
+  links: {
+    primary: "https://github.com/example/unsafe-demo",
+    repo: "javascript:alert(1)",
+    homepage: null,
+    docs: null,
+    endpoint: null,
+  },
+  install: {
+    commands: ["npx unsafe-demo"],
+    env: ["API_KEY"],
+    confidence: "medium",
+  },
+  transport: ["stdio"],
+  auth: {
+    type: "api-key",
+    notes: [],
+  },
+  clients: [],
+  tools: {
+    count: null,
+    names: [],
+    source: "unknown",
+  },
+  license: "unknown",
+  health: {
+    repoPublic: null,
+    packageFound: null,
+    endpointReachable: null,
+    lastCheckedAt: null,
+  },
+  verification: {
+    status: "unknown",
+    notes: [],
+  },
+  community: {
+    maintainedBy: [],
+    verifiedBy: [],
+    claimed: false,
+  },
+};
+
+describe("renderServerProfilePage", () => {
+  it("escapes text and blocks unsafe links", () => {
+    const html = renderServerProfilePage(entry);
+
+    expect(html).toContain("Unsafe &lt;Demo&gt;");
+    expect(html).toContain("&quot;quoted&quot;");
+    expect(html).not.toContain("<script>");
+    expect(html).not.toContain("javascript:alert");
+    expect(html).toContain('href="#"');
+  });
+});

--- a/packages/registry-api/test/search.test.ts
+++ b/packages/registry-api/test/search.test.ts
@@ -136,9 +136,11 @@ const catalog: CatalogEntry[] = [
 
 describe("searchCatalog", () => {
   it("ranks matching entries and returns summaries", () => {
-    expect(searchCatalog(catalog, { query: "postgres", limit: 10 })).toEqual([
-      summarizeServer(catalog[0]),
-    ]);
+    const results = searchCatalog(catalog, { query: "postgres", limit: 10 });
+
+    expect(results).toEqual([summarizeServer(catalog[0])]);
+    expect(results[0].profilePath).toBe("/v1/servers/postgres-mcp");
+    expect(results[0].webProfilePath).toBe("/servers/postgres-mcp");
   });
 
   it("filters by category, transport, and auth", () => {

--- a/packages/registry-api/test/search.test.ts
+++ b/packages/registry-api/test/search.test.ts
@@ -140,7 +140,7 @@ describe("searchCatalog", () => {
 
     expect(results).toEqual([summarizeServer(catalog[0])]);
     expect(results[0].profilePath).toBe("/v1/servers/postgres-mcp");
-    expect(results[0].webProfilePath).toBe("/servers/postgres-mcp");
+    expect(results[0].webProfilePath).toBe("https://tensorblock.co/mcp/servers/postgres-mcp");
   });
 
   it("filters by category, transport, and auth", () => {

--- a/packages/registry-api/test/server.test.ts
+++ b/packages/registry-api/test/server.test.ts
@@ -87,6 +87,7 @@ describe("registry API server", () => {
     expect(body.name).toBe("TensorBlock MCP Index API");
     expect(body.catalogEntries).toBe(1);
     expect(body.endpoints.searchServers).toBe("/v1/servers?query=postgres&limit=5");
+    expect(body.endpoints.serverProfile).toBe("/servers/{id}");
   });
 
   it("keeps the version discovery path available", async () => {
@@ -96,6 +97,30 @@ describe("registry API server", () => {
 
     expect(response.status).toBe(200);
     expect(body.version).toBe("v1");
+  });
+
+  it("serves a shareable HTML profile page for a server", async () => {
+    const baseUrl = await startServer();
+    const response = await fetch(`${baseUrl}/servers/postgres-mcp`);
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/html");
+    expect(body).toContain("<h1>Postgres MCP</h1>");
+    expect(body).toContain("Query PostgreSQL databases from agents.");
+    expect(body).toContain("npx postgres-mcp");
+    expect(body).toContain("/v1/servers/postgres-mcp");
+    expect(body).toContain("claude-desktop");
+  });
+
+  it("returns JSON errors for missing profile pages", async () => {
+    const baseUrl = await startServer();
+    const response = await fetch(`${baseUrl}/servers/missing`);
+    const body = await response.json() as { error: { message: string; statusCode: number } };
+
+    expect(response.status).toBe(404);
+    expect(body.error.statusCode).toBe(404);
+    expect(body.error.message).toBe("Server not found: missing");
   });
 });
 

--- a/packages/registry-api/test/server.test.ts
+++ b/packages/registry-api/test/server.test.ts
@@ -87,7 +87,8 @@ describe("registry API server", () => {
     expect(body.name).toBe("TensorBlock MCP Index API");
     expect(body.catalogEntries).toBe(1);
     expect(body.endpoints.searchServers).toBe("/v1/servers?query=postgres&limit=5");
-    expect(body.endpoints.serverProfile).toBe("/servers/{id}");
+    expect(body.endpoints.serverProfile).toBe("https://tensorblock.co/mcp/servers/{id}");
+    expect(body.endpoints.apiHtmlProfile).toBe("/servers/{id}");
   });
 
   it("keeps the version discovery path available", async () => {
@@ -109,6 +110,7 @@ describe("registry API server", () => {
     expect(body).toContain("<h1>Postgres MCP</h1>");
     expect(body).toContain("Query PostgreSQL databases from agents.");
     expect(body).toContain("npx postgres-mcp");
+    expect(body).toContain("https://tensorblock.co/mcp/servers/postgres-mcp");
     expect(body).toContain("/v1/servers/postgres-mcp");
     expect(body).toContain("claude-desktop");
   });


### PR DESCRIPTION
## Summary
- Add human-readable server profile pages at /servers/{id}
- Expose webProfilePath in search results while keeping existing JSON profilePath
- Add profile route to API discovery and docs
- Guard profile HTML rendering with text escaping and safe href handling
- Update generated profile default base URL to the hosted profile route

## Jira
- MCP-8

## Tests
- npm test
- npm run typecheck
- npm run build
- git diff --check