### PR TITLE
Split add-server workflow tokens

### DIFF
--- a/.github/workflows/add-server-issue-pr.yml
+++ b/.github/workflows/add-server-issue-pr.yml
@@ -27,7 +27,6 @@ jobs:
         with:
           fetch-depth: 0
           ref: main
-          token: ${{ secrets.MCP_AUTOMATION_TOKEN || github.token }}
 
       - name: Set up Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- use the default `github.token` for checkout and branch pushes
- keep `MCP_AUTOMATION_TOKEN` scoped to GitHub API calls for draft PR creation and issue comments
- reduce the required PAT permission surface after E2E showed the secret token could not push branches

## Validation
- node --test .github/scripts/*.test.mjs