### PR TITLE
Fix add-server PR entry generation

### DIFF
--- a/.github/scripts/create-add-server-pr.mjs
+++ b/.github/scripts/create-add-server-pr.mjs
@@ -66,31 +66,8 @@ export function validateSubmission(submission) {
 }
 
 export function buildMarkdownEntry(submission) {
-  const segments = [sentence(compactText(submission.description, 420))];
-
-  const install = metadataSegment("Install", submission.install, 220);
-  if (install) {
-    segments.push(install);
-  }
-
-  if (submission.transport && submission.transport !== "unknown") {
-    segments.push(metadataSegment("Transport", submission.transport, 80));
-  }
-
-  if (submission.auth && submission.auth !== "unknown") {
-    segments.push(metadataSegment("Auth", submission.auth, 80));
-  }
-
-  const clients = metadataSegment("Clients", submission.clients, 160);
-  if (clients) {
-    segments.push(clients);
-  }
-
-  if (submission.license && submission.license !== "unknown") {
-    segments.push(metadataSegment("License", submission.license, 80));
-  }
-
-  return `- [${sanitizeLinkText(submission.serverName)}](${submission.projectUrl}): ${segments.filter(Boolean).join(" ")}`;
+  const description = sentence(compactText(submission.description, 360));
+  return `- [${sanitizeLinkText(submission.serverName)}](${submission.projectUrl}): ${description}`;
 }
 
 export function docPathForCategory(category) {
@@ -133,13 +110,17 @@ export function buildPrBody({ issue, submission, docPath, entry }) {
   return [
     "## Summary",
     `- add \`${submission.serverName}\` to \`${docPath}\` from community issue #${issue.number}`,
-    "- preserve submitted install, transport, auth, client, and license metadata when provided",
+    "- include submitted metadata below for maintainer verification",
     "",
     "## Generated entry",
     "",
     "```md",
     entry,
     "```",
+    "",
+    "## Submitted metadata",
+    "",
+    ...formatSubmittedMetadata(submission),
     "",
     "## Source issue",
     issue.html_url ?? `#${issue.number}`,
@@ -176,6 +157,22 @@ export function buildIssueComment({ issue, submission, pullRequest, duplicate, e
     ].join("\n");
   }
 
+  if (pullRequest?.blocked) {
+    return [
+      COMMENT_MARKER,
+      `I generated a docs branch for \`${submission.serverName}\`, but could not open the draft PR automatically.`,
+      "",
+      "GitHub Actions currently does not have permission to create pull requests for this repository or organization.",
+      "",
+      "Maintainer action:",
+      `- Open a draft PR from branch \`${pullRequest.branch}\`.`,
+      `- Compare link: ${pullRequest.compareUrl}`,
+      "- Or enable pull request creation for Actions and edit this issue to retry the automation.",
+      "",
+      `Source issue: #${issue.number}`,
+    ].join("\n");
+  }
+
   return [
     COMMENT_MARKER,
     `I created or updated a draft docs PR for \`${submission.serverName}\`: ${pullRequest.html_url}`,
@@ -202,10 +199,18 @@ function normalizeField(value) {
 }
 
 function compactText(value, maxLength = 240) {
-  return value
+  const compacted = value
     .replace(/\s+/g, " ")
-    .trim()
-    .slice(0, maxLength);
+    .trim();
+
+  if (compacted.length <= maxLength) {
+    return compacted;
+  }
+
+  const slice = compacted.slice(0, Math.max(0, maxLength - 3)).trimEnd();
+  const lastSpace = slice.lastIndexOf(" ");
+  const wordBoundary = lastSpace > maxLength * 0.6 ? slice.slice(0, lastSpace) : slice;
+  return `${wordBoundary.trimEnd()}...`;
 }
 
 function sentence(value) {
@@ -217,17 +222,26 @@ function sentence(value) {
   return /[.!?)]$/.test(compacted) ? compacted : `${compacted}.`;
 }
 
-function metadataSegment(label, value, maxLength) {
-  const compacted = compactText(value, maxLength);
-  if (!compacted) {
-    return "";
+function formatSubmittedMetadata(submission) {
+  const rows = [
+    ["Install", submission.install],
+    ["Transport", submission.transport],
+    ["Auth", submission.auth],
+    ["Clients", submission.clients],
+    ["License", submission.license],
+  ]
+    .map(([label, value]) => [label, formatMetadataValue(label, value)])
+    .filter(([, value]) => value && value !== "unknown");
+
+  if (!rows.length) {
+    return ["_No additional metadata submitted._"];
   }
 
-  if (new RegExp(`^${label}:`, "i").test(compacted)) {
-    return sentence(compacted);
-  }
+  return rows.map(([label, value]) => `- **${label}:** ${value}`);
+}
 
-  return `${label}: ${sentence(compacted)}`;
+function formatMetadataValue(label, value) {
+  return compactText(value, 500).replace(new RegExp(`^${label}:\\s*`, "i"), "");
 }
 
 function sanitizeLinkText(value) {
@@ -317,12 +331,37 @@ async function main() {
   run("git", ["commit", "-m", title]);
   run("git", ["push", "--force-with-lease", "origin", `HEAD:${branch}`]);
 
-  const pullRequest = await createOrUpdatePullRequest(request, {
-    owner,
-    branch,
-    title,
-    body,
-  });
+  let pullRequest;
+  try {
+    pullRequest = await createOrUpdatePullRequest(request, {
+      owner,
+      branch,
+      title,
+      body,
+    });
+  } catch (error) {
+    if (!isPullRequestCreationBlocked(error)) {
+      throw error;
+    }
+
+    const compareUrl = `https://github.com/${owner}/${repo}/compare/${DEFAULT_BASE_BRANCH}...${branch}?expand=1`;
+    await upsertIssueComment(
+      request,
+      issue.number,
+      buildIssueComment({
+        issue,
+        submission,
+        pullRequest: {
+          blocked: true,
+          branch,
+          compareUrl,
+        },
+      }),
+    );
+    console.log(`Generated branch ${branch} for issue #${issue.number}, but Actions cannot create pull requests.`);
+    console.log(formatGitHubError(error));
+    return;
+  }
 
   await upsertIssueComment(request, issue.number, buildIssueComment({ issue, submission, pullRequest }));
   console.log(`Created or updated draft PR ${pullRequest.html_url} for issue #${issue.number}.`);
@@ -396,6 +435,23 @@ async function createOrUpdatePullRequest(request, { owner, branch, title, body }
   });
 }
 
+function isPullRequestCreationBlocked(error) {
+  if (error?.status !== 403) {
+    return false;
+  }
+
+  const message = `${error.data?.message ?? ""} ${JSON.stringify(error.data?.errors ?? [])}`;
+  return /not permitted to create|Resource not accessible by integration|pull request/i.test(message);
+}
+
+function formatGitHubError(error) {
+  if (!error?.data) {
+    return error?.message ?? String(error);
+  }
+
+  return `${error.message}: ${JSON.stringify(error.data)}`;
+}
+
 async function upsertIssueComment(request, issueNumber, body) {
   const comments = await request(`/issues/${issueNumber}/comments?per_page=100`);
   const existing = comments.find((comment) => comment.body?.includes(COMMENT_MARKER));
@@ -420,4 +476,3 @@ if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
     process.exit(1);
   });
 }
-

--- a/.github/scripts/create-add-server-pr.test.mjs
+++ b/.github/scripts/create-add-server-pr.test.mjs
@@ -6,6 +6,7 @@ import test from "node:test";
 
 import {
   buildIssueComment,
+  buildPrBody,
   buildMarkdownEntry,
   docPathForCategory,
   findDuplicateByUrl,
@@ -74,8 +75,37 @@ test("builds catalog markdown entry", () => {
 
   assert.equal(
     entry,
-    "- [owner/example-mcp](https://github.com/owner/example-mcp): Lets agents inspect example database schemas. Install: npx -y example-mcp. Transport: stdio. Auth: no auth. Clients: Claude Desktop, Cursor. License: MIT.",
+    "- [owner/example-mcp](https://github.com/owner/example-mcp): Lets agents inspect example database schemas.",
   );
+});
+
+test("keeps install metadata in the draft PR body instead of the catalog entry", () => {
+  const submission = parseAddServerIssue(issueBody);
+  const entry = buildMarkdownEntry(submission);
+  const body = buildPrBody({
+    issue: {
+      number: 123,
+      html_url: "https://github.com/TensorBlock/awesome-mcp-servers/issues/123",
+    },
+    submission,
+    docPath: "docs/databases.md",
+    entry,
+  });
+
+  assert.match(body, /## Submitted metadata/);
+  assert.match(body, /\*\*Install:\*\* npx -y example-mcp/);
+  assert.match(body, /\*\*Transport:\*\* stdio/);
+  assert.match(body, /\*\*Clients:\*\* Claude Desktop, Cursor/);
+  assert.doesNotMatch(entry, /Install:/);
+
+  const bodyWithLabeledInstall = buildPrBody({
+    issue: { number: 123 },
+    submission: { ...submission, install: "Install: npx -y example-mcp" },
+    docPath: "docs/databases.md",
+    entry,
+  });
+  assert.match(bodyWithLabeledInstall, /\*\*Install:\*\* npx -y example-mcp/);
+  assert.doesNotMatch(bodyWithLabeledInstall, /\*\*Install:\*\* Install:/);
 });
 
 test("validates required fields and category", () => {
@@ -118,3 +148,18 @@ test("builds issue comment for generated PR", () => {
   assert.match(comment, /hosted API and public MCP Index website/);
 });
 
+test("builds issue comment when Actions cannot create a pull request", () => {
+  const comment = buildIssueComment({
+    issue: { number: 123 },
+    submission: parseAddServerIssue(issueBody),
+    pullRequest: {
+      blocked: true,
+      branch: "mcp/add-server-issue-123",
+      compareUrl: "https://github.com/TensorBlock/awesome-mcp-servers/compare/main...mcp/add-server-issue-123?expand=1",
+    },
+  });
+
+  assert.match(comment, /could not open the draft PR automatically/);
+  assert.match(comment, /mcp\/add-server-issue-123/);
+  assert.match(comment, /compare\/main\.\.\.mcp\/add-server-issue-123/);
+});


### PR DESCRIPTION
## Summary
- keep generated catalog entries concise by only writing the submitted server description to docs pages
- move install, transport, auth, client, and license metadata into the draft PR body for maintainer verification
- add a graceful issue comment when GitHub Actions can push the branch but cannot create the pull request because of organization policy

## Validation
- node --test .github/scripts/*.test.mjs

## E2E context
- verified with issue #707; Actions pushed branch `mcp/add-server-issue-707` but PR creation failed with a 403 organization policy error