### PR TITLE
Improve add-server issue intake

### DIFF
--- a/.github/scripts/create-add-server-pr.mjs
+++ b/.github/scripts/create-add-server-pr.mjs
@@ -13,30 +13,56 @@ const DEFAULT_BASE_BRANCH = "main";
 
 export const CATEGORY_TO_DOCS_PATH = {
   "AI & LLM Integration": "docs/ai--llm-integration.md",
+  "Art, Culture & Media": "docs/art-culture--media.md",
   "Browser Automation & Web Scraping": "docs/browser-automation--web-scraping.md",
+  "Build & Deployment Tools": "docs/build--deployment-tools.md",
   "Cloud Platforms & Services": "docs/cloud-platforms--services.md",
+  "Code Analysis & Quality": "docs/code-analysis--quality.md",
   "Code Execution": "docs/code-execution.md",
+  "Communication & Messaging": "docs/communication--messaging.md",
+  "Content Management Systems": "docs/content-management-systems-cms.md",
+  "Data Analysis & Business Intelligence": "docs/data-analysis--business-intelligence.md",
   Databases: "docs/databases.md",
   "Developer Productivity & Utilities": "docs/developer-productivity--utilities.md",
   Filesystems: "docs/filesystems.md",
+  "Finance & Crypto": "docs/finance--crypto.md",
+  Frameworks: "docs/frameworks.md",
+  Gaming: "docs/gaming.md",
+  "Hardware & IoT": "docs/hardware--iot.md",
+  "Healthcare & Life Sciences": "docs/healthcare--life-sciences.md",
+  Infrastructure: "docs/infrastructure.md",
   "Knowledge Management & Memory": "docs/knowledge-management--memory.md",
+  "Location & Maps": "docs/location--maps.md",
+  "Marketing, Sales & CRM": "docs/marketing-sales--crm.md",
   "Monitoring & Observability": "docs/monitoring--observability.md",
+  "Multimedia Processing": "docs/multimedia-processing.md",
   "Operating System & Command Line": "docs/operating-system--command-line.md",
+  "Project & Task Management": "docs/project--task-management.md",
+  "Science & Research": "docs/science--research.md",
   Search: "docs/search.md",
   Security: "docs/security.md",
+  "Social Media & Content Platforms": "docs/social-media--content-platforms.md",
+  Sports: "docs/sport.md",
+  "Travel & Transportation": "docs/travel--transportation.md",
+  "Utilities & Helpers": "docs/utilities--helpers.md",
+  "Version Control": "docs/version-control.md",
 };
+
+const DOCS_PATH_TO_CATEGORY = Object.fromEntries(
+  Object.entries(CATEGORY_TO_DOCS_PATH).map(([category, docsPath]) => [docsPath, category]),
+);
 
 export function parseAddServerIssue(body) {
   return {
-    serverName: normalizeField(extractField(body, "Server name")),
-    projectUrl: normalizeField(extractField(body, "Project URL")),
-    category: normalizeField(extractField(body, "Best category")),
-    description: normalizeField(extractField(body, "What can an agent do with this server?")),
-    install: normalizeField(extractField(body, "Install or connection instructions")),
-    transport: normalizeField(extractField(body, "Transport")),
-    auth: normalizeField(extractField(body, "Auth requirements")),
-    clients: normalizeField(extractField(body, "Known supported clients")),
-    license: normalizeField(extractField(body, "License")),
+    serverName: normalizeField(extractIssueField(body, "Server name")),
+    projectUrl: normalizeField(extractIssueField(body, "Project URL")),
+    category: normalizeCategory(normalizeField(extractIssueField(body, "Best category")), body),
+    description: normalizeField(extractIssueField(body, "What can an agent do with this server?")),
+    install: normalizeField(extractIssueField(body, "Install or connection instructions")),
+    transport: normalizeField(extractIssueField(body, "Transport")),
+    auth: normalizeField(extractIssueField(body, "Auth requirements", "Auth")),
+    clients: normalizeField(extractIssueField(body, "Known supported clients", "Clients")),
+    license: normalizeField(extractIssueField(body, "License")),
   };
 }
 
@@ -72,7 +98,7 @@ export function buildMarkdownEntry(submission) {
 }
 
 export function docPathForCategory(category) {
-  return CATEGORY_TO_DOCS_PATH[category] ?? null;
+  return CATEGORY_TO_DOCS_PATH[normalizeCategory(category)] ?? null;
 }
 
 export function appendEntryToDocs(docPath, entry) {
@@ -153,8 +179,9 @@ export function buildMetadataSidecar({ issue, submission }) {
       projectUrl: submission.projectUrl,
     },
     ...definedObject({
+      links: buildLinkMetadata(submission.install),
       install: buildInstallMetadata(submission.install),
-      transport: parseTransportMetadata(submission.transport),
+      transport: parseTransportMetadata(`${submission.transport}\n${submission.install}`),
       auth: buildAuthMetadata(submission.auth),
       clients: parseListMetadata(submission.clients),
       license: normalizeMetadataScalar(submission.license),
@@ -166,6 +193,56 @@ export function buildMetadataSidecar({ issue, submission }) {
     path: `data/server-metadata/${serverId}.json`,
     content: `${JSON.stringify(metadata, null, 2)}\n`,
   };
+}
+
+function extractIssueField(body, ...labels) {
+  for (const label of labels) {
+    const markdownField = extractField(body, label);
+    if (markdownField) {
+      return markdownField;
+    }
+
+    const boldField = extractBoldField(body, label);
+    if (boldField) {
+      return boldField;
+    }
+  }
+
+  return "";
+}
+
+function extractBoldField(body, label) {
+  const pattern = new RegExp(
+    `(?:^|\\n)\\s*\\*\\*${escapeRegex(label)}\\*\\*\\s*:?\\s*([^\\n]*)\\n?([\\s\\S]*?)(?=\\n\\s*(?:\\*\\*[^\\n*]+\\*\\*\\s*:?|###\\s+)|$)`,
+    "i",
+  );
+  const match = body.match(pattern);
+  if (!match) {
+    return "";
+  }
+
+  return [match[1], match[2]]
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+}
+
+function normalizeCategory(value, context = "") {
+  const lookupText = [value, context].filter(Boolean).join("\n");
+  const docsPath = lookupText.match(/docs\/[a-z0-9-]+\.md/i)?.[0];
+  if (docsPath && DOCS_PATH_TO_CATEGORY[docsPath]) {
+    return DOCS_PATH_TO_CATEGORY[docsPath];
+  }
+
+  const normalizedValue = lookupText.toLowerCase();
+  for (const category of Object.keys(CATEGORY_TO_DOCS_PATH)) {
+    if (normalizedValue.includes(category.toLowerCase())) {
+      return category;
+    }
+  }
+
+  return value;
 }
 
 export function buildIssueComment({ issue, submission, pullRequest, duplicate, errors }) {
@@ -283,6 +360,11 @@ function formatMetadataValue(label, value) {
   return compactText(value, 500).replace(new RegExp(`^${label}:\\s*`, "i"), "");
 }
 
+function buildLinkMetadata(value) {
+  const endpoint = extractEndpoint(value);
+  return endpoint ? { endpoint } : null;
+}
+
 function buildInstallMetadata(value) {
   const commands = parseInstallCommands(value);
   const env = extractEnvVars(value);
@@ -336,10 +418,10 @@ function buildAuthMetadata(value) {
 
   if (/\b(no auth|none|not required|no authentication)\b/.test(lower)) type = "none";
   else if (lower.includes("oauth")) type = "oauth";
-  else if (lower.includes("bearer")) type = "bearer";
   else if (lower.includes("api key") || lower.includes("api-key") || /\b[A-Z][A-Z0-9_]*API_KEY\b/.test(value)) {
     type = "api-key";
   }
+  else if (lower.includes("bearer")) type = "bearer";
 
   return {
     type,
@@ -366,6 +448,11 @@ function extractEnvVars(value) {
   return unique(matches.filter((match) => /(KEY|TOKEN|SECRET|PASSWORD|ENDPOINT|URL)$/.test(match)));
 }
 
+function extractEndpoint(value) {
+  const urls = value.match(/https?:\/\/[^\s`,)\]]+/gi) ?? [];
+  return urls.map(stripUrlPunctuation).find(looksLikeMcpEndpoint) ?? null;
+}
+
 function cleanMetadataLine(value) {
   return value
     .trim()
@@ -377,6 +464,26 @@ function cleanMetadataLine(value) {
 
 function isLikelyLaunchCommand(value) {
   return /^(?:npx|uvx|npm|docker|node|python3?|[a-z0-9._-]*mcp)\b/i.test(value);
+}
+
+function stripUrlPunctuation(url) {
+  return url.replace(/[.;:!?]+$/, "");
+}
+
+function looksLikeMcpEndpoint(url) {
+  try {
+    const parsed = new URL(url);
+    const hostname = parsed.hostname.toLowerCase();
+    const pathname = parsed.pathname.toLowerCase().replace(/\/+$/, "");
+
+    return hostname.startsWith("mcp.") || pathname === "/mcp" || pathname.endsWith("/mcp");
+  } catch {
+    return false;
+  }
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function definedObject(entries) {

--- a/.github/scripts/create-add-server-pr.test.mjs
+++ b/.github/scripts/create-add-server-pr.test.mjs
@@ -53,6 +53,65 @@ const issueBody = [
   "MIT",
 ].join("\n");
 
+const boldIssueBody = [
+  "**Server name**: kaitoInfra/twitterapi-io-mcp-server",
+  "",
+  "**Project URL**: https://github.com/kaitoInfra/twitterapi-io-mcp-server",
+  "",
+  "**Best category**: Other / not sure — closest fit is `docs/social-media--content-platforms.md`.",
+  "",
+  "**What can an agent do with this server?**",
+  "",
+  "Official MCP server for twitterapi.io. 12 read-only tools let agents search tweets, fetch profiles, expand conversation threads, stream real-time tweets, get trends, and pull engagement metrics.",
+  "",
+  "**Install or connection instructions**",
+  "",
+  "Hosted endpoint: https://mcp.twitterapi.io/mcp",
+  "",
+  "```bash",
+  "npx -y @kaitoinfra/twitterapi-io-mcp-server",
+  "```",
+  "",
+  "Env: TWITTERAPI_API_KEY=...",
+  "",
+  "**Transport**: multiple (streamable-http for hosted, stdio for npm/local)",
+  "",
+  "**Auth**: API key (Bearer or env var)",
+  "",
+  "**License**: MIT",
+].join("\n");
+
+const suggestedCategoryIssueBody = [
+  "### Server name",
+  "",
+  "sapph1re/findata-mcp",
+  "",
+  "### Project URL",
+  "",
+  "https://github.com/sapph1re/findata-mcp",
+  "",
+  "### Best category",
+  "",
+  "Other / not sure",
+  "",
+  "### What can an agent do with this server?",
+  "",
+  "Get real-time financial data, SEC filings, and crypto prices. Suggested category: Finance & Crypto.",
+  "",
+  "### Install or connection instructions",
+  "",
+  "Install: `pip install findata-mcp`",
+  "Transport: streamable-http (remote hosted)",
+  "",
+  "### Transport",
+  "",
+  "streamable-http",
+  "",
+  "### Auth requirements",
+  "",
+  "no auth",
+].join("\n");
+
 test("parses add-server issue form fields", () => {
   assert.deepEqual(parseAddServerIssue(issueBody), {
     serverName: "owner/example-mcp",
@@ -67,8 +126,37 @@ test("parses add-server issue form fields", () => {
   });
 });
 
+test("parses bold add-server issue fields and category path hints", () => {
+  assert.deepEqual(parseAddServerIssue(boldIssueBody), {
+    serverName: "kaitoInfra/twitterapi-io-mcp-server",
+    projectUrl: "https://github.com/kaitoInfra/twitterapi-io-mcp-server",
+    category: "Social Media & Content Platforms",
+    description: "Official MCP server for twitterapi.io. 12 read-only tools let agents search tweets, fetch profiles, expand conversation threads, stream real-time tweets, get trends, and pull engagement metrics.",
+    install: [
+      "Hosted endpoint: https://mcp.twitterapi.io/mcp",
+      "```bash",
+      "npx -y @kaitoinfra/twitterapi-io-mcp-server",
+      "```",
+      "",
+      "Env: TWITTERAPI_API_KEY=...",
+    ].join("\n"),
+    transport: "multiple (streamable-http for hosted, stdio for npm/local)",
+    auth: "API key (Bearer or env var)",
+    clients: "",
+    license: "MIT",
+  });
+});
+
 test("maps category to docs path", () => {
   assert.equal(docPathForCategory("Databases"), "docs/databases.md");
+  assert.equal(docPathForCategory("Finance & Crypto"), "docs/finance--crypto.md");
+  assert.equal(docPathForCategory("Social Media & Content Platforms"), "docs/social-media--content-platforms.md");
+  assert.equal(docPathForCategory("Other / not sure — suggested category: Finance & Crypto"), "docs/finance--crypto.md");
+});
+
+test("uses suggested category from the issue description when category is unsure", () => {
+  assert.equal(parseAddServerIssue(suggestedCategoryIssueBody).category, "Finance & Crypto");
+  assert.deepEqual(validateSubmission(parseAddServerIssue(suggestedCategoryIssueBody)), []);
 });
 
 test("builds catalog markdown entry", () => {
@@ -137,14 +225,33 @@ test("builds a metadata sidecar for submitted install and compatibility fields",
   assert.equal(metadata.license, "MIT");
 });
 
+test("builds sidecar endpoint, command, and transport from install text", () => {
+  const submission = parseAddServerIssue(boldIssueBody);
+  const metadata = JSON.parse(buildMetadataSidecar({
+    issue: { number: 724 },
+    submission,
+  }).content);
+
+  assert.deepEqual(metadata.links, {
+    endpoint: "https://mcp.twitterapi.io/mcp",
+  });
+  assert.deepEqual(metadata.install, {
+    commands: ["npx -y @kaitoinfra/twitterapi-io-mcp-server"],
+    env: ["TWITTERAPI_API_KEY"],
+    confidence: "medium",
+  });
+  assert.deepEqual(metadata.transport, ["stdio", "streamable-http"]);
+  assert.deepEqual(metadata.auth, {
+    type: "api-key",
+    notes: ["API key (Bearer or env var)"],
+  });
+});
+
 test("validates required fields and category", () => {
   const submission = parseAddServerIssue(issueBody);
   assert.deepEqual(validateSubmission(submission), []);
 
-  assert.deepEqual(
-    validateSubmission({ ...submission, category: "Other / not sure" }),
-    ['Category "Other / not sure" needs maintainer routing before a draft PR can be generated.'],
-  );
+  assert.deepEqual(validateSubmission(parseAddServerIssue(boldIssueBody)), []);
 });
 
 test("finds duplicate project URLs across docs", () => {


### PR DESCRIPTION
## Summary
- parse add-server submissions that use bold field labels as well as issue-form headings
- route unsure categories when the issue body includes a docs path or suggested category
- extract hosted MCP endpoints, launch commands, env vars, and transports into metadata sidecars

## Tests
- node --test .github/scripts/create-add-server-pr.test.mjs
- node --test .github/scripts/*.test.mjs
- npm test
- npm run typecheck
- npm run build
- git diff --check