### PR TITLE
Add MCP issue triage automation

### DIFF
--- a/.github/scripts/triage-issue.mjs
+++ b/.github/scripts/triage-issue.mjs
@@ -1,0 +1,368 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const API_BASE = "https://api.github.com";
+const COMMENT_MARKER_PREFIX = "<!-- tensorblock-mcp-issue-triage:v1";
+
+const LABEL_DEFINITIONS = {
+  "community-intake": {
+    color: "C5DEF5",
+    description: "Community-submitted MCP Index issue.",
+  },
+  "needs-triage": {
+    color: "FBCA04",
+    description: "Needs maintainer routing or verification.",
+  },
+  "priority-high": {
+    color: "D73A4A",
+    description: "High priority security, safety, or broken core-flow issue.",
+  },
+  "good-first-metadata": {
+    color: "7057FF",
+    description: "Good first contribution for MCP metadata cleanup.",
+  },
+  verification: {
+    color: "0E8A16",
+    description: "Needs maintainer or source verification.",
+  },
+};
+
+const ROUTES = [
+  {
+    id: "server-submission",
+    label: "server-submission",
+    titlePrefix: "Add MCP server:",
+    name: "server submission",
+  },
+  {
+    id: "metadata",
+    label: "metadata",
+    titlePrefix: "Improve metadata:",
+    name: "metadata improvement",
+  },
+  {
+    id: "claim-profile",
+    label: "claim-profile",
+    titlePrefix: "Claim MCP profile:",
+    name: "profile claim",
+  },
+  {
+    id: "client-config",
+    label: "client-config",
+    titlePrefix: "Request client config support:",
+    name: "client config request",
+  },
+  {
+    id: "broken-entry",
+    label: "broken-entry",
+    titlePrefix: "Report broken MCP entry:",
+    name: "broken entry report",
+  },
+];
+
+export function routeIssue(issue) {
+  const labels = new Set(labelNames(issue));
+  const title = issue.title ?? "";
+
+  return (
+    ROUTES.find((route) => labels.has(route.label)) ??
+    ROUTES.find((route) => title.startsWith(route.titlePrefix)) ??
+    null
+  );
+}
+
+export function labelsForIssue(issue, action = "opened") {
+  const route = routeIssue(issue);
+  if (!route) {
+    return [];
+  }
+
+  const labels = new Set(["community-intake"]);
+
+  if (action === "opened" || action === "reopened") {
+    labels.add("needs-triage");
+  }
+
+  if (route.id === "metadata") {
+    labels.add("good-first-metadata");
+  }
+
+  if (route.id === "claim-profile") {
+    labels.add("verification");
+  }
+
+  if (route.id === "broken-entry" && isSafetyReport(issue.body ?? "")) {
+    labels.add("priority-high");
+    labels.add("verification");
+  }
+
+  return Array.from(labels).filter((label) => !labelNames(issue).includes(label));
+}
+
+export function buildTriageComment(issue) {
+  const route = routeIssue(issue);
+  if (!route) {
+    return null;
+  }
+
+  const issueNumber = issue.number ? `#${issue.number}` : "this issue";
+  const body = issue.body ?? "";
+
+  const templates = {
+    "server-submission": [
+      `Thanks for submitting this MCP server in ${issueNumber}.`,
+      "",
+      "What happens next:",
+      "- We will check for duplicates and route it to the closest category page.",
+      "- If the metadata is complete enough, a maintainer or contributor can turn this into a docs entry PR.",
+      "- Once merged, the Railway deploy rebuilds the catalog and the server becomes searchable through the hosted MCP Index API.",
+      "",
+      describeCapturedFields(body, [
+        ["Server", "Server name"],
+        ["Project", "Project URL"],
+        ["Category", "Best category"],
+      ]),
+    ],
+    metadata: [
+      `Thanks for improving MCP metadata in ${issueNumber}.`,
+      "",
+      "What happens next:",
+      "- We will verify the corrected values against the source links or project docs.",
+      "- Small metadata fixes are good first contributions; a direct PR against the matching `docs/*.md` category page is welcome.",
+      "- Better install, transport, auth, docs, license, and tool metadata improves search and install-config generation.",
+      "",
+      describeCapturedFields(body, [
+        ["Profile", "TensorBlock profile URL or server id"],
+        ["Project", "Project URL"],
+      ]),
+    ],
+    "claim-profile": [
+      `Thanks for claiming this MCP profile in ${issueNumber}.`,
+      "",
+      "What happens next:",
+      "- We will verify the maintainer relationship using the repo, package, organization, or docs proof you provided.",
+      "- After verification, the profile can show maintainer and claim metadata in the index.",
+      "- If the profile also needs install/auth/docs updates, include them here or open a metadata PR.",
+      "",
+      describeCapturedFields(body, [
+        ["Profile", "TensorBlock profile URL or server id"],
+        ["Project", "Project URL"],
+        ["Maintainer", "Maintainer handle"],
+      ]),
+    ],
+    "client-config": [
+      `Thanks for requesting client config support in ${issueNumber}.`,
+      "",
+      "What happens next:",
+      "- We will compare the requested config shape with the existing Claude Desktop, Cursor, Codex, and VS Code generators.",
+      "- Official docs and real examples are the fastest way to add reliable support for a new client or install target.",
+      "- Once support lands, indexed profiles can expose generated install-config previews for that target.",
+      "",
+      describeCapturedFields(body, [["Client", "Client or install target"]]),
+    ],
+    "broken-entry": [
+      `Thanks for reporting a broken MCP entry in ${issueNumber}.`,
+      "",
+      "What happens next:",
+      "- We will verify the duplicate, dead link, stale metadata, wrong category, or safety concern.",
+      "- If there is a clear correction, a direct PR against the matching `docs/*.md` entry is welcome.",
+      "- Safety or security reports are routed with higher priority.",
+      "",
+      describeCapturedFields(body, [["Entry", "TensorBlock profile URL, server id, or project URL"]]),
+    ],
+  };
+
+  return [
+    markerForRoute(route.id),
+    ...templates[route.id].filter(Boolean),
+    commonFooter(),
+  ].join("\n");
+}
+
+export function extractField(body, label) {
+  const pattern = new RegExp(`###\\s+${escapeRegex(label)}\\s*\\n+([\\s\\S]*?)(?=\\n###\\s+|$)`, "i");
+  const match = body.match(pattern);
+  if (!match) {
+    return "";
+  }
+
+  return match[1]
+    .replace(/<!--[\s\S]*?-->/g, "")
+    .trim();
+}
+
+export function markerForRoute(routeId) {
+  return `${COMMENT_MARKER_PREFIX}:${routeId} -->`;
+}
+
+function commonFooter() {
+  return [
+    "",
+    "Useful links:",
+    "- Contribution guide: https://github.com/TensorBlock/awesome-mcp-servers/blob/main/docs/index-alpha/contribution-guide.md",
+    "- Hosted MCP Index API: https://mcp-index.tensorblock.co",
+    "- TensorBlock Discord: https://discord.com/invite/Ej5NmeHFf2",
+    "",
+    "If the index is useful for your project, starring the repo helps more MCP builders discover it.",
+  ].join("\n");
+}
+
+function describeCapturedFields(body, fields) {
+  const rows = fields
+    .map(([label, fieldName]) => [label, compactField(extractField(body, fieldName))])
+    .filter(([, value]) => value);
+
+  if (rows.length === 0) {
+    return "";
+  }
+
+  return ["Captured from the form:", ...rows.map(([label, value]) => `- ${label}: ${value}`)].join("\n");
+}
+
+function compactField(value) {
+  return value
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join(" ")
+    .slice(0, 240);
+}
+
+function labelNames(issue) {
+  return (issue.labels ?? []).map((label) => (typeof label === "string" ? label : label.name)).filter(Boolean);
+}
+
+function isSafetyReport(body) {
+  return /security or safety concern/i.test(body);
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+async function main() {
+  const token = process.env.GITHUB_TOKEN;
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  const repository = process.env.GITHUB_REPOSITORY;
+
+  if (!token || !eventPath || !repository) {
+    throw new Error("GITHUB_TOKEN, GITHUB_EVENT_PATH, and GITHUB_REPOSITORY are required.");
+  }
+
+  const event = JSON.parse(fs.readFileSync(eventPath, "utf8"));
+  const issue = event.issue;
+  if (!issue) {
+    console.log("No issue payload found; skipping.");
+    return;
+  }
+
+  const route = routeIssue(issue);
+  if (!route) {
+    console.log(`Issue #${issue.number} does not match an MCP community issue form; skipping.`);
+    return;
+  }
+
+  const [owner, repo] = repository.split("/");
+  const request = createGitHubRequest({ token, owner, repo });
+  const labelsToAdd = labelsForIssue(issue, event.action);
+
+  await ensureLabels(request, labelsToAdd);
+
+  if (labelsToAdd.length > 0) {
+    await request(`/issues/${issue.number}/labels`, {
+      method: "POST",
+      body: { labels: labelsToAdd },
+    });
+    console.log(`Added labels to #${issue.number}: ${labelsToAdd.join(", ")}`);
+  } else {
+    console.log(`No labels to add to #${issue.number}.`);
+  }
+
+  const commentBody = buildTriageComment(issue);
+  await upsertTriageComment(request, issue.number, route.id, commentBody);
+}
+
+function createGitHubRequest({ token, owner, repo }) {
+  return async function request(path, options = {}) {
+    const response = await fetch(`${API_BASE}/repos/${owner}/${repo}${path}`, {
+      method: options.method ?? "GET",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      body: options.body ? JSON.stringify(options.body) : undefined,
+    });
+
+    const text = await response.text();
+    const data = text ? JSON.parse(text) : null;
+
+    if (!response.ok) {
+      const error = new Error(`GitHub API ${options.method ?? "GET"} ${path} failed: ${response.status}`);
+      error.status = response.status;
+      error.data = data;
+      throw error;
+    }
+
+    return data;
+  };
+}
+
+async function ensureLabels(request, labelNamesToEnsure) {
+  for (const name of labelNamesToEnsure) {
+    const definition = LABEL_DEFINITIONS[name];
+    if (!definition) {
+      continue;
+    }
+
+    try {
+      await request(`/labels/${encodeURIComponent(name)}`);
+    } catch (error) {
+      if (error.status !== 404) {
+        throw error;
+      }
+
+      await request("/labels", {
+        method: "POST",
+        body: {
+          name,
+          color: definition.color,
+          description: definition.description,
+        },
+      });
+      console.log(`Created missing label: ${name}`);
+    }
+  }
+}
+
+async function upsertTriageComment(request, issueNumber, routeId, body) {
+  const marker = markerForRoute(routeId);
+  const comments = await request(`/issues/${issueNumber}/comments?per_page=100`);
+  const existing = comments.find((comment) => comment.body?.includes(marker));
+
+  if (existing) {
+    await request(`/issues/comments/${existing.id}`, {
+      method: "PATCH",
+      body: { body },
+    });
+    console.log(`Updated triage comment on #${issueNumber}.`);
+    return;
+  }
+
+  await request(`/issues/${issueNumber}/comments`, {
+    method: "POST",
+    body: { body },
+  });
+  console.log(`Created triage comment on #${issueNumber}.`);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}
+

--- a/.github/scripts/triage-issue.test.mjs
+++ b/.github/scripts/triage-issue.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildTriageComment,
+  extractField,
+  labelsForIssue,
+  routeIssue,
+} from "./triage-issue.mjs";
+
+const metadataIssue = {
+  number: 42,
+  title: "Improve metadata: example",
+  labels: [{ name: "metadata" }],
+  body: [
+    "### TensorBlock profile URL or server id",
+    "",
+    "https://tensorblock.co/mcp/servers/github-owner-example",
+    "",
+    "### Project URL",
+    "",
+    "https://github.com/owner/example",
+  ].join("\n"),
+};
+
+test("routes issues by issue-form label", () => {
+  assert.equal(routeIssue(metadataIssue)?.id, "metadata");
+});
+
+test("routes issues by title prefix when labels are missing", () => {
+  const issue = { ...metadataIssue, labels: [], title: "Claim MCP profile: example" };
+  assert.equal(routeIssue(issue)?.id, "claim-profile");
+});
+
+test("adds triage and metadata labels on opened issues", () => {
+  assert.deepEqual(labelsForIssue(metadataIssue, "opened"), [
+    "community-intake",
+    "needs-triage",
+    "good-first-metadata",
+  ]);
+});
+
+test("does not re-add needs-triage on edited issues", () => {
+  assert.deepEqual(labelsForIssue(metadataIssue, "edited"), [
+    "community-intake",
+    "good-first-metadata",
+  ]);
+});
+
+test("labels safety reports as high priority", () => {
+  const issue = {
+    number: 7,
+    title: "Report broken MCP entry: example",
+    labels: [{ name: "broken-entry" }],
+    body: "- [X] Security or safety concern",
+  };
+
+  assert.deepEqual(labelsForIssue(issue, "opened"), [
+    "community-intake",
+    "needs-triage",
+    "priority-high",
+    "verification",
+  ]);
+});
+
+test("extracts issue form fields", () => {
+  assert.equal(
+    extractField(metadataIssue.body, "Project URL"),
+    "https://github.com/owner/example",
+  );
+});
+
+test("builds a deduplicated route-specific comment", () => {
+  const comment = buildTriageComment(metadataIssue);
+
+  assert.match(comment, /tensorblock-mcp-issue-triage:v1:metadata/);
+  assert.match(comment, /Thanks for improving MCP metadata/);
+  assert.match(comment, /https:\/\/github.com\/owner\/example/);
+});
+

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,35 @@
+name: MCP Issue Triage
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - reopened
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: mcp-issue-triage-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  triage:
+    name: Route community issue
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Route issue and reply
+        run: node .github/scripts/triage-issue.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 </div>
 TensorBlock MCP Index turns this community-curated MCP server directory into a hosted, searchable registry for agents and applications. Contributors add servers in markdown; TensorBlock normalizes the entries, generates structured profiles and install-config previews, and serves the index through a free public API.
 
+**MCP Index website:** [https://www.tensorblock.co/mcp](https://www.tensorblock.co/mcp)
+
 **Hosted API:** [https://mcp-index.tensorblock.co](https://mcp-index.tensorblock.co)
 
 ## Coverage
@@ -32,6 +34,7 @@ Choose the path that matches what you want to do.
 
 **If you maintain an MCP server:**
 
+- Share your public MCP profile from [https://www.tensorblock.co/mcp](https://www.tensorblock.co/mcp) so users can inspect metadata, install configs, source links, and badges without reading the raw markdown.
 - Add your server to the best category under [Browse by Category](#browse-by-category), or use the [Add MCP server issue form](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=add-mcp-server.yml).
 - Improve your existing entry with install command, transport, auth requirements, supported clients, docs URL, license, endpoint, and tool details. Use the [metadata issue form](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=improve-metadata.yml) if you do not want to open a PR directly.
 - Claim your TensorBlock MCP profile with the [claim profile issue form](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=claim-profile.yml).
@@ -49,6 +52,8 @@ Choose the path that matches what you want to do.
 - Add missing metadata that makes search and install generation more accurate.
 - Propose verification signals, health checks, ranking improvements, or better category rules.
 - Join the [TensorBlock Discord](https://discord.com/invite/Ej5NmeHFf2) to discuss roadmap work before opening a larger PR.
+
+Issue forms are routed automatically. When you submit a server, metadata update, profile claim, client config request, or broken-entry report, the repo adds the right triage labels and posts the next steps so contributors and maintainers can keep the workflow moving.
 
 New server entries can be simple, but high-quality metadata makes the profile much more useful. The best entries answer:
 
@@ -68,6 +73,12 @@ This repo is both a community directory and an agent-ready index. Humans add MCP
 ### Hosted MCP Index API
 
 TensorBlock provides the MCP Index API as free community infrastructure. We contribute the compute, hosting, data normalization, and ongoing maintenance needed to make this directory usable by agents and applications without requiring every user to clone the repo or parse markdown.
+
+Public website:
+
+```text
+https://www.tensorblock.co/mcp
+```
 
 Base URL:
 


### PR DESCRIPTION
## Summary
- add an MCP issue triage workflow for opened, edited, and reopened issues
- route community issue forms with labels and deduplicated next-step comments
- document the automatic issue routing in the README

## Impact
This turns the new issue forms into an active contribution funnel: server submissions, metadata fixes, profile claims, client config requests, and broken-entry reports now get immediate guidance and maintainer-facing labels.

## Validation
- node --test .github/scripts/triage-issue.test.mjs
- node --check .github/scripts/triage-issue.mjs
- ruby YAML parse for workflows and issue templates
- git diff --check
- npm test
- npm run typecheck
