### PR TITLE
Add haymon-ai/dbmcp MCP server

### DIFF
--- a/data/server-metadata/github-haymon-ai-dbmcp-8e39ed6b.json
+++ b/data/server-metadata/github-haymon-ai-dbmcp-8e39ed6b.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "../../schemas/server-metadata.schema.json",
+  "id": "github-haymon-ai-dbmcp-8e39ed6b",
+  "source": {
+    "issue": 707,
+    "projectUrl": "https://github.com/haymon-ai/dbmcp"
+  },
+  "install": {
+    "commands": [],
+    "env": [
+      "DB_PASSWORD"
+    ],
+    "confidence": "low"
+  },
+  "transport": [
+    "stdio"
+  ],
+  "auth": {
+    "type": "none",
+    "notes": []
+  },
+  "clients": [
+    "Claude Desktop",
+    "Cursor",
+    "Claude Code",
+    "clients that support stdio or HTTP MCP servers"
+  ],
+  "license": "MIT"
+}

--- a/docs/databases.md
+++ b/docs/databases.md
@@ -299,3 +299,4 @@ Servers providing interfaces to various database types like SQL, NoSQL, Vector D
 - [daedalus/mcp-sqlite3](https://github.com/daedalus/mcp-sqlite3) - MCP server exposing sqlite3 library functionality.
 
 - [stucchi/db-mcp-server](https://github.com/stucchi/db-mcp-server): Database MCP server for MySQL, PostgreSQL, and MongoDB with SSH tunneling support. Run queries, explore schemas, and manage data across multiple database types.
+- [haymon-ai/dbmcp](https://github.com/haymon-ai/dbmcp): Connect AI assistants to MySQL, MariaDB, PostgreSQL, and SQLite databases through an MCP server with schema discovery, query execution, read-only mode, and optional PII redaction.


### PR DESCRIPTION
## Summary
- add `haymon-ai/dbmcp` to `docs/databases.md` from community issue #707
- add structured metadata sidecar `data/server-metadata/github-haymon-ai-dbmcp-8e39ed6b.json`
- include submitted metadata below for maintainer verification

## Generated entry

```md
- [haymon-ai/dbmcp](https://github.com/haymon-ai/dbmcp): Connect AI assistants to MySQL, MariaDB, PostgreSQL, and SQLite databases through an MCP server with schema discovery, query execution, read-only mode, and optional PII redaction.
```

## Generated metadata sidecar

`data/server-metadata/github-haymon-ai-dbmcp-8e39ed6b.json`

```json
{
  "$schema": "../../schemas/server-metadata.schema.json",
  "id": "github-haymon-ai-dbmcp-8e39ed6b",
  "source": {
    "issue": 707,
    "projectUrl": "https://github.com/haymon-ai/dbmcp"
  },
  "install": {
    "commands": [],
    "env": [
      "DB_PASSWORD"
    ],
    "confidence": "low"
  },
  "transport": [
    "stdio"
  ],
  "auth": {
    "type": "none",
    "notes": []
  },
  "clients": [
    "Claude Desktop",
    "Cursor",
    "Claude Code",
    "clients that support stdio or HTTP MCP servers"
  ],
  "license": "MIT"
}
```

## Submitted metadata

- **Install:** curl -fsSL https://dbmcp.haymon.ai/install.sh | bash Run stdio: dbmcp stdio --db-backend postgres --db-host localhost --db-user postgres --db-name mydb Env: DB_BACKEND, DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME
- **Transport:** multiple
- **Auth:** no auth
- **Clients:** Claude Desktop, Cursor, Claude Code, clients that support stdio or HTTP MCP servers
- **License:** MIT

## Source issue
https://github.com/TensorBlock/awesome-mcp-servers/issues/707

This is an automated draft PR. Maintainers should verify the project URL, category, metadata, and duplicate status before merging.