### PR TITLE
Add MCP Index badge endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Useful endpoints:
 - `GET /v1/servers?query=postgres&limit=5` - search servers by name, description, category, or URL.
 - `GET /v1/servers?category=Databases&transport=stdio` - filter by category, transport, auth type, and result limit.
 - `GET /v1/servers/{id}` - fetch the normalized profile for one MCP server.
+- `GET /v1/servers/{id}/badge.svg` - render a TensorBlock MCP Index badge for project READMEs.
 - `GET /v1/servers/{id}/install-config?client=claude-desktop` - generate an MCP client config for Claude Desktop, Cursor, Codex, or VS Code.
 - `https://tensorblock.co/mcp/servers/{id}` - share a public website profile for an indexed server.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,43 @@ TensorBlock MCP Index turns this community-curated MCP server directory into a h
 
 This repo currently indexes **7,493 unique MCP server links** from the category docs. The README stays lightweight while the full directory lives in `docs/*.md`, `data/catalog.json`, and the registry MCP server.
 
+## How to Participate
+
+This repo is a community directory plus a hosted index. Every useful contribution makes the MCP Index easier for people and agents to search, compare, install, and verify.
+
+Choose the path that matches what you want to do.
+
+**If you maintain an MCP server:**
+
+- Add your server to the best category under [Browse by Category](#browse-by-category).
+- Improve your existing entry with install command, transport, auth requirements, supported clients, docs URL, license, endpoint, and tool details.
+- Claim your TensorBlock MCP profile by opening an issue with the server id or public profile URL.
+- Add the TensorBlock MCP Index badge to your project README so users can jump from your repo to the indexed profile.
+
+**If you build MCP clients, agents, or developer tools:**
+
+- Use the hosted API at [https://mcp-index.tensorblock.co](https://mcp-index.tensorblock.co) to search servers, fetch normalized profiles, list categories, or generate install-config previews.
+- Request another install target by opening an issue with the client name, expected config shape, example config, and official docs.
+- Help improve the config generator for Claude Desktop, Cursor, Codex, VS Code, and future clients.
+
+**If you want to improve the index itself:**
+
+- Fix duplicate, stale, broken, or poorly categorized entries.
+- Add missing metadata that makes search and install generation more accurate.
+- Propose verification signals, health checks, ranking improvements, or better category rules.
+- Join the [TensorBlock Discord](https://discord.com/invite/Ej5NmeHFf2) to discuss roadmap work before opening a larger PR.
+
+New server entries can be simple, but high-quality metadata makes the profile much more useful. The best entries answer:
+
+- What can an agent do with this server?
+- How does a user install or connect to it?
+- Does it use `stdio`, `sse`, or `streamable-http`?
+- Does it require an API key, OAuth, bearer token, or no auth?
+- Which MCP clients does it support?
+- Where are the setup docs, source repo, license, and public endpoint?
+
+After a PR lands on `main`, the deploy workflow rebuilds the catalog and profiles. The hosted API and public profile pages refresh after the Railway deployment succeeds.
+
 ## TensorBlock MCP Index
 
 This repo is both a community directory and an agent-ready index. Humans add MCP servers in markdown category pages; the indexer turns those entries into structured data that agents can search, inspect, and use to draft install configs.
@@ -74,11 +111,11 @@ For local development:
 - `npm run registry:mcp` starts a local registry MCP server with `search_servers`, `get_server_profile`, and `get_install_config` tools.
 - `npm run registry:api:dev` starts a local HTTP API for search, category browsing, profiles, and install configs. See [TensorBlock MCP Index API](docs/index-api.md).
 
-That means contributors still submit a normal awesome-list entry, but better metadata makes the entry more useful to agents. When possible, include install command, transport, auth type, supported clients, tool count, license, docs URL, and public remote endpoint. See the [MCP Index Metadata Contribution Guide](docs/index-alpha/contribution-guide.md) for examples.
+Contributors still submit normal awesome-list entries, but better metadata makes each entry more useful to agents. See the [MCP Index Metadata Contribution Guide](docs/index-alpha/contribution-guide.md) for examples.
 
-## Contributing
+## Add or Improve an Entry
 
-We welcome MCP server submissions. To add your server:
+To add a new MCP server:
 
 1. Pick the best category from [Browse by Category](#browse-by-category).
 2. Open that category page under `docs/`.
@@ -89,15 +126,11 @@ We welcome MCP server submissions. To add your server:
 4. Search the repo for your URL or project name to avoid duplicates.
 5. Open a pull request.
 
-Good entries answer these questions in one or two sentences:
-
-- What can an agent do with this server?
-- How does a user install or connect to it?
-- Does it use `stdio`, `sse`, or `streamable-http`?
-- Does it require an API key, OAuth, or no auth?
-- Which MCP clients does it support?
+To improve an existing server, edit the same markdown bullet where the server is listed. Add missing install, transport, auth, docs, license, client, tool, endpoint, or maintainer information in the description when possible.
 
 Generated files such as `data/catalog.json` and `data/profiles/*.json` are maintained by the indexer. If you only add a server entry, editing the relevant `docs/*.md` category page is enough for the PR.
+
+For metadata and indexer examples, see the [MCP Index Metadata Contribution Guide](docs/index-alpha/contribution-guide.md).
 
 For maintainers validating a metadata/indexer change:
 

--- a/docs/index-api.md
+++ b/docs/index-api.md
@@ -17,6 +17,7 @@ GET /v1
 GET /v1/categories
 GET /v1/servers?query=&category=&transport=&auth=&limit=
 GET /v1/servers/{id}
+GET /v1/servers/{id}/badge.svg
 GET /v1/servers/{id}/install-config?client=claude-desktop|cursor|codex|vscode
 ```
 
@@ -53,6 +54,12 @@ https://tensorblock.co/mcp/servers/postgres-mcp
 ```
 
 The API also keeps `GET /servers/{id}` as a lightweight HTML fallback, but the canonical community profile is hosted on the TensorBlock website.
+
+Embed an MCP Index badge in a project README:
+
+```markdown
+[![Indexed on TensorBlock MCP Index](https://mcp-index.tensorblock.co/v1/servers/postgres-mcp/badge.svg)](https://tensorblock.co/mcp/servers/postgres-mcp)
+```
 
 Generate an install config:
 

--- a/packages/profile-renderer/src/renderProfiles.ts
+++ b/packages/profile-renderer/src/renderProfiles.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { CatalogEntry } from "../../catalog-builder/src/types.js";
+import { badgeMarkdown } from "../../registry-api/src/badge.js";
 
 export interface ServerProfile {
   id: string;
@@ -29,7 +30,7 @@ export const renderProfile = (entry: CatalogEntry, baseUrl: string): ServerProfi
     description: entry.description,
     category: entry.category,
     profileUrl,
-    badgeMarkdown: `[![Listed on TensorBlock MCP Index](https://img.shields.io/badge/TensorBlock-MCP%20Index-blue)](${profileUrl})`,
+    badgeMarkdown: badgeMarkdown(entry, profileUrl),
     links: entry.links,
     summary: {
       transport: entry.transport,

--- a/packages/profile-renderer/test/renderProfiles.test.ts
+++ b/packages/profile-renderer/test/renderProfiles.test.ts
@@ -59,11 +59,13 @@ const createEntry = (overrides: Partial<CatalogEntry> = {}): CatalogEntry => ({
 
 describe("renderProfile", () => {
   it("renders static profile metadata for a catalog entry", () => {
-    const profile = renderProfile(createEntry(), "https://tensorblock.co/mcp");
+    const profile = renderProfile(createEntry(), "https://tensorblock.co/mcp/servers");
 
     expect(profile.id).toBe("github-owner-demo");
-    expect(profile.profileUrl).toBe("https://tensorblock.co/mcp/github-owner-demo");
-    expect(profile.badgeMarkdown).toContain("Listed on TensorBlock MCP Index");
+    expect(profile.profileUrl).toBe("https://tensorblock.co/mcp/servers/github-owner-demo");
+    expect(profile.badgeMarkdown).toBe(
+      "[![Indexed on TensorBlock MCP Index](https://mcp-index.tensorblock.co/v1/servers/github-owner-demo/badge.svg)](https://tensorblock.co/mcp/servers/github-owner-demo)"
+    );
     expect(profile.summary.installConfidence).toBe("medium");
   });
 

--- a/packages/registry-api/src/badge.ts
+++ b/packages/registry-api/src/badge.ts
@@ -1,0 +1,46 @@
+import type { CatalogEntry } from "../../catalog-builder/src/types.js";
+import { webProfileUrl } from "./webProfile.js";
+
+const DEFAULT_API_BASE_URL = "https://mcp-index.tensorblock.co";
+
+export const badgeImageUrl = (serverId: string): string =>
+  `${apiBaseUrl()}/v1/servers/${encodeURIComponent(serverId)}/badge.svg`;
+
+export const badgeMarkdown = (
+  entry: CatalogEntry,
+  profileUrl = webProfileUrl(entry.id)
+): string =>
+  `[![Indexed on TensorBlock MCP Index](${badgeImageUrl(entry.id)})](${profileUrl})`;
+
+export const renderBadgeSvg = (entry: CatalogEntry): string => {
+  const title = `${entry.name} is indexed on TensorBlock MCP Index`;
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="246" height="34" viewBox="0 0 246 34" role="img" aria-label="${escapeAttribute(title)}">
+  <title>${escapeXml(title)}</title>
+  <defs>
+    <clipPath id="r">
+      <rect width="246" height="34" rx="6"/>
+    </clipPath>
+  </defs>
+  <g clip-path="url(#r)">
+    <rect width="246" height="34" fill="#f8f7f3"/>
+    <rect width="136" height="34" fill="#0c0a09"/>
+    <rect x="135.5" y="0.5" width="110" height="33" fill="#f8f7f3" stroke="#e6e3db"/>
+    <path d="M14 8h16l8 4-8 4H14l8-4-8-4Zm0 9h16l8 4-8 4H14l8-4-8-4Zm0 9h16l8 4-8 4H14l8-4-8-4Z" fill="none" stroke="#f8f7f3" stroke-width="1.25" stroke-linejoin="round"/>
+    <text x="48" y="21.5" fill="#f8f7f3" font-family="Inter, Arial, sans-serif" font-size="12" font-weight="650">TensorBlock</text>
+    <text x="150" y="21.5" fill="#0c0a09" font-family="Inter, Arial, sans-serif" font-size="12" font-weight="650">MCP Indexed</text>
+  </g>
+</svg>`;
+};
+
+const apiBaseUrl = (): string =>
+  (process.env.MCP_INDEX_API_BASE_URL ?? DEFAULT_API_BASE_URL).replace(/\/+$/, "");
+
+const escapeAttribute = (value: string): string =>
+  escapeXml(value).replace(/"/g, "&quot;");
+
+const escapeXml = (value: string): string =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");

--- a/packages/registry-api/src/server.ts
+++ b/packages/registry-api/src/server.ts
@@ -14,6 +14,7 @@ import {
 } from "./search.js";
 import { renderServerProfilePage } from "./profilePage.js";
 import { webProfileTemplate } from "./webProfile.js";
+import { renderBadgeSvg } from "./badge.js";
 
 const CLIENT_ALIASES: Record<string, ClientName> = {
   "claude": "claude",
@@ -90,6 +91,18 @@ const handleRequest = async (
       return;
     }
 
+    if (segments[0] === "servers" && segments[2] === "badge.svg" && segments.length === 3) {
+      const entry = findServer(state.catalog, segments[1]);
+
+      if (!entry) {
+        sendError(response, 404, `Server not found: ${segments[1]}`);
+        return;
+      }
+
+      sendSvg(response, 200, renderBadgeSvg(entry));
+      return;
+    }
+
     if (segments[0] !== "v1") {
       sendError(response, 404, "Not found");
       return;
@@ -121,6 +134,11 @@ const handleRequest = async (
       return;
     }
 
+    if (segments[1] === "servers" && segments[3] === "badge.svg" && segments.length === 4) {
+      handleBadge(response, state.catalog, segments[2]);
+      return;
+    }
+
     if (segments[1] === "servers" && segments[3] === "install-config" && segments.length === 4) {
       handleInstallConfig(url, response, state.catalog, segments[2]);
       return;
@@ -145,6 +163,7 @@ const discoveryPayload = (state: RegistryApiState) => ({
     getServer: "/v1/servers/{id}",
     serverProfile: webProfileTemplate(),
     apiHtmlProfile: "/servers/{id}",
+    badge: "/v1/servers/{id}/badge.svg",
     getInstallConfig: "/v1/servers/{id}/install-config?client=claude-desktop",
   },
   docs: "https://github.com/TensorBlock/awesome-mcp-servers/blob/main/docs/index-api.md",
@@ -214,6 +233,21 @@ const handleInstallConfig = (
   sendJson(response, 200, generateClientConfig(entry, client));
 };
 
+const handleBadge = (
+  response: ServerResponse,
+  catalog: CatalogEntry[],
+  serverId: string
+): void => {
+  const entry = findServer(catalog, serverId);
+
+  if (!entry) {
+    sendError(response, 404, `Server not found: ${serverId}`);
+    return;
+  }
+
+  sendSvg(response, 200, renderBadgeSvg(entry));
+};
+
 const normalizeClientName = (client: string): ClientName | null =>
   CLIENT_ALIASES[client.toLowerCase()] ?? null;
 
@@ -270,6 +304,18 @@ const sendHtml = (response: ServerResponse, statusCode: number, value: string): 
     "Access-Control-Allow-Headers": "Content-Type",
     "Cache-Control": statusCode === 200 ? "public, max-age=300" : "no-store",
     "Content-Type": "text/html; charset=utf-8",
+  });
+
+  response.end(value);
+};
+
+const sendSvg = (response: ServerResponse, statusCode: number, value: string): void => {
+  response.writeHead(statusCode, {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+    "Cache-Control": statusCode === 200 ? "public, max-age=3600" : "no-store",
+    "Content-Type": "image/svg+xml; charset=utf-8",
   });
 
   response.end(value);

--- a/packages/registry-api/test/badge.test.ts
+++ b/packages/registry-api/test/badge.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import type { CatalogEntry } from "../../catalog-builder/src/types.js";
+import { badgeImageUrl, badgeMarkdown, renderBadgeSvg } from "../src/badge.js";
+
+const entry: CatalogEntry = {
+  id: "unsafe-demo",
+  name: "Unsafe <Demo>",
+  description: "Demo.",
+  category: "Utilities & Helpers",
+  source: {
+    readmePath: null,
+    docsPath: "docs/utilities--helpers.md",
+    featuredInReadme: false,
+  },
+  links: {
+    primary: "https://github.com/example/unsafe-demo",
+    repo: "https://github.com/example/unsafe-demo",
+    homepage: null,
+    docs: null,
+    endpoint: null,
+  },
+  install: {
+    commands: ["npx unsafe-demo"],
+    env: [],
+    confidence: "medium",
+  },
+  transport: ["stdio"],
+  auth: {
+    type: "unknown",
+    notes: [],
+  },
+  clients: [],
+  tools: {
+    count: null,
+    names: [],
+    source: "unknown",
+  },
+  license: "unknown",
+  health: {
+    repoPublic: null,
+    packageFound: null,
+    endpointReachable: null,
+    lastCheckedAt: null,
+  },
+  verification: {
+    status: "unknown",
+    notes: [],
+  },
+  community: {
+    maintainedBy: [],
+    verifiedBy: [],
+    claimed: false,
+  },
+};
+
+describe("badge helpers", () => {
+  it("renders a branded SVG badge and escapes server names", () => {
+    const svg = renderBadgeSvg(entry);
+
+    expect(svg).toContain("TensorBlock");
+    expect(svg).toContain("MCP Indexed");
+    expect(svg).toContain("Unsafe &lt;Demo&gt;");
+    expect(svg).not.toContain("Unsafe <Demo>");
+  });
+
+  it("builds copy-ready badge markdown", () => {
+    expect(badgeImageUrl(entry.id)).toBe("https://mcp-index.tensorblock.co/v1/servers/unsafe-demo/badge.svg");
+    expect(badgeMarkdown(entry, "https://example.com/profile")).toBe(
+      "[![Indexed on TensorBlock MCP Index](https://mcp-index.tensorblock.co/v1/servers/unsafe-demo/badge.svg)](https://example.com/profile)"
+    );
+  });
+});

--- a/packages/registry-api/test/server.test.ts
+++ b/packages/registry-api/test/server.test.ts
@@ -89,6 +89,7 @@ describe("registry API server", () => {
     expect(body.endpoints.searchServers).toBe("/v1/servers?query=postgres&limit=5");
     expect(body.endpoints.serverProfile).toBe("https://tensorblock.co/mcp/servers/{id}");
     expect(body.endpoints.apiHtmlProfile).toBe("/servers/{id}");
+    expect(body.endpoints.badge).toBe("/v1/servers/{id}/badge.svg");
   });
 
   it("keeps the version discovery path available", async () => {
@@ -113,6 +114,19 @@ describe("registry API server", () => {
     expect(body).toContain("https://tensorblock.co/mcp/servers/postgres-mcp");
     expect(body).toContain("/v1/servers/postgres-mcp");
     expect(body).toContain("claude-desktop");
+  });
+
+  it("serves a branded SVG badge for a server", async () => {
+    const baseUrl = await startServer();
+    const response = await fetch(`${baseUrl}/v1/servers/postgres-mcp/badge.svg`);
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("image/svg+xml");
+    expect(body).toContain("<svg");
+    expect(body).toContain("TensorBlock");
+    expect(body).toContain("MCP Indexed");
+    expect(body).toContain("Postgres MCP is indexed on TensorBlock MCP Index");
   });
 
   it("returns JSON errors for missing profile pages", async () => {


### PR DESCRIPTION
## Summary
- add a branded SVG badge endpoint for indexed MCP servers
- include badge markdown in generated profile JSON
- document badge usage in the hosted API docs and README

## Verification
- npm test
- npm run typecheck
- npm run build
- git diff --check
- local smoke test: GET /v1/servers/{id}/badge.svg returns image/svg+xml