### PR TITLE
Clean quoted endpoint URLs in intake metadata

### DIFF
--- a/.github/scripts/create-add-server-pr.mjs
+++ b/.github/scripts/create-add-server-pr.mjs
@@ -467,7 +467,7 @@ function isLikelyLaunchCommand(value) {
 }
 
 function stripUrlPunctuation(url) {
-  return url.replace(/[.;:!?]+$/, "");
+  return url.replace(/[.;:!?"']+$/, "");
 }
 
 function looksLikeMcpEndpoint(url) {

--- a/.github/scripts/create-add-server-pr.test.mjs
+++ b/.github/scripts/create-add-server-pr.test.mjs
@@ -66,7 +66,7 @@ const boldIssueBody = [
   "",
   "**Install or connection instructions**",
   "",
-  "Hosted endpoint: https://mcp.twitterapi.io/mcp",
+  "Hosted endpoint: \"https://mcp.twitterapi.io/mcp\"",
   "",
   "```bash",
   "npx -y @kaitoinfra/twitterapi-io-mcp-server",
@@ -133,7 +133,7 @@ test("parses bold add-server issue fields and category path hints", () => {
     category: "Social Media & Content Platforms",
     description: "Official MCP server for twitterapi.io. 12 read-only tools let agents search tweets, fetch profiles, expand conversation threads, stream real-time tweets, get trends, and pull engagement metrics.",
     install: [
-      "Hosted endpoint: https://mcp.twitterapi.io/mcp",
+      "Hosted endpoint: \"https://mcp.twitterapi.io/mcp\"",
       "```bash",
       "npx -y @kaitoinfra/twitterapi-io-mcp-server",
       "```",


### PR DESCRIPTION
## Summary
- strip trailing quotes from detected hosted MCP endpoint URLs
- cover quoted endpoint snippets in add-server intake tests

## Tests
- node --test .github/scripts/create-add-server-pr.test.mjs
- node --test .github/scripts/*.test.mjs
- npm test
- npm run typecheck
- npm run build
- git diff --check