### PR TITLE
Add FiveCoins validation planner MCP

### DIFF
--- a/docs/developer-productivity--utilities.md
+++ b/docs/developer-productivity--utilities.md
@@ -2,6 +2,7 @@
 
 Servers enhancing developer workflows, integrating with IDEs, accessing documentation, API exploration, code generation helpers, or general dev utilities.
 
+- [AndreuSerraSastre/fivecoins-ai-profit-experiment](https://github.com/AndreuSerraSastre/fivecoins-ai-profit-experiment): No-signup validation planner MCP for AI-built micro-offers. Tool: `create_validation_plan`. Install: `npx --yes --package github:AndreuSerraSastre/fivecoins-ai-profit-experiment fivecoins-mcp`. Transport: stdio. Auth: none. License: MIT.
 - [aidi1723/OmniGlyph](https://github.com/aidi1723/OmniGlyph) [![aidi1723/OmniGlyph MCP server](https://glama.ai/mcp/servers/aidi1723/OmniGlyph/badges/score.svg)](https://glama.ai/mcp/servers/aidi1723/OmniGlyph): Local symbol ground-truth MCP server for Unicode/Unihan lookup, domain-term normalization, output guardrails, and code-symbol linting. Detects homoglyphs, zero-width spaces, and suspicious Unicode before agents reason over text. Published on PyPI as `omniglyph` and registered in the MCP Registry.
 - [KyaniteLabs/DialectOS](https://github.com/KyaniteLabs/DialectOS): Spanish dialect localization MCP server and CLI — translate and QA across 25 regional variants with register control and structure preservation.
 - [incultnitollc/mcp-probe](https://github.com/incultnitollc/mcp-probe) - CLI health-check for MCP servers. Enumerates tools/resources/prompts, calls them, validates schemas, prints pass/fail scorecard. CI-friendly (exits 0/1).


### PR DESCRIPTION
Adds FiveCoins validation planner MCP to Developer Productivity & Utilities.

Metadata included in the entry:
- Install: `npx --yes --package github:AndreuSerraSastre/fivecoins-ai-profit-experiment fivecoins-mcp`
- Transport: stdio
- Auth: none
- Tool: `create_validation_plan`
- License: MIT

The server returns no-spam validation plans for AI-built micro-offers and is part of a public experiment with transparent revenue status.

Public status: https://fivecoins.app.tipdata.es/status.json?src=tensorblock-mcp-pr
