### PR TITLE
Fix merged PR follow-up file detection

### DIFF
--- a/.github/scripts/comment-merged-pr.mjs
+++ b/.github/scripts/comment-merged-pr.mjs
@@ -16,7 +16,8 @@ export function extractAddedCatalogEntries(files) {
   const entriesById = new Map();
 
   for (const file of files) {
-    if (!file.path?.startsWith("docs/") || !file.path.endsWith(".md") || !file.patch) {
+    const sourcePath = file.filename ?? file.path;
+    if (!sourcePath?.startsWith("docs/") || !sourcePath.endsWith(".md") || !file.patch) {
       continue;
     }
 
@@ -28,7 +29,7 @@ export function extractAddedCatalogEntries(files) {
 
       entriesById.set(entry.id, {
         ...entry,
-        sourcePath: file.path,
+        sourcePath,
       });
     }
   }

--- a/.github/scripts/comment-merged-pr.test.mjs
+++ b/.github/scripts/comment-merged-pr.test.mjs
@@ -11,7 +11,7 @@ import {
 test("extracts added docs catalog entries from pull request files", () => {
   const entries = extractAddedCatalogEntries([
     {
-      path: "docs/search.md",
+      filename: "docs/search.md",
       patch: [
         "@@ -1,2 +1,3 @@",
         " ## Search",
@@ -20,7 +20,7 @@ test("extracts added docs catalog entries from pull request files", () => {
       ].join("\n"),
     },
     {
-      path: "README.md",
+      filename: "README.md",
       patch: "+- [Ignored](https://github.com/example/ignored): README entries are ignored.",
     },
   ]);
@@ -29,6 +29,18 @@ test("extracts added docs catalog entries from pull request files", () => {
   assert.equal(entries[0].name, "Example Search");
   assert.equal(entries[0].url, "https://github.com/example/search-mcp");
   assert.equal(entries[0].sourcePath, "docs/search.md");
+});
+
+test("also supports gh JSON file path shape", () => {
+  const entries = extractAddedCatalogEntries([
+    {
+      path: "docs/databases.md",
+      patch: "+- [Database MCP](https://github.com/example/db-mcp): Database MCP server.",
+    },
+  ]);
+
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].sourcePath, "docs/databases.md");
 });
 
 test("parses markdown entries with colon or dash separators", () => {


### PR DESCRIPTION
## Summary
- support the GitHub PR files API `filename` field when extracting added catalog entries
- keep compatibility with the `path` shape used by gh JSON/test helpers

## Validation
- node --test .github/scripts/*.test.mjs
- npm test
- npm run typecheck

## Context
The #726 smoke test showed the follow-up workflow skipped the merged PR because the script looked for `file.path`, but GitHub returns `filename` from `/pulls/{number}/files`.