### PR TITLE
Add CursorTouch/Windows-MCP MCP server

### DIFF
--- a/docs/operating-system--command-line.md
+++ b/docs/operating-system--command-line.md
@@ -110,3 +110,4 @@ Servers providing access to the host operating system's command line/shell, exec
 
 - [aybelatchane/mcp-server-terminal](https://github.com/aybelatchane/mcp-server-terminal): MCP server enabling AI agents to interact with terminal applications (TUI/CLI) through structured Terminal State Tree representation. Think Playwright for terminals.
 - [mnardit/clipboard-mcp](https://github.com/mnardit/clipboard-mcp): Cross-platform system clipboard access (read, write, watch for changes) for AI assistants. Single Rust binary, zero runtime deps. Supports Windows, macOS, Linux (X11 + Wayland).
+- [CursorTouch/Windows-MCP](https://github.com/CursorTouch/Windows-MCP): Lets AI agents control and inspect Windows desktops through native UI automation, including app control, keyboard and mouse actions, window interaction, browser DOM mode, and desktop QA workflows.


### PR DESCRIPTION
## Summary
- add `CursorTouch/Windows-MCP` to `docs/operating-system--command-line.md` from community issue #714
- include submitted metadata below for maintainer verification

## Generated entry

```md
- [CursorTouch/Windows-MCP](https://github.com/CursorTouch/Windows-MCP): Lets AI agents control and inspect Windows desktops through native UI automation, including app control, keyboard and mouse actions, window interaction, browser DOM mode, and desktop QA workflows.
```

## Submitted metadata

- **Install:** Install/run from PyPI: uvx windows-mcp serve Run with SSE: uvx windows-mcp serve --transport sse --host localhost --port 8000 Run with streamable HTTP: uvx windows-mcp serve --transport streamable-http --host localhost --port 8000 Claude Desktop command: uvx, args: ["windows-mcp", "serve"]
- **Transport:** multiple
- **Auth:** no auth
- **Clients:** Claude Desktop and MCP clients that support stdio, SSE, or streamable HTTP servers
- **License:** MIT

## Source issue
https://github.com/TensorBlock/awesome-mcp-servers/issues/714

This is an automated draft PR. Maintainers should verify the project URL, category, metadata, and duplicate status before merging.