### PR TITLE
Draft PRs from add-server issues

### DIFF
--- a/.github/scripts/create-add-server-pr.mjs
+++ b/.github/scripts/create-add-server-pr.mjs
@@ -1,0 +1,423 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { extractField } from "./triage-issue.mjs";
+
+const API_BASE = "https://api.github.com";
+const COMMENT_MARKER = "<!-- tensorblock-mcp-add-server-pr:v1 -->";
+const DEFAULT_BASE_BRANCH = "main";
+
+export const CATEGORY_TO_DOCS_PATH = {
+  "AI & LLM Integration": "docs/ai--llm-integration.md",
+  "Browser Automation & Web Scraping": "docs/browser-automation--web-scraping.md",
+  "Cloud Platforms & Services": "docs/cloud-platforms--services.md",
+  "Code Execution": "docs/code-execution.md",
+  Databases: "docs/databases.md",
+  "Developer Productivity & Utilities": "docs/developer-productivity--utilities.md",
+  Filesystems: "docs/filesystems.md",
+  "Knowledge Management & Memory": "docs/knowledge-management--memory.md",
+  "Monitoring & Observability": "docs/monitoring--observability.md",
+  "Operating System & Command Line": "docs/operating-system--command-line.md",
+  Search: "docs/search.md",
+  Security: "docs/security.md",
+};
+
+export function parseAddServerIssue(body) {
+  return {
+    serverName: normalizeField(extractField(body, "Server name")),
+    projectUrl: normalizeField(extractField(body, "Project URL")),
+    category: normalizeField(extractField(body, "Best category")),
+    description: normalizeField(extractField(body, "What can an agent do with this server?")),
+    install: normalizeField(extractField(body, "Install or connection instructions")),
+    transport: normalizeField(extractField(body, "Transport")),
+    auth: normalizeField(extractField(body, "Auth requirements")),
+    clients: normalizeField(extractField(body, "Known supported clients")),
+    license: normalizeField(extractField(body, "License")),
+  };
+}
+
+export function validateSubmission(submission) {
+  const errors = [];
+
+  if (!submission.serverName) {
+    errors.push("Server name is required.");
+  }
+
+  if (!submission.projectUrl) {
+    errors.push("Project URL is required.");
+  } else if (!isValidHttpUrl(submission.projectUrl)) {
+    errors.push("Project URL must be a valid HTTP or HTTPS URL.");
+  }
+
+  if (!submission.description) {
+    errors.push("A short description is required.");
+  }
+
+  if (!submission.category) {
+    errors.push("Category is required.");
+  } else if (!CATEGORY_TO_DOCS_PATH[submission.category]) {
+    errors.push(`Category "${submission.category}" needs maintainer routing before a draft PR can be generated.`);
+  }
+
+  return errors;
+}
+
+export function buildMarkdownEntry(submission) {
+  const segments = [sentence(compactText(submission.description, 420))];
+
+  const install = metadataSegment("Install", submission.install, 220);
+  if (install) {
+    segments.push(install);
+  }
+
+  if (submission.transport && submission.transport !== "unknown") {
+    segments.push(metadataSegment("Transport", submission.transport, 80));
+  }
+
+  if (submission.auth && submission.auth !== "unknown") {
+    segments.push(metadataSegment("Auth", submission.auth, 80));
+  }
+
+  const clients = metadataSegment("Clients", submission.clients, 160);
+  if (clients) {
+    segments.push(clients);
+  }
+
+  if (submission.license && submission.license !== "unknown") {
+    segments.push(metadataSegment("License", submission.license, 80));
+  }
+
+  return `- [${sanitizeLinkText(submission.serverName)}](${submission.projectUrl}): ${segments.filter(Boolean).join(" ")}`;
+}
+
+export function docPathForCategory(category) {
+  return CATEGORY_TO_DOCS_PATH[category] ?? null;
+}
+
+export function appendEntryToDocs(docPath, entry) {
+  const content = fs.readFileSync(docPath, "utf8");
+  const nextContent = `${content.trimEnd()}\n${entry}\n`;
+  fs.writeFileSync(docPath, nextContent);
+}
+
+export function findDuplicateByUrl(projectUrl, docsDir = "docs") {
+  const targetUrl = canonicalizeUrl(projectUrl);
+
+  for (const file of fs.readdirSync(docsDir).filter((name) => name.endsWith(".md")).sort()) {
+    const filePath = path.join(docsDir, file);
+    const lines = fs.readFileSync(filePath, "utf8").split(/\r?\n/);
+
+    for (const [index, line] of lines.entries()) {
+      const match = line.match(/^-\s+\[[^\]]+\]\(([^)]+)\)/);
+      if (!match) {
+        continue;
+      }
+
+      if (canonicalizeUrl(match[1]) === targetUrl) {
+        return {
+          path: filePath,
+          line: index + 1,
+          entry: line,
+        };
+      }
+    }
+  }
+
+  return null;
+}
+
+export function buildPrBody({ issue, submission, docPath, entry }) {
+  return [
+    "## Summary",
+    `- add \`${submission.serverName}\` to \`${docPath}\` from community issue #${issue.number}`,
+    "- preserve submitted install, transport, auth, client, and license metadata when provided",
+    "",
+    "## Generated entry",
+    "",
+    "```md",
+    entry,
+    "```",
+    "",
+    "## Source issue",
+    issue.html_url ?? `#${issue.number}`,
+    "",
+    "This is an automated draft PR. Maintainers should verify the project URL, category, metadata, and duplicate status before merging.",
+  ].join("\n");
+}
+
+export function buildIssueComment({ issue, submission, pullRequest, duplicate, errors }) {
+  if (errors?.length) {
+    return [
+      COMMENT_MARKER,
+      "I could not create a draft docs PR for this server submission yet.",
+      "",
+      "What needs attention:",
+      ...errors.map((error) => `- ${error}`),
+      "",
+      "A maintainer can update this issue or edit the category manually, and the automation will try again when the issue is edited.",
+    ].join("\n");
+  }
+
+  if (duplicate) {
+    return [
+      COMMENT_MARKER,
+      "I found an existing entry with the same project URL, so I did not create another docs PR.",
+      "",
+      `Existing entry: \`${duplicate.path}:${duplicate.line}\``,
+      "",
+      "```md",
+      duplicate.entry,
+      "```",
+      "",
+      "If this is a different MCP server, please update the Project URL or add details that distinguish it.",
+    ].join("\n");
+  }
+
+  return [
+    COMMENT_MARKER,
+    `I created or updated a draft docs PR for \`${submission.serverName}\`: ${pullRequest.html_url}`,
+    "",
+    "What happens next:",
+    "- Maintainers should verify the URL, category, description, and metadata.",
+    "- Once the PR lands, the catalog and profiles rebuild on the next deploy.",
+    "- The server will then become searchable from the hosted API and public MCP Index website.",
+    "",
+    `Source issue: #${issue.number}`,
+  ].join("\n");
+}
+
+function normalizeField(value) {
+  const normalized = value
+    .replace(/<!--[\s\S]*?-->/g, "")
+    .trim();
+
+  if (!normalized || normalized === "_No response_") {
+    return "";
+  }
+
+  return normalized;
+}
+
+function compactText(value, maxLength = 240) {
+  return value
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, maxLength);
+}
+
+function sentence(value) {
+  const compacted = value.trim();
+  if (!compacted) {
+    return "";
+  }
+
+  return /[.!?)]$/.test(compacted) ? compacted : `${compacted}.`;
+}
+
+function metadataSegment(label, value, maxLength) {
+  const compacted = compactText(value, maxLength);
+  if (!compacted) {
+    return "";
+  }
+
+  if (new RegExp(`^${label}:`, "i").test(compacted)) {
+    return sentence(compacted);
+  }
+
+  return `${label}: ${sentence(compacted)}`;
+}
+
+function sanitizeLinkText(value) {
+  return compactText(value, 120).replace(/[[\]]/g, "");
+}
+
+function isValidHttpUrl(value) {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function canonicalizeUrl(value) {
+  try {
+    const parsed = new URL(value.trim());
+    parsed.hash = "";
+    parsed.protocol = parsed.protocol.toLowerCase();
+    parsed.hostname = parsed.hostname.toLowerCase().replace(/^www\./, "");
+
+    if ((parsed.protocol === "https:" && parsed.port === "443") || (parsed.protocol === "http:" && parsed.port === "80")) {
+      parsed.port = "";
+    }
+
+    parsed.pathname = parsed.pathname.replace(/\.git$/i, "").replace(/\/+$/g, "");
+    return parsed.toString().replace(/\/$/g, "");
+  } catch {
+    return value.trim();
+  }
+}
+
+async function main() {
+  const token = process.env.GITHUB_TOKEN;
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  const repository = process.env.GITHUB_REPOSITORY;
+
+  if (!token || !eventPath || !repository) {
+    throw new Error("GITHUB_TOKEN, GITHUB_EVENT_PATH, and GITHUB_REPOSITORY are required.");
+  }
+
+  const event = JSON.parse(fs.readFileSync(eventPath, "utf8"));
+  const issue = event.issue;
+  if (!issue) {
+    console.log("No issue payload found; skipping.");
+    return;
+  }
+
+  const submission = parseAddServerIssue(issue.body ?? "");
+  const [owner, repo] = repository.split("/");
+  const request = createGitHubRequest({ token, owner, repo });
+  const errors = validateSubmission(submission);
+
+  if (errors.length > 0) {
+    await upsertIssueComment(request, issue.number, buildIssueComment({ issue, submission, errors }));
+    console.log(`Issue #${issue.number} cannot be converted to a draft PR: ${errors.join(" ")}`);
+    return;
+  }
+
+  const duplicate = findDuplicateByUrl(submission.projectUrl);
+  if (duplicate) {
+    await upsertIssueComment(request, issue.number, buildIssueComment({ issue, submission, duplicate }));
+    console.log(`Issue #${issue.number} matches an existing entry at ${duplicate.path}:${duplicate.line}.`);
+    return;
+  }
+
+  const docPath = docPathForCategory(submission.category);
+  const entry = buildMarkdownEntry(submission);
+  const branch = `mcp/add-server-issue-${issue.number}`;
+  const title = `Add ${submission.serverName} MCP server`;
+  const body = buildPrBody({ issue, submission, docPath, entry });
+
+  run("git", ["config", "user.name", "github-actions[bot]"]);
+  run("git", ["config", "user.email", "41898282+github-actions[bot]@users.noreply.github.com"]);
+  run("git", ["fetch", "origin", DEFAULT_BASE_BRANCH]);
+  run("git", ["checkout", "-B", branch, `origin/${DEFAULT_BASE_BRANCH}`]);
+
+  appendEntryToDocs(docPath, entry);
+  run("git", ["add", docPath]);
+
+  if (!hasStagedChanges()) {
+    console.log(`No docs changes generated for issue #${issue.number}.`);
+    return;
+  }
+
+  run("git", ["commit", "-m", title]);
+  run("git", ["push", "--force-with-lease", "origin", `HEAD:${branch}`]);
+
+  const pullRequest = await createOrUpdatePullRequest(request, {
+    owner,
+    branch,
+    title,
+    body,
+  });
+
+  await upsertIssueComment(request, issue.number, buildIssueComment({ issue, submission, pullRequest }));
+  console.log(`Created or updated draft PR ${pullRequest.html_url} for issue #${issue.number}.`);
+}
+
+function run(command, args) {
+  execFileSync(command, args, { stdio: "inherit" });
+}
+
+function hasStagedChanges() {
+  try {
+    execFileSync("git", ["diff", "--cached", "--quiet"], { stdio: "ignore" });
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+function createGitHubRequest({ token, owner, repo }) {
+  return async function request(pathname, options = {}) {
+    const response = await fetch(`${API_BASE}/repos/${owner}/${repo}${pathname}`, {
+      method: options.method ?? "GET",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      body: options.body ? JSON.stringify(options.body) : undefined,
+    });
+
+    const text = await response.text();
+    const data = text ? JSON.parse(text) : null;
+
+    if (!response.ok) {
+      const error = new Error(`GitHub API ${options.method ?? "GET"} ${pathname} failed: ${response.status}`);
+      error.status = response.status;
+      error.data = data;
+      throw error;
+    }
+
+    return data;
+  };
+}
+
+async function createOrUpdatePullRequest(request, { owner, branch, title, body }) {
+  const query = new URLSearchParams({
+    head: `${owner}:${branch}`,
+    state: "open",
+  });
+  const existingPulls = await request(`/pulls?${query.toString()}`);
+  const existingPull = existingPulls[0];
+
+  if (existingPull) {
+    return request(`/pulls/${existingPull.number}`, {
+      method: "PATCH",
+      body: { title, body },
+    });
+  }
+
+  return request("/pulls", {
+    method: "POST",
+    body: {
+      title,
+      body,
+      head: branch,
+      base: DEFAULT_BASE_BRANCH,
+      draft: true,
+      maintainer_can_modify: true,
+    },
+  });
+}
+
+async function upsertIssueComment(request, issueNumber, body) {
+  const comments = await request(`/issues/${issueNumber}/comments?per_page=100`);
+  const existing = comments.find((comment) => comment.body?.includes(COMMENT_MARKER));
+
+  if (existing) {
+    await request(`/issues/comments/${existing.id}`, {
+      method: "PATCH",
+      body: { body },
+    });
+    return;
+  }
+
+  await request(`/issues/${issueNumber}/comments`, {
+    method: "POST",
+    body: { body },
+  });
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}
+

--- a/.github/scripts/create-add-server-pr.test.mjs
+++ b/.github/scripts/create-add-server-pr.test.mjs
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  buildIssueComment,
+  buildMarkdownEntry,
+  docPathForCategory,
+  findDuplicateByUrl,
+  parseAddServerIssue,
+  validateSubmission,
+} from "./create-add-server-pr.mjs";
+
+const issueBody = [
+  "### Server name",
+  "",
+  "owner/example-mcp",
+  "",
+  "### Project URL",
+  "",
+  "https://github.com/owner/example-mcp",
+  "",
+  "### Best category",
+  "",
+  "Databases",
+  "",
+  "### What can an agent do with this server?",
+  "",
+  "Lets agents inspect example database schemas",
+  "",
+  "### Install or connection instructions",
+  "",
+  "npx -y example-mcp",
+  "",
+  "### Transport",
+  "",
+  "stdio",
+  "",
+  "### Auth requirements",
+  "",
+  "no auth",
+  "",
+  "### Known supported clients",
+  "",
+  "Claude Desktop, Cursor",
+  "",
+  "### License",
+  "",
+  "MIT",
+].join("\n");
+
+test("parses add-server issue form fields", () => {
+  assert.deepEqual(parseAddServerIssue(issueBody), {
+    serverName: "owner/example-mcp",
+    projectUrl: "https://github.com/owner/example-mcp",
+    category: "Databases",
+    description: "Lets agents inspect example database schemas",
+    install: "npx -y example-mcp",
+    transport: "stdio",
+    auth: "no auth",
+    clients: "Claude Desktop, Cursor",
+    license: "MIT",
+  });
+});
+
+test("maps category to docs path", () => {
+  assert.equal(docPathForCategory("Databases"), "docs/databases.md");
+});
+
+test("builds catalog markdown entry", () => {
+  const entry = buildMarkdownEntry(parseAddServerIssue(issueBody));
+
+  assert.equal(
+    entry,
+    "- [owner/example-mcp](https://github.com/owner/example-mcp): Lets agents inspect example database schemas. Install: npx -y example-mcp. Transport: stdio. Auth: no auth. Clients: Claude Desktop, Cursor. License: MIT.",
+  );
+});
+
+test("validates required fields and category", () => {
+  const submission = parseAddServerIssue(issueBody);
+  assert.deepEqual(validateSubmission(submission), []);
+
+  assert.deepEqual(
+    validateSubmission({ ...submission, category: "Other / not sure" }),
+    ['Category "Other / not sure" needs maintainer routing before a draft PR can be generated.'],
+  );
+});
+
+test("finds duplicate project URLs across docs", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-docs-"));
+  fs.writeFileSync(
+    path.join(tempDir, "databases.md"),
+    [
+      "## Databases",
+      "",
+      "- [owner/example-mcp](https://github.com/owner/example-mcp): Existing entry.",
+    ].join("\n"),
+  );
+
+  assert.deepEqual(findDuplicateByUrl("https://github.com/owner/example-mcp.git", tempDir), {
+    path: path.join(tempDir, "databases.md"),
+    line: 3,
+    entry: "- [owner/example-mcp](https://github.com/owner/example-mcp): Existing entry.",
+  });
+});
+
+test("builds issue comment for generated PR", () => {
+  const comment = buildIssueComment({
+    issue: { number: 123 },
+    submission: parseAddServerIssue(issueBody),
+    pullRequest: { html_url: "https://github.com/TensorBlock/awesome-mcp-servers/pull/999" },
+  });
+
+  assert.match(comment, /tensorblock-mcp-add-server-pr:v1/);
+  assert.match(comment, /pull\/999/);
+  assert.match(comment, /hosted API and public MCP Index website/);
+});
+

--- a/.github/scripts/triage-issue.mjs
+++ b/.github/scripts/triage-issue.mjs
@@ -116,7 +116,7 @@ export function buildTriageComment(issue) {
       "",
       "What happens next:",
       "- We will check for duplicates and route it to the closest category page.",
-      "- If the metadata is complete enough, a maintainer or contributor can turn this into a docs entry PR.",
+      "- If the category and required fields are clear, automation will draft a docs entry PR for maintainer review.",
       "- Once merged, the Railway deploy rebuilds the catalog and the server becomes searchable through the hosted MCP Index API.",
       "",
       describeCapturedFields(body, [
@@ -365,4 +365,3 @@ if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
     process.exit(1);
   });
 }
-

--- a/.github/workflows/add-server-issue-pr.yml
+++ b/.github/workflows/add-server-issue-pr.yml
@@ -1,0 +1,40 @@
+name: MCP Add Server Draft PR
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - reopened
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: mcp-add-server-issue-pr-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  draft-pr:
+    name: Draft docs PR from server submission
+    if: contains(github.event.issue.labels.*.name, 'server-submission') || startsWith(github.event.issue.title, 'Add MCP server:')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Create or update draft PR
+        run: node .github/scripts/create-add-server-pr.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Choose the path that matches what you want to do.
 - Propose verification signals, health checks, ranking improvements, or better category rules.
 - Join the [TensorBlock Discord](https://discord.com/invite/Ej5NmeHFf2) to discuss roadmap work before opening a larger PR.
 
-Issue forms are routed automatically. When you submit a server, metadata update, profile claim, client config request, or broken-entry report, the repo adds the right triage labels and posts the next steps so contributors and maintainers can keep the workflow moving.
+Issue forms are routed automatically. When you submit a server, metadata update, profile claim, client config request, or broken-entry report, the repo adds the right triage labels and posts the next steps so contributors and maintainers can keep the workflow moving. Server submissions with a clear category can also generate a draft docs PR automatically.
 
 New server entries can be simple, but high-quality metadata makes the profile much more useful. The best entries answer:
 


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that converts `server-submission` issues into draft docs PRs
- parse add-server issue form fields into a catalog markdown entry
- skip automation safely when the category needs maintainer routing or the project URL already exists
- update the triage reply and README to mention automatic draft PR generation

## Impact
This closes the contribution loop for new MCP server submissions. A clear add-server issue can now become a reviewable docs PR automatically instead of waiting for a maintainer to manually copy fields into `docs/*.md`.

## Safety
- only runs for issues labeled `server-submission` or titled `Add MCP server:`
- creates draft PRs only, never merges them
- checks for duplicate project URLs before writing docs
- uses a per-issue automation branch: `mcp/add-server-issue-{number}`
- updates its own issue comment instead of posting duplicates

## Validation
- node --test .github/scripts/create-add-server-pr.test.mjs .github/scripts/triage-issue.test.mjs
- node --check .github/scripts/create-add-server-pr.mjs
- node --check .github/scripts/triage-issue.mjs
- node .github/scripts/validate-issue-forms.mjs
- ruby YAML parse for workflows and issue templates
- git diff --check
- npm test
- npm run typecheck
