### PR TITLE
Add server metadata sidecars

### DIFF
--- a/.github/scripts/create-add-server-pr.mjs
+++ b/.github/scripts/create-add-server-pr.mjs
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import { slugFromUrl } from "./comment-merged-pr.mjs";
 import { extractField } from "./triage-issue.mjs";
 
 const API_BASE = "https://api.github.com";
@@ -106,10 +107,11 @@ export function findDuplicateByUrl(projectUrl, docsDir = "docs") {
   return null;
 }
 
-export function buildPrBody({ issue, submission, docPath, entry }) {
+export function buildPrBody({ issue, submission, docPath, entry, metadataSidecar }) {
   return [
     "## Summary",
     `- add \`${submission.serverName}\` to \`${docPath}\` from community issue #${issue.number}`,
+    ...(metadataSidecar ? [`- add structured metadata sidecar \`${metadataSidecar.path}\``] : []),
     "- include submitted metadata below for maintainer verification",
     "",
     "## Generated entry",
@@ -117,6 +119,18 @@ export function buildPrBody({ issue, submission, docPath, entry }) {
     "```md",
     entry,
     "```",
+    ...(metadataSidecar
+      ? [
+          "",
+          "## Generated metadata sidecar",
+          "",
+          `\`${metadataSidecar.path}\``,
+          "",
+          "```json",
+          metadataSidecar.content.trimEnd(),
+          "```",
+        ]
+      : []),
     "",
     "## Submitted metadata",
     "",
@@ -127,6 +141,31 @@ export function buildPrBody({ issue, submission, docPath, entry }) {
     "",
     "This is an automated draft PR. Maintainers should verify the project URL, category, metadata, and duplicate status before merging.",
   ].join("\n");
+}
+
+export function buildMetadataSidecar({ issue, submission }) {
+  const serverId = slugFromUrl(submission.projectUrl);
+  const metadata = {
+    "$schema": "../../schemas/server-metadata.schema.json",
+    id: serverId,
+    source: {
+      issue: issue.number,
+      projectUrl: submission.projectUrl,
+    },
+    ...definedObject({
+      install: buildInstallMetadata(submission.install),
+      transport: parseTransportMetadata(submission.transport),
+      auth: buildAuthMetadata(submission.auth),
+      clients: parseListMetadata(submission.clients),
+      license: normalizeMetadataScalar(submission.license),
+    }),
+  };
+
+  return {
+    serverId,
+    path: `data/server-metadata/${serverId}.json`,
+    content: `${JSON.stringify(metadata, null, 2)}\n`,
+  };
 }
 
 export function buildIssueComment({ issue, submission, pullRequest, duplicate, errors }) {
@@ -244,6 +283,110 @@ function formatMetadataValue(label, value) {
   return compactText(value, 500).replace(new RegExp(`^${label}:\\s*`, "i"), "");
 }
 
+function buildInstallMetadata(value) {
+  const commands = parseInstallCommands(value);
+  const env = extractEnvVars(value);
+
+  if (commands.length === 0 && env.length === 0) {
+    return null;
+  }
+
+  return {
+    commands,
+    env,
+    confidence: commands.length > 0 ? "medium" : "low",
+  };
+}
+
+function parseInstallCommands(value) {
+  const backtickCommands = Array.from(value.matchAll(/`([^`]+)`/g))
+    .map((match) => cleanMetadataLine(match[1]))
+    .filter(isLikelyLaunchCommand);
+
+  if (backtickCommands.length > 0) {
+    return unique(backtickCommands);
+  }
+
+  return unique(
+    value
+      .split(/\r?\n/)
+      .map(cleanMetadataLine)
+      .filter(isLikelyLaunchCommand),
+  );
+}
+
+function parseTransportMetadata(value) {
+  const lower = value.toLowerCase();
+  const transports = [];
+
+  if (/\bstdio\b/.test(lower)) transports.push("stdio");
+  if (/\bsse\b/.test(lower)) transports.push("sse");
+  if (/\bhttp\b/.test(lower) || lower.includes("streamable")) transports.push("streamable-http");
+
+  return transports.length > 0 ? unique(transports) : null;
+}
+
+function buildAuthMetadata(value) {
+  if (!value) {
+    return null;
+  }
+
+  const lower = value.toLowerCase();
+  let type = "unknown";
+
+  if (/\b(no auth|none|not required|no authentication)\b/.test(lower)) type = "none";
+  else if (lower.includes("oauth")) type = "oauth";
+  else if (lower.includes("bearer")) type = "bearer";
+  else if (lower.includes("api key") || lower.includes("api-key") || /\b[A-Z][A-Z0-9_]*API_KEY\b/.test(value)) {
+    type = "api-key";
+  }
+
+  return {
+    type,
+    notes: type === "none" ? [] : [compactText(value, 240)],
+  };
+}
+
+function parseListMetadata(value) {
+  const values = value
+    .split(/[,;\n]/)
+    .map(cleanMetadataLine)
+    .filter(Boolean);
+
+  return values.length > 0 ? unique(values) : null;
+}
+
+function normalizeMetadataScalar(value) {
+  const normalized = compactText(value, 120);
+  return normalized || null;
+}
+
+function extractEnvVars(value) {
+  const matches = value.match(/\b[A-Z][A-Z0-9_]{2,}\b/g) ?? [];
+  return unique(matches.filter((match) => /(KEY|TOKEN|SECRET|PASSWORD|ENDPOINT|URL)$/.test(match)));
+}
+
+function cleanMetadataLine(value) {
+  return value
+    .trim()
+    .replace(/^[-*]\s+/, "")
+    .replace(/^```[a-z]*|```$/gi, "")
+    .replace(/^`+|`+$/g, "")
+    .trim();
+}
+
+function isLikelyLaunchCommand(value) {
+  return /^(?:npx|uvx|npm|docker|node|python3?|[a-z0-9._-]*mcp)\b/i.test(value);
+}
+
+function definedObject(entries) {
+  return Object.fromEntries(Object.entries(entries).filter(([, value]) => value !== null && value !== ""));
+}
+
+function unique(values) {
+  return Array.from(new Set(values));
+}
+
 function sanitizeLinkText(value) {
   return compactText(value, 120).replace(/[[\]]/g, "");
 }
@@ -273,6 +416,11 @@ function canonicalizeUrl(value) {
   } catch {
     return value.trim();
   }
+}
+
+function writeMetadataSidecar(sidecar) {
+  fs.mkdirSync(path.dirname(sidecar.path), { recursive: true });
+  fs.writeFileSync(sidecar.path, sidecar.content);
 }
 
 async function main() {
@@ -311,9 +459,10 @@ async function main() {
 
   const docPath = docPathForCategory(submission.category);
   const entry = buildMarkdownEntry(submission);
+  const metadataSidecar = buildMetadataSidecar({ issue, submission });
   const branch = `mcp/add-server-issue-${issue.number}`;
   const title = `Add ${submission.serverName} MCP server`;
-  const body = buildPrBody({ issue, submission, docPath, entry });
+  const body = buildPrBody({ issue, submission, docPath, entry, metadataSidecar });
 
   run("git", ["config", "user.name", "github-actions[bot]"]);
   run("git", ["config", "user.email", "41898282+github-actions[bot]@users.noreply.github.com"]);
@@ -321,7 +470,8 @@ async function main() {
   run("git", ["checkout", "-B", branch, `origin/${DEFAULT_BASE_BRANCH}`]);
 
   appendEntryToDocs(docPath, entry);
-  run("git", ["add", docPath]);
+  writeMetadataSidecar(metadataSidecar);
+  run("git", ["add", docPath, metadataSidecar.path]);
 
   if (!hasStagedChanges()) {
     console.log(`No docs changes generated for issue #${issue.number}.`);

--- a/.github/scripts/create-add-server-pr.test.mjs
+++ b/.github/scripts/create-add-server-pr.test.mjs
@@ -7,6 +7,7 @@ import test from "node:test";
 import {
   buildIssueComment,
   buildPrBody,
+  buildMetadataSidecar,
   buildMarkdownEntry,
   docPathForCategory,
   findDuplicateByUrl,
@@ -106,6 +107,34 @@ test("keeps install metadata in the draft PR body instead of the catalog entry",
   });
   assert.match(bodyWithLabeledInstall, /\*\*Install:\*\* npx -y example-mcp/);
   assert.doesNotMatch(bodyWithLabeledInstall, /\*\*Install:\*\* Install:/);
+});
+
+test("builds a metadata sidecar for submitted install and compatibility fields", () => {
+  const submission = parseAddServerIssue(issueBody);
+  const sidecar = buildMetadataSidecar({
+    issue: { number: 123 },
+    submission,
+  });
+  const metadata = JSON.parse(sidecar.content);
+
+  assert.match(sidecar.path, /^data\/server-metadata\/github-owner-example-mcp-[a-f0-9]{8}\.json$/);
+  assert.equal(metadata.id, sidecar.serverId);
+  assert.deepEqual(metadata.source, {
+    issue: 123,
+    projectUrl: "https://github.com/owner/example-mcp",
+  });
+  assert.deepEqual(metadata.install, {
+    commands: ["npx -y example-mcp"],
+    env: [],
+    confidence: "medium",
+  });
+  assert.deepEqual(metadata.transport, ["stdio"]);
+  assert.deepEqual(metadata.auth, {
+    type: "none",
+    notes: [],
+  });
+  assert.deepEqual(metadata.clients, ["Claude Desktop", "Cursor"]);
+  assert.equal(metadata.license, "MIT");
 });
 
 test("validates required fields and category", () => {

--- a/README.md
+++ b/README.md
@@ -112,10 +112,11 @@ We plan to keep investing in this hosted registry: improving metadata quality, e
 How entries become index data:
 
 1. The source of truth is the category markdown under `docs/*.md`.
-2. Each server entry is parsed from a markdown bullet with a link and description.
-3. `npm run catalog:build` generates `data/catalog.json` with normalized server metadata.
-4. `npm run profiles:build` generates `data/profiles/*.json` for stable per-server profiles.
-5. The deploy workflow publishes the refreshed catalog to the hosted API after changes land on `main`.
+2. Optional `data/server-metadata/*.json` sidecars preserve structured install, transport, auth, client, and license metadata without making the markdown entry long.
+3. Each server entry is parsed from a markdown bullet with a link and description.
+4. `npm run catalog:build` merges markdown entries with sidecar metadata and generates `data/catalog.json`.
+5. `npm run profiles:build` generates `data/profiles/*.json` for stable per-server profiles.
+6. The deploy workflow publishes the refreshed catalog to the hosted API after changes land on `main`.
 
 For local development:
 
@@ -137,11 +138,11 @@ To add a new MCP server:
 4. Search the repo for your URL or project name to avoid duplicates.
 5. Open a pull request.
 
-If you are not sure where the server belongs, use the [Add MCP server issue form](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=add-mcp-server.yml) and we can help route it.
+If you are not sure where the server belongs, use the [Add MCP server issue form](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=add-mcp-server.yml) and we can help route it. When the form has enough information, automation can draft a PR with both the markdown entry and a metadata sidecar.
 
 To improve an existing server, edit the same markdown bullet where the server is listed. Add missing install, transport, auth, docs, license, client, tool, endpoint, or maintainer information in the description when possible.
 
-Generated files such as `data/catalog.json` and `data/profiles/*.json` are maintained by the indexer. If you only add a server entry, editing the relevant `docs/*.md` category page is enough for the PR.
+`data/server-metadata/*.json` files are source metadata used by the indexer. Generated files such as `data/catalog.json` and `data/profiles/*.json` are maintained by the indexer. If you only add a simple server entry, editing the relevant `docs/*.md` category page is enough for the PR.
 
 For metadata and indexer examples, see the [MCP Index Metadata Contribution Guide](docs/index-alpha/contribution-guide.md).
 

--- a/docs/index-alpha/contribution-guide.md
+++ b/docs/index-alpha/contribution-guide.md
@@ -9,7 +9,7 @@ The indexer reads the markdown catalog and generates:
 - install config previews,
 - and a local MCP registry that agents can query directly.
 
-When adding a server, include as much of this metadata as possible in the PR body or entry description:
+When adding a server, include as much of this metadata as possible in the issue form, PR body, or entry description:
 
 - Install command: `npx`, `uvx`, `pip`, Docker, or remote endpoint.
 - Transport: `stdio`, `streamable-http`, or `sse`.
@@ -19,6 +19,8 @@ When adding a server, include as much of this metadata as possible in the PR bod
 - License.
 - Docs URL.
 - Remote MCP endpoint, if public.
+
+For short markdown entries, structured metadata can live in `data/server-metadata/{serverId}.json`. Server submissions created through the Add MCP server issue form can generate this sidecar automatically, so the category page stays readable while the profile/API still get install, transport, auth, client, and license fields.
 
 Complete metadata helps TensorBlock generate:
 

--- a/packages/catalog-builder/src/buildCatalog.ts
+++ b/packages/catalog-builder/src/buildCatalog.ts
@@ -1,4 +1,4 @@
-import type { CatalogBuildError, CatalogEntry, ParsedMarkdownEntry } from "./types.js";
+import type { CatalogBuildError, CatalogEntry, CatalogMetadataOverride, ParsedMarkdownEntry } from "./types.js";
 import { CATEGORY_TO_DOCS_PATH } from "./category-map.js";
 import { parseMarkdownEntries, slugFromUrl } from "./parseMarkdown.js";
 
@@ -21,6 +21,7 @@ interface ParsedDocsEntries {
 export function buildCatalogFromMarkdown(
   readmeMarkdown: string,
   docsByPath: Map<string, string>,
+  metadataById: Map<string, CatalogMetadataOverride> = new Map(),
 ): CatalogBuildResult {
   const readmeEntries = parseMarkdownEntries(readmeMarkdown, "README.md");
   const docsEntries = parseDocsEntries(docsByPath);
@@ -48,7 +49,8 @@ export function buildCatalogFromMarkdown(
       docsEntry.entry,
       id,
       docsEntry.entry.sourcePath,
-      readmeEntriesByUrl.has(docsEntry.normalizedUrl)
+      readmeEntriesByUrl.has(docsEntry.normalizedUrl),
+      metadataById.get(id),
     ));
   }
 
@@ -72,7 +74,7 @@ export function buildCatalogFromMarkdown(
 
     const normalizedEntry = { entry: readmeEntry, normalizedUrl };
     seenUrls.set(normalizedUrl, normalizedEntry);
-    entries.push(toCatalogEntry(readmeEntry, id, null, true));
+    entries.push(toCatalogEntry(readmeEntry, id, null, true, metadataById.get(id)));
   }
 
   return { entries, errors };
@@ -154,12 +156,13 @@ function toCatalogEntry(
   id: string,
   docsPath: string | null,
   featuredInReadme: boolean,
+  metadata: CatalogMetadataOverride | undefined,
 ): CatalogEntry {
   const repo = isGithubUrl(entry.url) ? entry.url : null;
   const installCommands = extractInstallCommands(entry.description);
   const toolCount = extractToolCount(entry.description);
 
-  return {
+  const catalogEntry: CatalogEntry = {
     id,
     name: entry.name,
     description: entry.description,
@@ -206,6 +209,49 @@ function toCatalogEntry(
       claimed: false,
     },
   };
+
+  return applyMetadataOverride(catalogEntry, metadata);
+}
+
+function applyMetadataOverride(
+  entry: CatalogEntry,
+  metadata: CatalogMetadataOverride | undefined,
+): CatalogEntry {
+  if (!metadata) {
+    return entry;
+  }
+
+  return {
+    ...entry,
+    links: {
+      ...entry.links,
+      ...(metadata.links?.docs ? { docs: metadata.links.docs } : {}),
+      ...(metadata.links?.endpoint ? { endpoint: metadata.links.endpoint } : {}),
+    },
+    install: {
+      commands: nonEmptyArray(metadata.install?.commands) ?? entry.install.commands,
+      env: nonEmptyArray(metadata.install?.env) ?? entry.install.env,
+      confidence: metadata.install?.confidence ?? entry.install.confidence,
+    },
+    transport: nonEmptyArray(metadata.transport) ?? entry.transport,
+    auth: metadata.auth
+      ? {
+          type: metadata.auth.type ?? entry.auth.type,
+          notes: metadata.auth.notes ?? entry.auth.notes,
+        }
+      : entry.auth,
+    clients: nonEmptyArray(metadata.clients) ?? entry.clients,
+    license: nonEmptyString(metadata.license) ?? entry.license,
+  };
+}
+
+function nonEmptyArray<T extends string>(value: T[] | undefined): T[] | null {
+  return value && value.length > 0 ? Array.from(new Set(value)) : null;
+}
+
+function nonEmptyString(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
 }
 
 function normalizeUrl(url: string): string {

--- a/packages/catalog-builder/src/cli.ts
+++ b/packages/catalog-builder/src/cli.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { buildCatalogFromMarkdown } from "./buildCatalog.js";
+import { readMetadataSidecars } from "./metadata.js";
 
 const readme = readFileSync("README.md", "utf8");
 const docsByPath = new Map<string, string>();
@@ -12,7 +13,7 @@ for (const file of readdirSync("docs")) {
   }
 }
 
-const result = buildCatalogFromMarkdown(readme, docsByPath);
+const result = buildCatalogFromMarkdown(readme, docsByPath, readMetadataSidecars());
 
 mkdirSync("data", { recursive: true });
 writeFileSync("data/catalog.json", `${JSON.stringify(result.entries, null, 2)}\n`);

--- a/packages/catalog-builder/src/metadata.ts
+++ b/packages/catalog-builder/src/metadata.ts
@@ -1,0 +1,23 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { basename, join } from "node:path";
+import type { CatalogMetadataOverride } from "./types.js";
+
+export function readMetadataSidecars(
+  metadataDir = "data/server-metadata",
+): Map<string, CatalogMetadataOverride> {
+  const metadataById = new Map<string, CatalogMetadataOverride>();
+
+  if (!existsSync(metadataDir)) {
+    return metadataById;
+  }
+
+  for (const fileName of readdirSync(metadataDir).filter((name) => name.endsWith(".json")).sort()) {
+    const filePath = join(metadataDir, fileName);
+    const metadata = JSON.parse(readFileSync(filePath, "utf8")) as CatalogMetadataOverride;
+    const id = metadata.id ?? basename(fileName, ".json");
+
+    metadataById.set(id, metadata);
+  }
+
+  return metadataById;
+}

--- a/packages/catalog-builder/src/types.ts
+++ b/packages/catalog-builder/src/types.ts
@@ -55,6 +55,20 @@ export interface CatalogEntry {
   };
 }
 
+export interface CatalogMetadataOverride {
+  id?: string;
+  source?: {
+    issue?: number;
+    projectUrl?: string;
+  };
+  links?: Partial<Pick<CatalogEntry["links"], "docs" | "endpoint">>;
+  install?: Partial<CatalogEntry["install"]>;
+  transport?: Transport[];
+  auth?: Partial<CatalogEntry["auth"]>;
+  clients?: string[];
+  license?: string;
+}
+
 export interface ParsedMarkdownEntry {
   category: string;
   name: string;

--- a/packages/catalog-builder/test/buildCatalog.test.ts
+++ b/packages/catalog-builder/test/buildCatalog.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import type { FormatsPlugin } from "ajv-formats";
 import { Ajv2020 as Ajv } from "ajv/dist/2020.js";
 import { buildCatalogFromMarkdown } from "../src/buildCatalog.js";
+import { slugFromUrl } from "../src/parseMarkdown.js";
 
 const require = createRequire(import.meta.url);
 const addFormats = require("ajv-formats") as FormatsPlugin;
@@ -215,6 +216,49 @@ describe("buildCatalogFromMarkdown", () => {
       names: [],
       source: "self_reported",
     });
+    expect(entry?.license).toBe("MIT");
+  });
+
+  it("applies sidecar metadata over markdown inference", () => {
+    const projectUrl = "https://github.com/owner/plain-mcp";
+    const id = slugFromUrl(projectUrl);
+    const readme = [
+      "## Experimental",
+      `- [Plain MCP](${projectUrl}): Plain server entry without install metadata.`,
+    ].join("\n");
+
+    const result = buildCatalogFromMarkdown(readme, new Map(), new Map([
+      [
+        id,
+        {
+          install: {
+            commands: ["npx -y plain-mcp"],
+            env: ["PLAIN_API_KEY"],
+            confidence: "medium",
+          },
+          transport: ["stdio"],
+          auth: {
+            type: "api-key",
+            notes: ["Submitted through the add-server issue form."],
+          },
+          clients: ["Claude Desktop", "Cursor"],
+          license: "MIT",
+        },
+      ],
+    ]));
+    const entry = result.entries[0];
+
+    expect(entry?.install).toEqual({
+      commands: ["npx -y plain-mcp"],
+      env: ["PLAIN_API_KEY"],
+      confidence: "medium",
+    });
+    expect(entry?.transport).toEqual(["stdio"]);
+    expect(entry?.auth).toEqual({
+      type: "api-key",
+      notes: ["Submitted through the add-server issue form."],
+    });
+    expect(entry?.clients).toEqual(["Claude Desktop", "Cursor"]);
     expect(entry?.license).toBe("MIT");
   });
 

--- a/packages/catalog-builder/test/metadata.test.ts
+++ b/packages/catalog-builder/test/metadata.test.ts
@@ -1,0 +1,34 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { readMetadataSidecars } from "../src/metadata.js";
+
+describe("readMetadataSidecars", () => {
+  it("returns an empty map when the metadata directory does not exist", () => {
+    expect(readMetadataSidecars(join(tmpdir(), "missing-mcp-metadata-dir")).size).toBe(0);
+  });
+
+  it("loads sidecar metadata by explicit id", () => {
+    const metadataDir = mkdtempSync(join(tmpdir(), "mcp-metadata-"));
+
+    try {
+      writeFileSync(
+        join(metadataDir, "ignored-file-name.json"),
+        JSON.stringify({
+          id: "github-owner-demo-12345678",
+          install: {
+            commands: ["npx -y demo"],
+            confidence: "medium",
+          },
+        }),
+      );
+
+      const metadata = readMetadataSidecars(metadataDir);
+
+      expect(metadata.get("github-owner-demo-12345678")?.install?.commands).toEqual(["npx -y demo"]);
+    } finally {
+      rmSync(metadataDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/profile-renderer/src/renderProfiles.ts
+++ b/packages/profile-renderer/src/renderProfiles.ts
@@ -11,6 +11,11 @@ export interface ServerProfile {
   profileUrl: string;
   badgeMarkdown: string;
   links: CatalogEntry["links"];
+  install: CatalogEntry["install"];
+  transport: CatalogEntry["transport"];
+  auth: CatalogEntry["auth"];
+  clients: CatalogEntry["clients"];
+  license: CatalogEntry["license"];
   summary: {
     transport: string[];
     auth: string;
@@ -32,6 +37,11 @@ export const renderProfile = (entry: CatalogEntry, baseUrl: string): ServerProfi
     profileUrl,
     badgeMarkdown: badgeMarkdown(entry, profileUrl),
     links: entry.links,
+    install: entry.install,
+    transport: entry.transport,
+    auth: entry.auth,
+    clients: entry.clients,
+    license: entry.license,
     summary: {
       transport: entry.transport,
       auth: entry.auth.type,

--- a/packages/profile-renderer/test/renderProfiles.test.ts
+++ b/packages/profile-renderer/test/renderProfiles.test.ts
@@ -66,6 +66,18 @@ describe("renderProfile", () => {
     expect(profile.badgeMarkdown).toBe(
       "[![Indexed on TensorBlock MCP Index](https://mcp-index.tensorblock.co/v1/servers/github-owner-demo/badge.svg)](https://tensorblock.co/mcp/servers/github-owner-demo)"
     );
+    expect(profile.install).toEqual({
+      commands: ["npx -y @owner/demo-mcp"],
+      env: ["DEMO_API_KEY"],
+      confidence: "medium",
+    });
+    expect(profile.transport).toEqual(["stdio"]);
+    expect(profile.auth).toEqual({
+      type: "api-key",
+      notes: ["Requires DEMO_API_KEY."],
+    });
+    expect(profile.clients).toEqual(["claude"]);
+    expect(profile.license).toBe("MIT");
     expect(profile.summary.installConfidence).toBe("medium");
   });
 

--- a/schemas/server-metadata.schema.json
+++ b/schemas/server-metadata.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tensorblock.co/schemas/mcp-server-metadata.json",
+  "type": "object",
+  "required": ["id", "source"],
+  "properties": {
+    "$schema": { "type": "string" },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+    },
+    "source": {
+      "type": "object",
+      "required": ["projectUrl"],
+      "properties": {
+        "issue": { "type": "integer", "minimum": 1 },
+        "projectUrl": { "type": "string", "format": "uri", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "object",
+      "properties": {
+        "docs": { "type": "string", "format": "uri", "minLength": 1 },
+        "endpoint": { "type": "string", "format": "uri", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "install": {
+      "type": "object",
+      "properties": {
+        "commands": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "env": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "confidence": { "enum": ["high", "medium", "low"] }
+      },
+      "additionalProperties": false
+    },
+    "transport": {
+      "type": "array",
+      "items": { "enum": ["stdio", "streamable-http", "sse", "unknown"] },
+      "minItems": 1
+    },
+    "auth": {
+      "type": "object",
+      "required": ["type", "notes"],
+      "properties": {
+        "type": { "enum": ["none", "api-key", "oauth", "bearer", "unknown"] },
+        "notes": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      },
+      "additionalProperties": false
+    },
+    "clients": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "license": { "type": "string", "minLength": 1 }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- generate data/server-metadata/{serverId}.json sidecars from Add MCP server issue submissions
- merge sidecar install, transport, auth, client, and license metadata into catalog entries without bloating docs bullets
- expose structured install/auth/client/license fields in generated profile JSON
- document the sidecar workflow for contributors and add a sidecar JSON schema

## Tests
- node --test .github/scripts/*.test.mjs
- npm test
- npm run typecheck
- npm run build
- git diff --check