### PR TITLE
Support MCP automation token

### DIFF
--- a/.github/workflows/add-server-issue-pr.yml
+++ b/.github/workflows/add-server-issue-pr.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: main
+          token: ${{ secrets.MCP_AUTOMATION_TOKEN || github.token }}
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -36,5 +37,4 @@ jobs:
       - name: Create or update draft PR
         run: node .github/scripts/create-add-server-pr.mjs
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+          GITHUB_TOKEN: ${{ secrets.MCP_AUTOMATION_TOKEN || github.token }}


### PR DESCRIPTION
## Summary
- let the add-server issue workflow use `MCP_AUTOMATION_TOKEN` when the repo secret is configured
- fall back to the default `github.token` when the secret is absent
- use the same token for checkout/push and PR creation so fully automated issue-to-PR creation can bypass restrictive GITHUB_TOKEN org policy with a repo-scoped bot token

## Validation
- node --test .github/scripts/*.test.mjs