### PR TITLE
Fix add server issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-mcp-server.yml
+++ b/.github/ISSUE_TEMPLATE/add-mcp-server.yml
@@ -80,7 +80,7 @@ body:
     attributes:
       label: Auth requirements
       options:
-        - none
+        - no auth
         - api-key
         - oauth
         - bearer

--- a/.github/scripts/triage-issue.test.mjs
+++ b/.github/scripts/triage-issue.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import test from "node:test";
 
 import {
@@ -78,3 +79,10 @@ test("builds a deduplicated route-specific comment", () => {
   assert.match(comment, /https:\/\/github.com\/owner\/example/);
 });
 
+test("issue forms avoid GitHub reserved dropdown options", () => {
+  assert.doesNotThrow(() => {
+    execFileSync("node", [".github/scripts/validate-issue-forms.mjs"], {
+      stdio: "pipe",
+    });
+  });
+});

--- a/.github/scripts/validate-issue-forms.mjs
+++ b/.github/scripts/validate-issue-forms.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+
+const issueTemplateDir = path.join(".github", "ISSUE_TEMPLATE");
+const reservedDropdownOptions = new Set(["none"]);
+
+function main() {
+  const files = fs
+    .readdirSync(issueTemplateDir)
+    .filter((file) => file.endsWith(".yml") || file.endsWith(".yaml"))
+    .map((file) => path.join(issueTemplateDir, file));
+
+  const errors = files.flatMap(validateFile);
+
+  if (errors.length > 0) {
+    for (const error of errors) {
+      console.error(error);
+    }
+    process.exit(1);
+  }
+
+  console.log(`Validated ${files.length} issue template files.`);
+}
+
+function validateFile(file) {
+  const lines = fs.readFileSync(file, "utf8").split(/\r?\n/);
+  const errors = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const optionMatch = line.match(/^(\s*)-\s+(.+?)\s*$/);
+    if (!optionMatch) {
+      continue;
+    }
+
+    const value = stripQuotes(optionMatch[2]);
+    if (reservedDropdownOptions.has(value.toLowerCase())) {
+      errors.push(
+        `${file}:${index + 1}: dropdown options cannot use GitHub's reserved "${value}" option; use a clearer value like "no auth".`,
+      );
+    }
+  }
+
+  return errors;
+}
+
+function stripQuotes(value) {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+
+  return trimmed;
+}
+
+main();
+


### PR DESCRIPTION
## Summary
- replace the reserved `none` dropdown option in the add-server issue form with `no auth`
- add a local validator for GitHub issue-form reserved dropdown values
- wire the validator into the existing issue triage script test

## Root cause
GitHub issue forms reserve the dropdown option value `none` for the implicit empty choice. The `Auth requirements` dropdown used `none`, so GitHub treated the form as invalid and the direct template link opened as an empty/broken issue form.

## Validation
- node .github/scripts/validate-issue-forms.mjs
- node --test .github/scripts/triage-issue.test.mjs
- ruby YAML parse for workflows and issue templates
- git diff --check
- npm test
- npm run typecheck
