### PR TITLE
Add scala-mcp-server — 250M+ companies for AI agents

### DIFF
--- a/docs/data-analysis--business-intelligence.md
+++ b/docs/data-analysis--business-intelligence.md
@@ -2,6 +2,7 @@
 
 Servers connecting to data warehouses, data query engines, analytics platforms, or specific data APIs.
 
+- [Alessandro114/scala-mcp-server](https://github.com/Alessandro114/scala-mcp-server): Search 250M+ companies across 40+ countries — revenue, employees, credit score (0-100), industry. 6 tools for company search, lookup, report generation, and database stats. Free tier: 50 lookups/month. Install: `npx scala-mcp-server`.
 - [us-all/openmetadata-mcp-server](https://github.com/us-all/openmetadata-mcp-server) - OpenMetadata MCP server with 170 tools across metadata, lineage, search, data quality, sample data, and OM 1.12+ Data Contracts. Includes `lineage-impact` and `quality-rollup` aggregations.
 - [us-all/dbt-mcp-server](https://github.com/us-all/dbt-mcp-server): dbt MCP server with 22 read-only tools across `manifest.json` / `run_results.json` / `sources.json` / `catalog.json` (model/test/source introspection, run-history analysis, slow models, per-column test coverage, lineage walks) plus 5 DQ result-table tools (BigQuery + Postgres lazy peer imports). 4 triage Prompts and 4 aggregations.
 - [us-all/airflow-mcp-server](https://github.com/us-all/airflow-mcp-server): Airflow MCP for the Airflow 3.x `/api/v2` REST API with JWT auth (SimpleAuthManager). 7 tools (DAG list, runs, task instances, log tails, trigger, clear) plus `dag-health-rollup` aggregation and 2 triage Prompts. Read-only by default; trigger/clear gated by `AIRFLOW_ALLOW_WRITE`.


### PR DESCRIPTION
Adds [scala-mcp-server](https://github.com/Alessandro114/scala-mcp-server) to **Data Analysis & Business Intelligence**.

- 250M+ company records across 40+ countries
- 6 MCP tools: search, lookup, report, stats, countries, credits
- Free tier: 50 lookups/month, no signup
- npm: `npx scala-mcp-server`
- [GitHub](https://github.com/Alessandro114/scala-mcp-server) | [npm](https://www.npmjs.com/package/scala-mcp-server)