### PR TITLE
Add agent-qa MCP server

### DIFF
--- a/docs/code-analysis--quality.md
+++ b/docs/code-analysis--quality.md
@@ -111,6 +111,7 @@ Servers focused on static analysis, linting, code metrics, security scanning, vu
 - [Laith0003/ux-skill](https://github.com/Laith0003/ux-skill): Deterministic design-intelligence MCP server with 18 tools that lints AI-generated UI against 152 anti-slop rules, drawing on 160 brand specs and a 7-axis synthesizer. Runs fully offline and never calls an LLM.
 
 - [Vulert](https://www.vulert.com): Vulert secures software by detecting vulnerabilities in open-source dependencies—without accessing your code. It supports Js, PHP, Java, Python, and more.
+- [vostride/agent-qa](https://github.com/vostride/agent-qa): Self-improving agentic QA harness with a local MCP server for authoring, running, validating, and triaging natural-language web and mobile tests. Install: `npm install -D agent-qa`.
 - [autonomous-testing/wopee-mcp](https://github.com/autonomous-testing/wopee-mcp): AI testing agents for web apps — dispatch test runs, analysis crawls, and AI agent tests, fetch artifacts and project status.
 - [Aboudjem/sniff](https://github.com/Aboudjem/sniff): Autonomous QA and accessibility scanner that walks real user flows in a headless browser, reporting broken pages, dead links, console errors, and WCAG issues. Install with `npx -y sniff-qa --mcp`.
 - [Aboudjem/ui-ux-suite](https://github.com/Aboudjem/ui-ux-suite): UI/UX design-audit server that scores a project across 12 dimensions including color contrast, typography, accessibility, layout, and spacing against WCAG 2.2 and APCA. Install with `npx -y ui-ux-suite`.


### PR DESCRIPTION
## Summary

Adds `vostride/agent-qa` to `docs/code-analysis--quality.md`.

## Why

`agent-qa` is a self-improving agentic QA harness with a local MCP server for authoring, running, validating, and triaging natural-language web and mobile tests. The entry includes the public npm install command requested by the contribution guide.
