### PR TITLE
Add metadata sidecars for recent PRs

### DIFF
--- a/data/server-metadata/bitcompare-net-mcp-1db77cc7.json
+++ b/data/server-metadata/bitcompare-net-mcp-1db77cc7.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "../../schemas/server-metadata.schema.json",
+  "id": "bitcompare-net-mcp-1db77cc7",
+  "source": {
+    "projectUrl": "https://bitcompare.net/mcp"
+  },
+  "links": {
+    "docs": "https://api.bitcompare.net/openapi.json",
+    "endpoint": "https://api.bitcompare.net/mcp"
+  },
+  "install": {
+    "commands": [
+      "npx @bitcompare/mcp-server"
+    ],
+    "env": [],
+    "confidence": "medium"
+  },
+  "transport": [
+    "stdio",
+    "streamable-http"
+  ],
+  "auth": {
+    "type": "api-key",
+    "notes": [
+      "Bearer/API-key auth from Bitcompare Pro"
+    ]
+  }
+}

--- a/data/server-metadata/github-ipythoning-domain-monitor-mcp-server-48496711.json
+++ b/data/server-metadata/github-ipythoning-domain-monitor-mcp-server-48496711.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "../../schemas/server-metadata.schema.json",
+  "id": "github-ipythoning-domain-monitor-mcp-server-48496711",
+  "source": {
+    "projectUrl": "https://github.com/iPythoning/domain-monitor-mcp-server"
+  },
+  "install": {
+    "commands": [
+      "npx domain-monitor-mcp-server"
+    ],
+    "env": [],
+    "confidence": "medium"
+  },
+  "transport": [
+    "stdio"
+  ],
+  "auth": {
+    "type": "none",
+    "notes": []
+  }
+}

--- a/data/server-metadata/github-thebrierfox-the-stall-4a05b315.json
+++ b/data/server-metadata/github-thebrierfox-the-stall-4a05b315.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../schemas/server-metadata.schema.json",
+  "id": "github-thebrierfox-the-stall-4a05b315",
+  "source": {
+    "projectUrl": "https://github.com/thebrierfox/the-stall"
+  },
+  "links": {
+    "endpoint": "https://the-stall.intuitek.ai/mcp"
+  },
+  "transport": [
+    "streamable-http"
+  ],
+  "auth": {
+    "type": "none",
+    "notes": []
+  }
+}

--- a/data/server-metadata/github-xquik-dev-x-twitter-scraper-95ed8f41.json
+++ b/data/server-metadata/github-xquik-dev-x-twitter-scraper-95ed8f41.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../../schemas/server-metadata.schema.json",
+  "id": "github-xquik-dev-x-twitter-scraper-95ed8f41",
+  "source": {
+    "projectUrl": "https://github.com/Xquik-dev/x-twitter-scraper"
+  },
+  "links": {
+    "endpoint": "https://xquik.com/mcp"
+  },
+  "transport": [
+    "streamable-http"
+  ],
+  "auth": {
+    "type": "api-key",
+    "notes": [
+      "x-api-key auth"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add structured metadata for Bitcompare, Domain Monitor, The Stall, and Xquik
- correct Domain Monitor auth from inferred api-key to none
- expose hosted endpoints and transports for recently merged entries

## Tests
- npm test
- node --test .github/scripts/*.test.mjs
- npm run typecheck
- npm run build
- npm run catalog:build
- npm run profiles:build
- git diff --check