### PR TITLE
Add MCP community issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-mcp-server.yml
+++ b/.github/ISSUE_TEMPLATE/add-mcp-server.yml
@@ -1,0 +1,110 @@
+name: Add MCP server
+description: Submit a new MCP server for the community directory and index.
+title: "Add MCP server: "
+labels:
+  - server-submission
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve the TensorBlock MCP Index. If you can edit the category markdown directly, a pull request is still the fastest path. Use this issue form when you want help choosing the category or shaping the entry.
+  - type: input
+    id: server-name
+    attributes:
+      label: Server name
+      description: The public project or package name.
+      placeholder: owner/project-name
+    validations:
+      required: true
+  - type: input
+    id: project-url
+    attributes:
+      label: Project URL
+      description: GitHub repo, package page, homepage, or docs URL.
+      placeholder: https://github.com/owner/project
+    validations:
+      required: true
+  - type: dropdown
+    id: category
+    attributes:
+      label: Best category
+      description: Pick the closest category. We can adjust it during triage.
+      options:
+        - AI & LLM Integration
+        - Browser Automation & Web Scraping
+        - Cloud Platforms & Services
+        - Code Execution
+        - Databases
+        - Developer Productivity & Utilities
+        - Filesystems
+        - Knowledge Management & Memory
+        - Monitoring & Observability
+        - Operating System & Command Line
+        - Search
+        - Security
+        - Other / not sure
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: What can an agent do with this server?
+      description: Keep it short and specific. This text may become the indexed description.
+      placeholder: This MCP server lets agents...
+    validations:
+      required: true
+  - type: textarea
+    id: install
+    attributes:
+      label: Install or connection instructions
+      description: Include commands, package names, remote endpoint URLs, and required environment variables.
+      placeholder: |
+        Install: npx -y your-package
+        Env: API_KEY
+    validations:
+      required: false
+  - type: dropdown
+    id: transport
+    attributes:
+      label: Transport
+      options:
+        - stdio
+        - sse
+        - streamable-http
+        - multiple
+        - unknown
+    validations:
+      required: false
+  - type: dropdown
+    id: auth
+    attributes:
+      label: Auth requirements
+      options:
+        - none
+        - api-key
+        - oauth
+        - bearer
+        - unknown
+    validations:
+      required: false
+  - type: input
+    id: clients
+    attributes:
+      label: Known supported clients
+      placeholder: Claude Desktop, Cursor, Codex, VS Code, other
+    validations:
+      required: false
+  - type: input
+    id: license
+    attributes:
+      label: License
+      placeholder: MIT, Apache-2.0, unknown
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched the repo for this project URL or name to avoid duplicates.
+          required: true

--- a/.github/ISSUE_TEMPLATE/claim-profile.yml
+++ b/.github/ISSUE_TEMPLATE/claim-profile.yml
@@ -1,0 +1,45 @@
+name: Claim MCP profile
+description: Let maintainers connect an indexed profile to their project.
+title: "Claim MCP profile: "
+labels:
+  - claim-profile
+body:
+  - type: input
+    id: profile-url
+    attributes:
+      label: TensorBlock profile URL or server id
+      placeholder: https://tensorblock.co/mcp/servers/... or server id
+    validations:
+      required: true
+  - type: input
+    id: project-url
+    attributes:
+      label: Project URL
+      placeholder: https://github.com/owner/project
+    validations:
+      required: true
+  - type: input
+    id: maintainer
+    attributes:
+      label: Maintainer handle
+      description: GitHub username, package owner, or organization handle.
+      placeholder: "@maintainer"
+    validations:
+      required: true
+  - type: textarea
+    id: proof
+    attributes:
+      label: Maintainer proof
+      description: Explain how we can verify your relationship to the project.
+      placeholder: |
+        I am an owner of the GitHub repo / npm package / organization.
+        Verification link:
+    validations:
+      required: true
+  - type: textarea
+    id: metadata
+    attributes:
+      label: Metadata you want displayed
+      description: Optional maintainer, verification, docs, or support details for the indexed profile.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: TensorBlock Discord
+    url: https://discord.com/invite/Ej5NmeHFf2
+    about: Discuss metadata quality, profile claims, client config formats, and roadmap work with the community.
+  - name: Hosted MCP Index API
+    url: https://mcp-index.tensorblock.co
+    about: Explore the live API discovery page, search endpoints, profile endpoints, badges, and install-config generation.
+  - name: MCP Index API docs
+    url: https://github.com/TensorBlock/awesome-mcp-servers/blob/main/docs/index-api.md
+    about: Read the HTTP API docs before building against the index.

--- a/.github/ISSUE_TEMPLATE/improve-metadata.yml
+++ b/.github/ISSUE_TEMPLATE/improve-metadata.yml
@@ -1,0 +1,54 @@
+name: Improve MCP metadata
+description: Fix or enrich an indexed MCP server profile.
+title: "Improve metadata: "
+labels:
+  - metadata
+body:
+  - type: input
+    id: profile-url
+    attributes:
+      label: TensorBlock profile URL or server id
+      placeholder: https://tensorblock.co/mcp/servers/... or server id
+    validations:
+      required: true
+  - type: input
+    id: project-url
+    attributes:
+      label: Project URL
+      placeholder: https://github.com/owner/project
+    validations:
+      required: false
+  - type: checkboxes
+    id: fields
+    attributes:
+      label: Metadata to update
+      options:
+        - label: Description
+        - label: Category
+        - label: Install command
+        - label: Environment variables
+        - label: Transport
+        - label: Auth requirements
+        - label: Supported clients
+        - label: Tool names or tool count
+        - label: Docs URL
+        - label: License
+        - label: Health or verification status
+  - type: textarea
+    id: changes
+    attributes:
+      label: Correct metadata
+      description: Include the exact values we should index and links to source docs when possible.
+      placeholder: |
+        Transport: stdio
+        Auth: api-key, requires EXAMPLE_API_KEY
+        Install: npx -y example-mcp
+    validations:
+      required: true
+  - type: textarea
+    id: source
+    attributes:
+      label: Source or proof
+      description: Link docs, README sections, package pages, maintainer comments, or other references.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/report-broken-entry.yml
+++ b/.github/ISSUE_TEMPLATE/report-broken-entry.yml
@@ -1,0 +1,40 @@
+name: Report broken entry
+description: Report a duplicate, dead link, bad category, stale metadata, or unsafe entry.
+title: "Report broken MCP entry: "
+labels:
+  - broken-entry
+body:
+  - type: input
+    id: profile-url
+    attributes:
+      label: TensorBlock profile URL, server id, or project URL
+      placeholder: https://tensorblock.co/mcp/servers/... or https://github.com/owner/project
+    validations:
+      required: true
+  - type: checkboxes
+    id: issue-type
+    attributes:
+      label: What is wrong?
+      options:
+        - label: Dead link
+        - label: Duplicate entry
+        - label: Wrong category
+        - label: Incorrect install command
+        - label: Incorrect auth or transport metadata
+        - label: Stale project
+        - label: Security or safety concern
+        - label: Other
+  - type: textarea
+    id: details
+    attributes:
+      label: Details
+      description: Explain the issue and include the corrected value if you know it.
+    validations:
+      required: true
+  - type: input
+    id: source
+    attributes:
+      label: Source or proof
+      placeholder: https://...
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/request-client-config.yml
+++ b/.github/ISSUE_TEMPLATE/request-client-config.yml
@@ -1,0 +1,44 @@
+name: Request client config support
+description: Request install-config generation for another MCP client or format.
+title: "Request client config support: "
+labels:
+  - client-config
+body:
+  - type: input
+    id: client
+    attributes:
+      label: Client or install target
+      placeholder: Claude Code, Windsurf, Continue, custom agent runtime
+    validations:
+      required: true
+  - type: textarea
+    id: config-shape
+    attributes:
+      label: Expected config shape
+      description: Paste an example config or describe the required file format.
+      render: json
+      placeholder: |
+        {
+          "mcpServers": {
+            "example": {
+              "command": "npx",
+              "args": ["-y", "example-mcp"]
+            }
+          }
+        }
+    validations:
+      required: true
+  - type: input
+    id: docs
+    attributes:
+      label: Official docs or reference
+      placeholder: https://...
+    validations:
+      required: false
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Include platform differences, auth handling, env var behavior, or examples from real MCP servers.
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -32,20 +32,20 @@ Choose the path that matches what you want to do.
 
 **If you maintain an MCP server:**
 
-- Add your server to the best category under [Browse by Category](#browse-by-category).
-- Improve your existing entry with install command, transport, auth requirements, supported clients, docs URL, license, endpoint, and tool details.
-- Claim your TensorBlock MCP profile by opening an issue with the server id or public profile URL.
+- Add your server to the best category under [Browse by Category](#browse-by-category), or use the [Add MCP server issue form](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=add-mcp-server.yml).
+- Improve your existing entry with install command, transport, auth requirements, supported clients, docs URL, license, endpoint, and tool details. Use the [metadata issue form](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=improve-metadata.yml) if you do not want to open a PR directly.
+- Claim your TensorBlock MCP profile with the [claim profile issue form](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=claim-profile.yml).
 - Add the TensorBlock MCP Index badge to your project README so users can jump from your repo to the indexed profile.
 
 **If you build MCP clients, agents, or developer tools:**
 
 - Use the hosted API at [https://mcp-index.tensorblock.co](https://mcp-index.tensorblock.co) to search servers, fetch normalized profiles, list categories, or generate install-config previews.
-- Request another install target by opening an issue with the client name, expected config shape, example config, and official docs.
+- Request another install target with the [client config issue form](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=request-client-config.yml). Include the client name, expected config shape, example config, and official docs.
 - Help improve the config generator for Claude Desktop, Cursor, Codex, VS Code, and future clients.
 
 **If you want to improve the index itself:**
 
-- Fix duplicate, stale, broken, or poorly categorized entries.
+- Fix duplicate, stale, broken, or poorly categorized entries. Use the [broken entry issue form](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=report-broken-entry.yml) when you want maintainers to triage it.
 - Add missing metadata that makes search and install generation more accurate.
 - Propose verification signals, health checks, ranking improvements, or better category rules.
 - Join the [TensorBlock Discord](https://discord.com/invite/Ej5NmeHFf2) to discuss roadmap work before opening a larger PR.
@@ -125,6 +125,8 @@ To add a new MCP server:
    ```
 4. Search the repo for your URL or project name to avoid duplicates.
 5. Open a pull request.
+
+If you are not sure where the server belongs, use the [Add MCP server issue form](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=add-mcp-server.yml) and we can help route it.
 
 To improve an existing server, edit the same markdown bullet where the server is listed. Add missing install, transport, auth, docs, license, client, tool, endpoint, or maintainer information in the description when possible.
 


### PR DESCRIPTION
## Summary
- add GitHub issue forms for MCP server submissions, metadata fixes, profile claims, client config requests, and broken entries
- add issue template contact links for Discord, hosted API, and API docs
- update README participation paths to link directly to the right issue forms
- create matching triage labels for community participation workflows

## Verification
- ruby YAML parse for all .github/ISSUE_TEMPLATE/*.yml
- git diff --check