### PR TITLE
Strengthen maintainer growth loop

### DIFF
--- a/.github/scripts/comment-merged-pr.mjs
+++ b/.github/scripts/comment-merged-pr.mjs
@@ -8,9 +8,10 @@ const API_BASE = "https://api.github.com";
 const API_PROFILE_BASE_URL = "https://mcp-index.tensorblock.co/v1/servers";
 const WEB_PROFILE_BASE_URL = "https://tensorblock.co/mcp/servers";
 const DISCORD_URL = "https://discord.com/invite/Ej5NmeHFf2";
-const CLAIM_PROFILE_URL = "https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=claim-profile.yml";
+const ISSUE_FORM_BASE_URL = "https://github.com/TensorBlock/awesome-mcp-servers/issues/new";
 const COMMENT_MARKER = "<!-- tensorblock-mcp-merge-follow-up:v1 -->";
 const MAX_ENTRIES_IN_COMMENT = 10;
+const CLIENTS = ["claude-desktop", "cursor", "codex", "vscode"];
 
 export function extractAddedCatalogEntries(files) {
   const entriesById = new Map();
@@ -72,14 +73,14 @@ export function buildMergedPrComment({ pullRequest, entries }) {
     COMMENT_MARKER,
     `Thanks for contributing to the TensorBlock MCP Index. PR #${pullRequest.number} has been merged into \`main\`.`,
     "",
-    "After the registry deploy finishes, the new server entry will be searchable through the public MCP Index website and API.",
+    "After the registry deploy finishes, the new server entry will be searchable through the public MCP Index website and API. Each indexed profile includes normalized metadata, generated install-config previews, and a README badge you can share from your project.",
     "",
     ...visibleEntries.flatMap(formatEntryFollowUp),
     ...(omittedCount > 0 ? [`_Omitted ${omittedCount} additional entries from this comment._`, ""] : []),
-    "Useful next steps:",
-    "- Add the TensorBlock MCP Index badge to your project README.",
-    `- Share the public profile link with users who want install/config metadata.`,
-    `- Claim or improve your profile metadata: ${CLAIM_PROFILE_URL}`,
+    "Maintainer next steps:",
+    "- Add the README badge to your project so users can jump back to the indexed profile.",
+    "- Share the public profile link with users who want install/config metadata.",
+    "- Claim the profile if you maintain the project, or submit metadata fixes when install, auth, docs, license, or tool details change.",
     `- Join the community: ${DISCORD_URL}`,
   ].join("\n");
 }
@@ -88,12 +89,16 @@ function formatEntryFollowUp(entry) {
   const profileUrl = webProfileUrl(entry.id);
   const apiProfileUrl = apiProfileUrlFor(entry.id);
   const badgeMarkdown = badgeMarkdownFor(entry);
+  const installConfigLinks = CLIENTS
+    .map((client) => `[${client}](${apiProfileUrl}/install-config?client=${client})`)
+    .join(" · ");
 
   return [
     `### ${entry.name}`,
     `- Profile: ${profileUrl}`,
     `- API profile: ${apiProfileUrl}`,
-    `- Install config preview: ${apiProfileUrl}/install-config?client=claude-desktop`,
+    `- Install config previews: ${installConfigLinks}`,
+    `- Maintainer actions: [claim profile](${issueFormUrl("claim-profile.yml", `Claim MCP profile: ${entry.name}`)}) · [improve metadata](${issueFormUrl("improve-metadata.yml", `Improve metadata: ${entry.name}`)}) · [report issue](${issueFormUrl("report-broken-entry.yml", `Report broken MCP entry: ${entry.name}`)})`,
     "",
     "README badge:",
     "",
@@ -166,6 +171,15 @@ function apiProfileUrlFor(serverId) {
 
 function badgeMarkdownFor(entry) {
   return `[![Indexed on TensorBlock MCP Index](${apiProfileUrlFor(entry.id)}/badge.svg)](${webProfileUrl(entry.id)})`;
+}
+
+function issueFormUrl(template, title) {
+  const params = new URLSearchParams({
+    template,
+    title,
+  });
+
+  return `${ISSUE_FORM_BASE_URL}?${params.toString()}`;
 }
 
 async function main() {

--- a/.github/scripts/comment-merged-pr.test.mjs
+++ b/.github/scripts/comment-merged-pr.test.mjs
@@ -84,5 +84,11 @@ test("builds a merged PR follow-up with profile, API, badge, and community links
   assert.match(comment, /https:\/\/mcp-index\.tensorblock\.co\/v1\/servers\/github-cursortouch-windows-mcp-83a6332f/);
   assert.match(comment, /badge\.svg/);
   assert.match(comment, /claim-profile\.yml/);
+  assert.match(comment, /improve-metadata\.yml/);
+  assert.match(comment, /report-broken-entry\.yml/);
+  assert.match(comment, /install-config\?client=claude-desktop/);
+  assert.match(comment, /install-config\?client=cursor/);
+  assert.match(comment, /install-config\?client=codex/);
+  assert.match(comment, /install-config\?client=vscode/);
   assert.match(comment, /discord\.com\/invite/);
 });

--- a/.github/scripts/triage-issue.mjs
+++ b/.github/scripts/triage-issue.mjs
@@ -120,6 +120,7 @@ export function buildTriageComment(issue) {
       "- We will check for duplicates and route it to the closest category page.",
       "- If the category and required fields are clear, automation will draft a docs entry PR for maintainer review.",
       "- Once merged, the Railway deploy rebuilds the catalog and the server becomes searchable through the hosted MCP Index API.",
+      "- The merged PR follow-up includes the public profile URL, API profile URL, install-config links, and README badge markdown.",
       "",
       describeCapturedFields(body, [
         ["Server", "Server name"],

--- a/README.md
+++ b/README.md
@@ -22,9 +22,19 @@ TensorBlock MCP Index turns this community-curated MCP server directory into a h
 
 **Hosted API:** [https://mcp-index.tensorblock.co](https://mcp-index.tensorblock.co)
 
+## MCP Maintainer Quick Start
+
+If you maintain an MCP server, the index can give your project a public profile, install-config previews, API metadata, and a README badge.
+
+1. Add your server in the best `docs/*.md` category, or use the [Add MCP server issue form](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=add-mcp-server.yml).
+2. Include install, transport, auth, supported clients, docs, license, endpoint, and tool details when you have them.
+3. After merge, the follow-up comment gives you the public profile URL, API profile URL, install-config links, and badge markdown.
+4. Add the TensorBlock MCP Index badge to your project README so users can jump back to the indexed profile.
+5. Claim your profile or send metadata fixes through the [claim profile](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=claim-profile.yml) and [metadata improvement](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=improve-metadata.yml) forms.
+
 ## Coverage
 
-This repo currently indexes **7,493 unique MCP server links** from the category docs. The README stays lightweight while the full directory lives in `docs/*.md`, `data/catalog.json`, and the registry MCP server.
+This repo currently indexes **7,746 unique MCP server links** from the category docs. The README stays lightweight while the full directory lives in `docs/*.md`, `data/catalog.json`, and the registry MCP server.
 
 ## How to Participate
 
@@ -162,38 +172,38 @@ The README is now a lightweight entry point. Browse the full directory in the ca
 
 | Category | Listed entries | Full list |
 | --- | ---: | --- |
-| AI & LLM Integration | 1,629 | [Browse](docs/ai--llm-integration.md) |
+| AI & LLM Integration | 1,632 | [Browse](docs/ai--llm-integration.md) |
 | Art, Culture & Media | 82 | [Browse](docs/art-culture--media.md) |
-| Browser Automation & Web Scraping | 277 | [Browse](docs/browser-automation--web-scraping.md) |
+| Browser Automation & Web Scraping | 281 | [Browse](docs/browser-automation--web-scraping.md) |
 | Build & Deployment Tools | 88 | [Browse](docs/build--deployment-tools.md) |
 | Cloud Platforms & Services | 373 | [Browse](docs/cloud-platforms--services.md) |
-| Code Analysis & Quality | 116 | [Browse](docs/code-analysis--quality.md) |
+| Code Analysis & Quality | 118 | [Browse](docs/code-analysis--quality.md) |
 | Code Execution | 164 | [Browse](docs/code-execution.md) |
-| Communication & Messaging | 333 | [Browse](docs/communication--messaging.md) |
+| Communication & Messaging | 334 | [Browse](docs/communication--messaging.md) |
 | Content Management Systems | 60 | [Browse](docs/content-management-systems-cms.md) |
-| Data Analysis & Business Intelligence | 243 | [Browse](docs/data-analysis--business-intelligence.md) |
-| Databases | 297 | [Browse](docs/databases.md) |
-| Developer Productivity & Utilities | 407 | [Browse](docs/developer-productivity--utilities.md) |
+| Data Analysis & Business Intelligence | 244 | [Browse](docs/data-analysis--business-intelligence.md) |
+| Databases | 299 | [Browse](docs/databases.md) |
+| Developer Productivity & Utilities | 414 | [Browse](docs/developer-productivity--utilities.md) |
 | Filesystems | 56 | [Browse](docs/filesystems.md) |
-| Finance & Crypto | 437 | [Browse](docs/finance--crypto.md) |
-| Frameworks | 244 | [Browse](docs/frameworks.md) |
+| Finance & Crypto | 445 | [Browse](docs/finance--crypto.md) |
+| Frameworks | 245 | [Browse](docs/frameworks.md) |
 | Gaming | 108 | [Browse](docs/gaming.md) |
-| Hardware & IoT | 66 | [Browse](docs/hardware--iot.md) |
+| Hardware & IoT | 67 | [Browse](docs/hardware--iot.md) |
 | Healthcare & Life Sciences | 59 | [Browse](docs/healthcare--life-sciences.md) |
-| Infrastructure | 161 | [Browse](docs/infrastructure.md) |
-| Knowledge Management & Memory | 571 | [Browse](docs/knowledge-management--memory.md) |
+| Infrastructure | 162 | [Browse](docs/infrastructure.md) |
+| Knowledge Management & Memory | 572 | [Browse](docs/knowledge-management--memory.md) |
 | Location & Maps | 92 | [Browse](docs/location--maps.md) |
-| Marketing, Sales & CRM | 186 | [Browse](docs/marketing-sales--crm.md) |
-| Monitoring & Observability | 85 | [Browse](docs/monitoring--observability.md) |
-| Multimedia Processing | 211 | [Browse](docs/multimedia-processing.md) |
+| Marketing, Sales & CRM | 189 | [Browse](docs/marketing-sales--crm.md) |
+| Monitoring & Observability | 87 | [Browse](docs/monitoring--observability.md) |
+| Multimedia Processing | 212 | [Browse](docs/multimedia-processing.md) |
 | Operating System & Command Line | 107 | [Browse](docs/operating-system--command-line.md) |
 | Project & Task Management | 222 | [Browse](docs/project--task-management.md) |
-| Real Estate & Home Services | 2 | [Browse](docs/real-estate--home-services.md) |
+| Real Estate & Home Services | 3 | [Browse](docs/real-estate--home-services.md) |
 | Science & Research | 118 | [Browse](docs/science--research.md) |
 | Search | 172 | [Browse](docs/search.md) |
 | Security | 140 | [Browse](docs/security.md) |
 | Social Media & Content Platforms | 112 | [Browse](docs/social-media--content-platforms.md) |
 | Sports | 3 | [Browse](docs/sport.md) |
-| Travel & Transportation | 50 | [Browse](docs/travel--transportation.md) |
+| Travel & Transportation | 51 | [Browse](docs/travel--transportation.md) |
 | Utilities & Helpers | 357 | [Browse](docs/utilities--helpers.md) |
-| Version Control | 76 | [Browse](docs/version-control.md) |
+| Version Control | 78 | [Browse](docs/version-control.md) |

--- a/packages/registry-api/src/profilePage.ts
+++ b/packages/registry-api/src/profilePage.ts
@@ -1,10 +1,15 @@
 import type { CatalogEntry } from "../../catalog-builder/src/types.js";
+import { badgeMarkdown } from "./badge.js";
 import { webProfileUrl } from "./webProfile.js";
 
 const CLIENTS = ["claude-desktop", "cursor", "codex", "vscode"] as const;
+const DISCORD_URL = "https://discord.com/invite/Ej5NmeHFf2";
+const ISSUE_FORM_BASE_URL = "https://github.com/TensorBlock/awesome-mcp-servers/issues/new";
 
 export const renderServerProfilePage = (entry: CatalogEntry): string => {
   const title = `${entry.name} - TensorBlock MCP Index`;
+  const profileUrl = webProfileUrl(entry.id);
+  const readmeBadge = badgeMarkdown(entry, profileUrl);
   const installCommands = entry.install.commands.length > 0
     ? entry.install.commands.map((command) => `<code>${escapeHtml(command)}</code>`).join("")
     : "<p>No install command has been indexed yet.</p>";
@@ -147,12 +152,46 @@ export const renderServerProfilePage = (entry: CatalogEntry): string => {
     }
     .button {
       align-items: center;
+      background: var(--panel);
       border: 1px solid var(--line);
       border-radius: 7px;
+      color: var(--accent);
+      cursor: pointer;
       display: inline-flex;
+      font: inherit;
       font-weight: 650;
       min-height: 38px;
       padding: 7px 11px;
+    }
+    .button.primary {
+      background: var(--accent);
+      border-color: var(--accent);
+      color: #ffffff;
+    }
+    .helper {
+      color: var(--muted);
+      max-width: 760px;
+    }
+    h3 {
+      font-size: 15px;
+      margin: 18px 0 8px;
+      letter-spacing: 0;
+    }
+    pre {
+      background: #f3f5f8;
+      border: 1px solid #e1e6ee;
+      border-radius: 8px;
+      margin: 0;
+      overflow-x: auto;
+      padding: 12px;
+    }
+    pre code {
+      background: transparent;
+      border: 0;
+      display: block;
+      margin: 0;
+      padding: 0;
+      white-space: pre-wrap;
     }
     .footer {
       color: var(--muted);
@@ -196,8 +235,25 @@ export const renderServerProfilePage = (entry: CatalogEntry): string => {
         ${optionalLink("Docs", entry.links.docs)}
         ${optionalLink("Homepage", entry.links.homepage)}
         ${optionalLink("Remote endpoint", entry.links.endpoint)}
-        <a class="button" href="${escapeAttribute(webProfileUrl(entry.id))}">Website profile</a>
+        <a class="button" href="${escapeAttribute(profileUrl)}">Website profile</a>
         <a class="button" href="/v1/servers/${encodeURIComponent(entry.id)}">JSON profile</a>
+      </div>
+    </section>
+
+    <section class="maintainer-actions">
+      <h2>For Maintainers</h2>
+      <p class="helper">Use this profile as the public install and metadata page for your MCP server. Claim the profile, add the badge to your README, and send metadata fixes when install or auth details change.</p>
+      <div class="links">
+        <a class="button primary" href="${escapeAttribute(issueFormUrl("claim-profile.yml", `Claim MCP profile: ${entry.name}`))}">Claim profile</a>
+        <a class="button" href="${escapeAttribute(issueFormUrl("improve-metadata.yml", `Improve metadata: ${entry.name}`))}">Improve metadata</a>
+        <a class="button" href="${escapeAttribute(issueFormUrl("report-broken-entry.yml", `Report broken MCP entry: ${entry.name}`))}">Report issue</a>
+        <a class="button" href="${escapeAttribute(issueFormUrl("request-client-config.yml", `Request client config support: ${entry.name}`))}">Request client config</a>
+        <a class="button" href="${escapeAttribute(DISCORD_URL)}">Join Discord</a>
+      </div>
+      <h3>README badge</h3>
+      <pre><code id="readme-badge">${escapeHtml(readmeBadge)}</code></pre>
+      <div class="links">
+        <button class="button" type="button" data-copy-target="readme-badge">Copy badge</button>
       </div>
     </section>
 
@@ -239,6 +295,27 @@ export const renderServerProfilePage = (entry: CatalogEntry): string => {
 
     <p class="footer">This profile is generated from the community-maintained <a href="https://github.com/TensorBlock/awesome-mcp-servers">TensorBlock MCP Index</a>.</p>
   </main>
+  <script>
+    document.querySelectorAll("[data-copy-target]").forEach((button) => {
+      const originalText = button.textContent;
+
+      button.addEventListener("click", async () => {
+        const target = document.getElementById(button.getAttribute("data-copy-target"));
+        if (!target) return;
+
+        try {
+          await navigator.clipboard.writeText(target.textContent || "");
+          button.textContent = "Copied";
+        } catch {
+          button.textContent = "Copy failed";
+        }
+
+        window.setTimeout(() => {
+          button.textContent = originalText;
+        }, 1800);
+      });
+    });
+  </script>
 </body>
 </html>`;
 };
@@ -250,6 +327,15 @@ const optionalLink = (label: string, href: string | null | undefined): string =>
 
 const githubSourceUrl = (path: string): string =>
   `https://github.com/TensorBlock/awesome-mcp-servers/blob/main/${encodeURIComponent(path).replace(/%2F/g, "/")}`;
+
+const issueFormUrl = (template: string, title: string): string => {
+  const params = new URLSearchParams({
+    template,
+    title,
+  });
+
+  return `${ISSUE_FORM_BASE_URL}?${params.toString()}`;
+};
 
 const escapeAttribute = (value: string): string =>
   escapeHtml(value).replace(/"/g, "&quot;");

--- a/packages/registry-api/test/profilePage.test.ts
+++ b/packages/registry-api/test/profilePage.test.ts
@@ -59,8 +59,24 @@ describe("renderServerProfilePage", () => {
 
     expect(html).toContain("Unsafe &lt;Demo&gt;");
     expect(html).toContain("&quot;quoted&quot;");
-    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+    expect(html).not.toContain("<script>alert(1)</script>");
     expect(html).not.toContain("javascript:alert");
     expect(html).toContain('href="#"');
+  });
+
+  it("renders maintainer action links and README badge markdown", () => {
+    const html = renderServerProfilePage(entry);
+
+    expect(html).toContain("For Maintainers");
+    expect(html).toContain("template=claim-profile.yml");
+    expect(html).toContain("template=improve-metadata.yml");
+    expect(html).toContain("template=report-broken-entry.yml");
+    expect(html).toContain("template=request-client-config.yml");
+    expect(html).toContain("discord.com/invite/Ej5NmeHFf2");
+    expect(html).toContain("README badge");
+    expect(html).toContain("Copy badge");
+    expect(html).toContain("https://mcp-index.tensorblock.co/v1/servers/unsafe-demo/badge.svg");
+    expect(html).toContain("https://tensorblock.co/mcp/servers/unsafe-demo");
   });
 });


### PR DESCRIPTION
## Summary
- add maintainer actions to generated server profile pages: claim profile, improve metadata, report issue, request client config, Discord, and copyable README badge
- strengthen merged PR follow-up comments with profile/API links, install-config links for supported clients, badge markdown, and per-entry maintainer actions
- make the README maintainer path more explicit and refresh catalog/category counts to 7,746 indexed links
- tell issue submitters that merged PRs will include profile, API, install-config, and badge links

## Validation
- `node --test .github/scripts/comment-merged-pr.test.mjs .github/scripts/triage-issue.test.mjs`
- `npm test -- packages/registry-api/test/profilePage.test.ts packages/registry-api/test/server.test.ts packages/registry-api/test/badge.test.ts`
- `npm run typecheck`
- `npm run build`
- `npm test`
