### PR TITLE
Add WhatsApp MCP

### DIFF
--- a/docs/communication--messaging.md
+++ b/docs/communication--messaging.md
@@ -4,6 +4,7 @@ Servers for interacting with email, chat platforms, SMS, or notification service
 
 - [nylas/cli](https://github.com/nylas/cli): MCP server for email, calendar, and contacts. 16 tools across Gmail, Outlook, Exchange, Yahoo, iCloud, and IMAP via a single auth flow. JSON output, install with `nylas mcp install`, works with Claude Code, Cursor, Codex, and Windsurf. Docs at https://cli.nylas.com.
 - [Rich627/whatsapp-claude-plugin](https://github.com/Rich627/whatsapp-claude-plugin): WhatsApp channel plugin for Claude Code. Connect WhatsApp as a native channel to your Claude Code session — send/receive messages, voice transcription, access control, and remote tool approval. Uses Baileys (no API keys needed).
+- [meharajM/whatsapp-mcp](https://github.com/meharajM/whatsapp-mcp): Human-in-the-loop approvals and notifications for AI agents via WhatsApp. Enables Cursor, Claude Code, and autonomous AI agents to reach users when they are away from their computers.
 - [jamesacklin/tlon-mcp-server](https://github.com/jamesacklin/tlon-mcp-server): Facilitates interaction with Tlon agents through direct messaging, contact management, and natural language support.
 - [varunwahi-plivo/plivo-mcp-server](https://github.com/varunwahi-plivo/plivo-mcp-server): Facilitates SMS messaging through Plivo's API using the Message Control Protocol.
 - [virtualsms-io/mcp-server](https://github.com/virtualsms-io/mcp-server): Enables AI agents to get virtual phone numbers and receive SMS/OTP codes for automated phone verification workflows via VirtualSMS API.


### PR DESCRIPTION
Adds WhatsApp MCP.

Repository:
https://github.com/meharajM/whatsapp-mcp

Description:
Human-in-the-loop approvals and notifications for AI agents via WhatsApp.