### PR TITLE
Add AgentNDX MCP directory

### DIFF
--- a/docs/utilities--helpers.md
+++ b/docs/utilities--helpers.md
@@ -2,6 +2,7 @@
 
 Servers providing simple, general-purpose tools like time/date information, calculators, dice rollers, formatters, unit converters, UUID generation, etc.
 
+- [AgentNDX](https://agentndx.ai/mcp): Search and discover MCP servers, A2A agents, and x402-enabled services through a hosted MCP directory endpoint. Includes search, server details, category listing, and registry stats tools over Streamable HTTP. Docs: https://agentndx.ai/api.
 - [dmeldrum6/PHP-MCP-Web-Tools](https://github.com/dmeldrum6/PHP-MCP-Web-Tools) - PHP MCP tools including fetch webpage, fetch links, date & time, DNS lookup, text utils, MCP Server code and chat client configured for using them
 - [rogertheunissenmerge-oss/mcp-server](https://github.com/rogertheunissenmerge-oss/mcp-server): Remote MCP server for sommelier-grade wine pairing. 7 tools powered by a proprietary Wine DNA algorithm with 600+ wine archetypes. Pair wines with meals, ingredients, or recipe URLs; reverse pairing; group dinner planning. Supports API key and x402 pay-per-call (USDC on Base). Live at `https://api.sommelierx.com/mcp`.
 - [Markgatcha/universal-mcp-toolkit](https://github.com/Markgatcha/universal-mcp-toolkit): An all-in-one MCP server aggregating 15+ tools across file system, web search, weather, SQLite database, system info, and more. Zero-config via `npx universal-mcp-toolkit`, Glama-listed, 100+ monthly npm downloads.


### PR DESCRIPTION
## Summary

Adds AgentNDX to `docs/utilities--helpers.md` as a hosted MCP directory/search endpoint.

AgentNDX exposes an MCP endpoint at https://agentndx.ai/mcp for:
- searching MCP servers
- fetching server details
- listing categories
- fetching registry stats

Docs: https://agentndx.ai/api
