### PR TITLE
Add claim profile metadata flow

### DIFF
--- a/.github/ISSUE_TEMPLATE/claim-profile.yml
+++ b/.github/ISSUE_TEMPLATE/claim-profile.yml
@@ -4,6 +4,10 @@ title: "Claim MCP profile: "
 labels:
   - claim-profile
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form if you maintain an indexed MCP server and want the public profile to show maintainer and verification metadata. The Project URL should match the indexed profile source, repository, homepage, docs URL, or existing metadata sidecar project URL.
   - type: input
     id: profile-url
     attributes:

--- a/.github/scripts/create-claim-profile-pr.mjs
+++ b/.github/scripts/create-claim-profile-pr.mjs
@@ -1,0 +1,472 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { extractField, serverIdFromProfileReference } from "./triage-issue.mjs";
+
+const API_BASE = "https://api.github.com";
+const COMMENT_MARKER = "<!-- tensorblock-mcp-claim-profile-pr:v1 -->";
+const DEFAULT_BASE_BRANCH = "main";
+const DEFAULT_SCHEMA = "../../schemas/server-metadata.schema.json";
+
+export function parseClaimProfileIssue(body) {
+  const profileReference = normalizeField(extractField(body, "TensorBlock profile URL or server id"));
+
+  return {
+    profileReference,
+    serverId: serverIdFromProfileReference(profileReference),
+    projectUrl: normalizeField(extractField(body, "Project URL")),
+    maintainer: normalizeMaintainer(normalizeField(extractField(body, "Maintainer handle"))),
+    proof: normalizeField(extractField(body, "Maintainer proof")),
+    requestedMetadata: normalizeField(extractField(body, "Metadata you want displayed")),
+  };
+}
+
+export function validateClaimSubmission(submission, entry, existingMetadata) {
+  const errors = [];
+
+  if (!submission.serverId) {
+    errors.push("A valid TensorBlock profile URL or server id is required.");
+  }
+
+  if (!entry) {
+    errors.push(`Indexed profile not found for server id "${submission.serverId || submission.profileReference}".`);
+  }
+
+  if (!submission.projectUrl) {
+    errors.push("Project URL is required.");
+  } else if (!isValidHttpUrl(submission.projectUrl)) {
+    errors.push("Project URL must be a valid HTTP or HTTPS URL.");
+  }
+
+  if (!submission.maintainer) {
+    errors.push("Maintainer handle is required.");
+  }
+
+  if (!submission.proof) {
+    errors.push("Maintainer proof is required.");
+  }
+
+  if (entry && submission.projectUrl && !projectUrlMatchesEntry(submission.projectUrl, entry, existingMetadata)) {
+    errors.push("Project URL must match the indexed profile source URL, repository, homepage, docs URL, or existing sidecar project URL.");
+  }
+
+  return errors;
+}
+
+export function buildClaimMetadataSidecar({ issue, submission, entry, existingMetadata = {} }) {
+  const proofNote = `Claimed by ${submission.maintainer} in #${issue.number}. Proof: ${compactText(submission.proof, 220)}`;
+  const requestedMetadataNote = submission.requestedMetadata
+    ? `Requested profile metadata in #${issue.number}: ${compactText(submission.requestedMetadata, 220)}`
+    : "";
+
+  const source = {
+    ...(existingMetadata.source ?? {}),
+    issue: existingMetadata.source?.issue ?? issue.number,
+    projectUrl: existingMetadata.source?.projectUrl ?? submission.projectUrl ?? entry.links.primary,
+  };
+
+  const metadata = {
+    "$schema": existingMetadata.$schema ?? DEFAULT_SCHEMA,
+    ...existingMetadata,
+    id: entry.id,
+    source,
+    verification: {
+      ...(existingMetadata.verification ?? {}),
+      status: "verified",
+      notes: unique([
+        ...(existingMetadata.verification?.notes ?? []),
+        proofNote,
+        requestedMetadataNote,
+      ].filter(Boolean)),
+    },
+    community: {
+      ...(existingMetadata.community ?? {}),
+      maintainedBy: unique([
+        ...(existingMetadata.community?.maintainedBy ?? []),
+        submission.maintainer,
+      ]),
+      verifiedBy: unique([
+        ...(existingMetadata.community?.verifiedBy ?? []),
+        "TensorBlock",
+      ]),
+      claimed: true,
+    },
+  };
+
+  return {
+    path: `data/server-metadata/${entry.id}.json`,
+    content: `${JSON.stringify(metadata, null, 2)}\n`,
+  };
+}
+
+export function findCatalogEntry(catalog, serverId) {
+  return catalog.find((entry) => entry.id === serverId) ?? null;
+}
+
+export function buildIssueComment({ issue, submission, pullRequest, errors }) {
+  if (errors?.length) {
+    return [
+      COMMENT_MARKER,
+      "I could not create a claim-profile metadata PR yet.",
+      "",
+      "What needs attention:",
+      ...errors.map((error) => `- ${error}`),
+      "",
+      "Update this issue with the corrected profile id, matching project URL, maintainer handle, and proof link. The automation will try again when the issue is edited.",
+    ].join("\n");
+  }
+
+  if (pullRequest?.blocked) {
+    return [
+      COMMENT_MARKER,
+      `Generated branch \`${pullRequest.branch}\` for this profile claim, but GitHub Actions could not create the pull request automatically.`,
+      "",
+      `Open the PR manually: ${pullRequest.compareUrl}`,
+    ].join("\n");
+  }
+
+  return [
+    COMMENT_MARKER,
+    `Created a draft metadata PR for this profile claim: ${pullRequest.html_url}`,
+    "",
+    "A maintainer should verify the proof before merging. Once merged and deployed, the profile will show the claimed maintainer and verification metadata.",
+    "",
+    `Claimed profile id: \`${submission.serverId}\``,
+  ].join("\n");
+}
+
+export function buildPrBody({ issue, submission, entry, sidecar }) {
+  return [
+    "## Summary",
+    `- claim TensorBlock MCP profile \`${entry.id}\` for \`${entry.name}\``,
+    `- add maintainer and verification metadata to \`${sidecar.path}\``,
+    "- mark the profile as claimed once this PR is reviewed and merged",
+    "",
+    "## Maintainer verification",
+    `- Maintainer: ${submission.maintainer}`,
+    `- Project URL: ${submission.projectUrl}`,
+    `- Indexed primary link: ${entry.links.primary}`,
+    "",
+    "Proof submitted in the issue:",
+    "",
+    "```text",
+    submission.proof,
+    "```",
+    ...(submission.requestedMetadata
+      ? [
+          "",
+          "Requested profile metadata:",
+          "",
+          "```text",
+          submission.requestedMetadata,
+          "```",
+        ]
+      : []),
+    "",
+    "## Generated metadata sidecar",
+    "",
+    `\`${sidecar.path}\``,
+    "",
+    "```json",
+    sidecar.content.trimEnd(),
+    "```",
+    "",
+    `Closes #${issue.number}`,
+  ].join("\n");
+}
+
+function loadExistingMetadata(serverId) {
+  const metadataPath = `data/server-metadata/${serverId}.json`;
+  if (!fs.existsSync(metadataPath)) {
+    return {};
+  }
+
+  return JSON.parse(fs.readFileSync(metadataPath, "utf8"));
+}
+
+function writeSidecar(sidecar) {
+  fs.mkdirSync(path.dirname(sidecar.path), { recursive: true });
+  fs.writeFileSync(sidecar.path, sidecar.content);
+}
+
+function normalizeField(value) {
+  const normalized = value
+    .replace(/<!--[\s\S]*?-->/g, "")
+    .trim();
+
+  if (!normalized || normalized === "_No response_") {
+    return "";
+  }
+
+  return normalized;
+}
+
+function normalizeMaintainer(value) {
+  const normalized = value.trim();
+  if (!normalized) {
+    return "";
+  }
+
+  return normalized.startsWith("@") ? normalized : `@${normalized}`;
+}
+
+function isValidHttpUrl(value) {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function projectUrlMatchesEntry(projectUrl, entry, existingMetadata) {
+  const submitted = canonicalizeUrl(projectUrl);
+  const candidates = [
+    entry.links.primary,
+    entry.links.repo,
+    entry.links.homepage,
+    entry.links.docs,
+    existingMetadata?.source?.projectUrl,
+  ].filter(Boolean);
+
+  return candidates.some((candidate) => canonicalizeUrl(candidate) === submitted);
+}
+
+function canonicalizeUrl(value) {
+  try {
+    const parsed = new URL(value.trim());
+    parsed.hash = "";
+    parsed.protocol = parsed.protocol.toLowerCase();
+    parsed.hostname = parsed.hostname.toLowerCase().replace(/^www\./, "");
+
+    if ((parsed.protocol === "https:" && parsed.port === "443") || (parsed.protocol === "http:" && parsed.port === "80")) {
+      parsed.port = "";
+    }
+
+    parsed.pathname = parsed.pathname.replace(/\.git$/i, "").replace(/\/+$/g, "");
+    return parsed.toString().replace(/\/$/g, "");
+  } catch {
+    return value.trim();
+  }
+}
+
+function compactText(value, maxLength) {
+  const compacted = value.replace(/\s+/g, " ").trim();
+  if (compacted.length <= maxLength) {
+    return compacted;
+  }
+
+  const slice = compacted.slice(0, Math.max(0, maxLength - 3)).trimEnd();
+  const lastSpace = slice.lastIndexOf(" ");
+  const wordBoundary = lastSpace > maxLength * 0.6 ? slice.slice(0, lastSpace) : slice;
+  return `${wordBoundary.trimEnd()}...`;
+}
+
+function unique(values) {
+  return Array.from(new Set(values));
+}
+
+async function main() {
+  const token = process.env.GITHUB_TOKEN;
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  const repository = process.env.GITHUB_REPOSITORY;
+
+  if (!token || !eventPath || !repository) {
+    throw new Error("GITHUB_TOKEN, GITHUB_EVENT_PATH, and GITHUB_REPOSITORY are required.");
+  }
+
+  const event = JSON.parse(fs.readFileSync(eventPath, "utf8"));
+  const issue = event.issue;
+  if (!issue) {
+    console.log("No issue payload found; skipping.");
+    return;
+  }
+
+  const [owner, repo] = repository.split("/");
+  const request = createGitHubRequest({ token, owner, repo });
+  const submission = parseClaimProfileIssue(issue.body ?? "");
+  const catalog = JSON.parse(fs.readFileSync("data/catalog.json", "utf8"));
+  const entry = findCatalogEntry(catalog, submission.serverId);
+  const existingMetadata = entry ? loadExistingMetadata(entry.id) : {};
+  const errors = validateClaimSubmission(submission, entry, existingMetadata);
+
+  if (errors.length > 0) {
+    await upsertIssueComment(request, issue.number, buildIssueComment({ issue, submission, errors }));
+    console.log(`Issue #${issue.number} cannot be converted to a claim PR: ${errors.join(" ")}`);
+    return;
+  }
+
+  const sidecar = buildClaimMetadataSidecar({
+    issue,
+    submission,
+    entry,
+    existingMetadata,
+  });
+  const branch = `mcp/claim-profile-issue-${issue.number}`;
+  const title = `Claim ${entry.name} MCP profile`;
+  const body = buildPrBody({ issue, submission, entry, sidecar });
+
+  run("git", ["config", "user.name", "github-actions[bot]"]);
+  run("git", ["config", "user.email", "41898282+github-actions[bot]@users.noreply.github.com"]);
+  run("git", ["fetch", "origin", DEFAULT_BASE_BRANCH]);
+  run("git", ["checkout", "-B", branch, `origin/${DEFAULT_BASE_BRANCH}`]);
+
+  writeSidecar(sidecar);
+  run("git", ["add", sidecar.path]);
+
+  if (!hasStagedChanges()) {
+    console.log(`No claim metadata changes generated for issue #${issue.number}.`);
+    return;
+  }
+
+  run("git", ["commit", "-m", title]);
+  run("git", ["push", "--force-with-lease", "origin", `HEAD:${branch}`]);
+
+  let pullRequest;
+  try {
+    pullRequest = await createOrUpdatePullRequest(request, {
+      owner,
+      branch,
+      title,
+      body,
+    });
+  } catch (error) {
+    if (!isPullRequestCreationBlocked(error)) {
+      throw error;
+    }
+
+    const compareUrl = `https://github.com/${owner}/${repo}/compare/${DEFAULT_BASE_BRANCH}...${branch}?expand=1`;
+    await upsertIssueComment(
+      request,
+      issue.number,
+      buildIssueComment({
+        issue,
+        submission,
+        pullRequest: {
+          blocked: true,
+          branch,
+          compareUrl,
+        },
+      }),
+    );
+    console.log(`Generated branch ${branch} for issue #${issue.number}, but Actions cannot create pull requests.`);
+    console.log(formatGitHubError(error));
+    return;
+  }
+
+  await upsertIssueComment(request, issue.number, buildIssueComment({ issue, submission, pullRequest }));
+  console.log(`Created or updated draft PR ${pullRequest.html_url} for issue #${issue.number}.`);
+}
+
+function run(command, args) {
+  execFileSync(command, args, { stdio: "inherit" });
+}
+
+function hasStagedChanges() {
+  try {
+    execFileSync("git", ["diff", "--cached", "--quiet"], { stdio: "ignore" });
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+function createGitHubRequest({ token, owner, repo }) {
+  return async function request(pathname, options = {}) {
+    const response = await fetch(`${API_BASE}/repos/${owner}/${repo}${pathname}`, {
+      method: options.method ?? "GET",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      body: options.body ? JSON.stringify(options.body) : undefined,
+    });
+
+    const text = await response.text();
+    const data = text ? JSON.parse(text) : null;
+
+    if (!response.ok) {
+      const error = new Error(`GitHub API ${options.method ?? "GET"} ${pathname} failed: ${response.status}`);
+      error.status = response.status;
+      error.data = data;
+      throw error;
+    }
+
+    return data;
+  };
+}
+
+async function createOrUpdatePullRequest(request, { owner, branch, title, body }) {
+  const query = new URLSearchParams({
+    head: `${owner}:${branch}`,
+    state: "open",
+  });
+  const existingPulls = await request(`/pulls?${query.toString()}`);
+  const existingPull = existingPulls[0];
+
+  if (existingPull) {
+    return request(`/pulls/${existingPull.number}`, {
+      method: "PATCH",
+      body: { title, body },
+    });
+  }
+
+  return request("/pulls", {
+    method: "POST",
+    body: {
+      title,
+      body,
+      head: branch,
+      base: DEFAULT_BASE_BRANCH,
+      draft: true,
+      maintainer_can_modify: true,
+    },
+  });
+}
+
+function isPullRequestCreationBlocked(error) {
+  if (error?.status !== 403) {
+    return false;
+  }
+
+  const message = `${error.data?.message ?? ""} ${JSON.stringify(error.data?.errors ?? [])}`;
+  return /not permitted to create|Resource not accessible by integration|pull request/i.test(message);
+}
+
+function formatGitHubError(error) {
+  if (!error?.data) {
+    return error?.message ?? String(error);
+  }
+
+  return `${error.message}: ${JSON.stringify(error.data)}`;
+}
+
+async function upsertIssueComment(request, issueNumber, body) {
+  const comments = await request(`/issues/${issueNumber}/comments?per_page=100`);
+  const existing = comments.find((comment) => comment.body?.includes(COMMENT_MARKER));
+
+  if (existing) {
+    await request(`/issues/comments/${existing.id}`, {
+      method: "PATCH",
+      body: { body },
+    });
+    return;
+  }
+
+  await request(`/issues/${issueNumber}/comments`, {
+    method: "POST",
+    body: { body },
+  });
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/.github/scripts/create-claim-profile-pr.test.mjs
+++ b/.github/scripts/create-claim-profile-pr.test.mjs
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildClaimMetadataSidecar,
+  buildIssueComment,
+  findCatalogEntry,
+  parseClaimProfileIssue,
+  validateClaimSubmission,
+} from "./create-claim-profile-pr.mjs";
+
+const issueBody = [
+  "### TensorBlock profile URL or server id",
+  "",
+  "https://tensorblock.co/mcp/servers/github-owner-demo-mcp-12345678",
+  "",
+  "### Project URL",
+  "",
+  "https://github.com/owner/demo-mcp",
+  "",
+  "### Maintainer handle",
+  "",
+  "owner",
+  "",
+  "### Maintainer proof",
+  "",
+  "I am an owner of the GitHub repository. Verification link: https://github.com/owner/demo-mcp/issues/1",
+  "",
+  "### Metadata you want displayed",
+  "",
+  "Maintained by the demo-mcp core team.",
+].join("\n");
+
+const catalogEntry = {
+  id: "github-owner-demo-mcp-12345678",
+  name: "owner/demo-mcp",
+  links: {
+    primary: "https://github.com/owner/demo-mcp",
+    repo: "https://github.com/owner/demo-mcp",
+    homepage: null,
+    docs: null,
+  },
+};
+
+test("parses claim-profile issue fields", () => {
+  assert.deepEqual(parseClaimProfileIssue(issueBody), {
+    profileReference: "https://tensorblock.co/mcp/servers/github-owner-demo-mcp-12345678",
+    serverId: "github-owner-demo-mcp-12345678",
+    projectUrl: "https://github.com/owner/demo-mcp",
+    maintainer: "@owner",
+    proof: "I am an owner of the GitHub repository. Verification link: https://github.com/owner/demo-mcp/issues/1",
+    requestedMetadata: "Maintained by the demo-mcp core team.",
+  });
+});
+
+test("validates profile claim submissions against indexed project URLs", () => {
+  const submission = parseClaimProfileIssue(issueBody);
+
+  assert.deepEqual(validateClaimSubmission(submission, catalogEntry, {}), []);
+  assert.deepEqual(
+    validateClaimSubmission({
+      ...submission,
+      projectUrl: "https://example.com/not-the-project",
+    }, catalogEntry, {}),
+    ["Project URL must match the indexed profile source URL, repository, homepage, docs URL, or existing sidecar project URL."],
+  );
+});
+
+test("builds a claimed profile metadata sidecar while preserving existing metadata", () => {
+  const submission = parseClaimProfileIssue(issueBody);
+  const sidecar = buildClaimMetadataSidecar({
+    issue: { number: 761 },
+    submission,
+    entry: catalogEntry,
+    existingMetadata: {
+      id: catalogEntry.id,
+      source: {
+        issue: 700,
+        projectUrl: "https://github.com/owner/demo-mcp",
+      },
+      install: {
+        commands: ["npx demo-mcp"],
+        confidence: "medium",
+      },
+      verification: {
+        status: "self_reported",
+        notes: ["Initial self-reported metadata."],
+      },
+      community: {
+        maintainedBy: ["@co-maintainer"],
+        verifiedBy: [],
+        claimed: false,
+      },
+    },
+  });
+  const metadata = JSON.parse(sidecar.content);
+
+  assert.equal(sidecar.path, "data/server-metadata/github-owner-demo-mcp-12345678.json");
+  assert.equal(metadata.source.issue, 700);
+  assert.deepEqual(metadata.install, {
+    commands: ["npx demo-mcp"],
+    confidence: "medium",
+  });
+  assert.equal(metadata.verification.status, "verified");
+  assert.ok(metadata.verification.notes.some((note) => /Claimed by @owner in #761/.test(note)));
+  assert.ok(metadata.verification.notes.some((note) => /Requested profile metadata in #761/.test(note)));
+  assert.deepEqual(metadata.community, {
+    maintainedBy: ["@co-maintainer", "@owner"],
+    verifiedBy: ["TensorBlock"],
+    claimed: true,
+  });
+});
+
+test("finds catalog entries and builds actionable comments", () => {
+  const entry = findCatalogEntry([catalogEntry], catalogEntry.id);
+  assert.equal(entry, catalogEntry);
+
+  const comment = buildIssueComment({
+    issue: { number: 761 },
+    submission: parseClaimProfileIssue(issueBody),
+    pullRequest: {
+      html_url: "https://github.com/TensorBlock/awesome-mcp-servers/pull/761",
+    },
+  });
+
+  assert.match(comment, /tensorblock-mcp-claim-profile-pr:v1/);
+  assert.match(comment, /draft metadata PR/);
+  assert.match(comment, /github-owner-demo-mcp-12345678/);
+});

--- a/.github/scripts/triage-issue.mjs
+++ b/.github/scripts/triage-issue.mjs
@@ -146,7 +146,8 @@ export function buildTriageComment(issue) {
       "",
       "What happens next:",
       "- We will verify the maintainer relationship using the repo, package, organization, or docs proof you provided.",
-      "- After verification, the profile can show maintainer and claim metadata in the index.",
+      "- If the profile id and project URL match the index, automation will draft a metadata PR for maintainer review.",
+      "- After that PR is verified, merged, and deployed, the profile can show maintainer and claim metadata in the index.",
       "- If the profile also needs install/auth/docs updates, include them here or open a metadata PR.",
       "",
       describeCapturedFields(body, [

--- a/.github/workflows/claim-profile-pr.yml
+++ b/.github/workflows/claim-profile-pr.yml
@@ -1,0 +1,46 @@
+name: MCP Claim Profile Draft PR
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - reopened
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: mcp-claim-profile-pr-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  draft-pr:
+    name: Draft metadata PR from profile claim
+    if: contains(github.event.issue.labels.*.name, 'claim-profile') || startsWith(github.event.issue.title, 'Claim MCP profile:')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate latest catalog
+        run: npm run catalog:build
+
+      - name: Create or update draft claim PR
+        run: node .github/scripts/create-claim-profile-pr.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.MCP_AUTOMATION_TOKEN || github.token }}

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you maintain an MCP server, the index can give your project a public profile,
 2. Include install, transport, auth, supported clients, docs, license, endpoint, and tool details when you have them.
 3. After merge, the follow-up comment gives you the public profile URL, API profile URL, install-config links, and badge markdown.
 4. Add the TensorBlock MCP Index badge to your project README so users can jump back to the indexed profile.
-5. Claim your profile or send metadata fixes through the [claim profile](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=claim-profile.yml) and [metadata improvement](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=improve-metadata.yml) forms.
+5. Claim your profile or send metadata fixes through the [claim profile](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=claim-profile.yml) and [metadata improvement](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=improve-metadata.yml) forms. Valid profile claims generate a metadata PR; once reviewed, merged, and deployed, the public profile shows the maintainer and verification status.
 
 ## Coverage
 

--- a/packages/catalog-builder/src/buildCatalog.ts
+++ b/packages/catalog-builder/src/buildCatalog.ts
@@ -242,6 +242,19 @@ function applyMetadataOverride(
       : entry.auth,
     clients: nonEmptyArray(metadata.clients) ?? entry.clients,
     license: nonEmptyString(metadata.license) ?? entry.license,
+    verification: metadata.verification
+      ? {
+          status: metadata.verification.status ?? entry.verification.status,
+          notes: nonEmptyArray(metadata.verification.notes) ?? entry.verification.notes,
+        }
+      : entry.verification,
+    community: metadata.community
+      ? {
+          maintainedBy: nonEmptyArray(metadata.community.maintainedBy) ?? entry.community.maintainedBy,
+          verifiedBy: nonEmptyArray(metadata.community.verifiedBy) ?? entry.community.verifiedBy,
+          claimed: metadata.community.claimed ?? entry.community.claimed,
+        }
+      : entry.community,
   };
 }
 

--- a/packages/catalog-builder/src/types.ts
+++ b/packages/catalog-builder/src/types.ts
@@ -67,6 +67,8 @@ export interface CatalogMetadataOverride {
   auth?: Partial<CatalogEntry["auth"]>;
   clients?: string[];
   license?: string;
+  verification?: Partial<CatalogEntry["verification"]>;
+  community?: Partial<CatalogEntry["community"]>;
 }
 
 export interface ParsedMarkdownEntry {

--- a/packages/catalog-builder/test/buildCatalog.test.ts
+++ b/packages/catalog-builder/test/buildCatalog.test.ts
@@ -243,6 +243,15 @@ describe("buildCatalogFromMarkdown", () => {
           },
           clients: ["Claude Desktop", "Cursor"],
           license: "MIT",
+          verification: {
+            status: "verified",
+            notes: ["Maintainer relationship verified in #42."],
+          },
+          community: {
+            maintainedBy: ["@owner"],
+            verifiedBy: ["TensorBlock"],
+            claimed: true,
+          },
         },
       ],
     ]));
@@ -260,6 +269,15 @@ describe("buildCatalogFromMarkdown", () => {
     });
     expect(entry?.clients).toEqual(["Claude Desktop", "Cursor"]);
     expect(entry?.license).toBe("MIT");
+    expect(entry?.verification).toEqual({
+      status: "verified",
+      notes: ["Maintainer relationship verified in #42."],
+    });
+    expect(entry?.community).toEqual({
+      maintainedBy: ["@owner"],
+      verifiedBy: ["TensorBlock"],
+      claimed: true,
+    });
   });
 
   it("builds entries that validate against the catalog schema", () => {

--- a/packages/registry-api/src/profilePage.ts
+++ b/packages/registry-api/src/profilePage.ts
@@ -10,6 +10,10 @@ export const renderServerProfilePage = (entry: CatalogEntry): string => {
   const title = `${entry.name} - TensorBlock MCP Index`;
   const profileUrl = webProfileUrl(entry.id);
   const readmeBadge = badgeMarkdown(entry, profileUrl);
+  const maintainerActions = renderMaintainerActions(entry);
+  const maintainerIntro = entry.community.claimed
+    ? "This profile has been claimed by a verified project maintainer. Keep metadata current when install, auth, docs, license, or tool details change."
+    : "Use this profile as the public install and metadata page for your MCP server. Claim the profile, add the badge to your README, and send metadata fixes when install or auth details change.";
   const installCommands = entry.install.commands.length > 0
     ? entry.install.commands.map((command) => `<code>${escapeHtml(command)}</code>`).join("")
     : "<p>No install command has been indexed yet.</p>";
@@ -103,6 +107,11 @@ export const renderServerProfilePage = (entry: CatalogEntry): string => {
       font-weight: 650;
       padding: 5px 10px;
       white-space: nowrap;
+    }
+    .badge.claimed {
+      background: #eaf8ef;
+      border-color: #c9ecd4;
+      color: #17663a;
     }
     section {
       background: var(--panel);
@@ -224,6 +233,7 @@ export const renderServerProfilePage = (entry: CatalogEntry): string => {
         <span class="badge">Install confidence: ${escapeHtml(entry.install.confidence)}</span>
         <span class="badge">Auth: ${escapeHtml(entry.auth.type)}</span>
         <span class="badge">Transport: ${escapeHtml(entry.transport.join(", "))}</span>
+        ${entry.community.claimed ? '<span class="badge claimed">Claimed profile</span>' : ""}
       </div>
     </header>
 
@@ -242,13 +252,9 @@ export const renderServerProfilePage = (entry: CatalogEntry): string => {
 
     <section class="maintainer-actions">
       <h2>For Maintainers</h2>
-      <p class="helper">Use this profile as the public install and metadata page for your MCP server. Claim the profile, add the badge to your README, and send metadata fixes when install or auth details change.</p>
+      <p class="helper">${escapeHtml(maintainerIntro)}</p>
       <div class="links">
-        <a class="button primary" href="${escapeAttribute(issueFormUrl("claim-profile.yml", `Claim MCP profile: ${entry.name}`))}">Claim profile</a>
-        <a class="button" href="${escapeAttribute(issueFormUrl("improve-metadata.yml", `Improve metadata: ${entry.name}`))}">Improve metadata</a>
-        <a class="button" href="${escapeAttribute(issueFormUrl("report-broken-entry.yml", `Report broken MCP entry: ${entry.name}`))}">Report issue</a>
-        <a class="button" href="${escapeAttribute(issueFormUrl("request-client-config.yml", `Request client config support: ${entry.name}`))}">Request client config</a>
-        <a class="button" href="${escapeAttribute(DISCORD_URL)}">Join Discord</a>
+        ${maintainerActions}
       </div>
       <h3>README badge</h3>
       <pre><code id="readme-badge">${escapeHtml(readmeBadge)}</code></pre>
@@ -286,8 +292,14 @@ export const renderServerProfilePage = (entry: CatalogEntry): string => {
         <dd>${escapeHtml(entry.license)}</dd>
         <dt>Verification</dt>
         <dd>${escapeHtml(entry.verification.status)}</dd>
+        <dt>Verification notes</dt>
+        <dd>${renderInlineValues(entry.verification.notes, "None indexed")}</dd>
         <dt>Claimed</dt>
         <dd>${entry.community.claimed ? "Yes" : "No"}</dd>
+        <dt>Maintainers</dt>
+        <dd>${renderInlineValues(entry.community.maintainedBy, "None indexed")}</dd>
+        <dt>Verified by</dt>
+        <dd>${renderInlineValues(entry.community.verifiedBy, "None indexed")}</dd>
         <dt>Source</dt>
         <dd>${sourceLink}</dd>
       </dl>
@@ -327,6 +339,26 @@ const optionalLink = (label: string, href: string | null | undefined): string =>
 
 const githubSourceUrl = (path: string): string =>
   `https://github.com/TensorBlock/awesome-mcp-servers/blob/main/${encodeURIComponent(path).replace(/%2F/g, "/")}`;
+
+const renderMaintainerActions = (entry: CatalogEntry): string => {
+  const claimButton = entry.community.claimed
+    ? ""
+    : `<a class="button primary" href="${escapeAttribute(issueFormUrl("claim-profile.yml", `Claim MCP profile: ${entry.name}`))}">Claim profile</a>`;
+  const improveClass = entry.community.claimed ? "button primary" : "button";
+
+  return [
+    claimButton,
+    `<a class="${improveClass}" href="${escapeAttribute(issueFormUrl("improve-metadata.yml", `Improve metadata: ${entry.name}`))}">Improve metadata</a>`,
+    `<a class="button" href="${escapeAttribute(issueFormUrl("report-broken-entry.yml", `Report broken MCP entry: ${entry.name}`))}">Report issue</a>`,
+    `<a class="button" href="${escapeAttribute(issueFormUrl("request-client-config.yml", `Request client config support: ${entry.name}`))}">Request client config</a>`,
+    `<a class="button" href="${escapeAttribute(DISCORD_URL)}">Join Discord</a>`,
+  ].filter(Boolean).join("\n        ");
+};
+
+const renderInlineValues = (values: string[], fallback: string): string =>
+  values.length > 0
+    ? values.map((value) => `<code>${escapeHtml(value)}</code>`).join("")
+    : `<span>${escapeHtml(fallback)}</span>`;
 
 const issueFormUrl = (template: string, title: string): string => {
   const params = new URLSearchParams({

--- a/packages/registry-api/test/profilePage.test.ts
+++ b/packages/registry-api/test/profilePage.test.ts
@@ -79,4 +79,29 @@ describe("renderServerProfilePage", () => {
     expect(html).toContain("https://mcp-index.tensorblock.co/v1/servers/unsafe-demo/badge.svg");
     expect(html).toContain("https://tensorblock.co/mcp/servers/unsafe-demo");
   });
+
+  it("renders claimed profile community metadata", () => {
+    const html = renderServerProfilePage({
+      ...entry,
+      verification: {
+        status: "verified",
+        notes: ["Maintainer relationship verified in #761."],
+      },
+      community: {
+        maintainedBy: ["@owner"],
+        verifiedBy: ["TensorBlock"],
+        claimed: true,
+      },
+    });
+
+    expect(html).toContain("Claimed profile");
+    expect(html).toContain("verified project maintainer");
+    expect(html).toContain("<dd>Yes</dd>");
+    expect(html).toContain("<code>@owner</code>");
+    expect(html).toContain("<code>TensorBlock</code>");
+    expect(html).toContain("<code>Maintainer relationship verified in #761.</code>");
+    expect(html).not.toContain(">Claim profile</a>");
+    expect(html).toContain("button primary");
+    expect(html).toContain(">Improve metadata</a>");
+  });
 });

--- a/schemas/server-metadata.schema.json
+++ b/schemas/server-metadata.schema.json
@@ -62,7 +62,33 @@
       "type": "array",
       "items": { "type": "string", "minLength": 1 }
     },
-    "license": { "type": "string", "minLength": 1 }
+    "license": { "type": "string", "minLength": 1 },
+    "verification": {
+      "type": "object",
+      "properties": {
+        "status": { "enum": ["unknown", "self_reported", "partial", "verified", "failing"] },
+        "notes": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      },
+      "additionalProperties": false
+    },
+    "community": {
+      "type": "object",
+      "properties": {
+        "maintainedBy": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "verifiedBy": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "claimed": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    }
   },
   "additionalProperties": false
 }


### PR DESCRIPTION
## Summary
- allow metadata sidecars to set profile verification and community claim fields
- add a claim-profile issue workflow that generates draft metadata PRs for verified maintainer claims
- make claimed profiles display claimed status, maintainers, verification notes, and verified-by metadata
- update claim form, triage copy, and README maintainer quick start for the new flow

## Validation
- `node --test .github/scripts/create-claim-profile-pr.test.mjs .github/scripts/triage-issue.test.mjs .github/scripts/create-add-server-pr.test.mjs .github/scripts/comment-merged-pr.test.mjs`
- `npm test -- packages/catalog-builder/test/buildCatalog.test.ts packages/catalog-builder/test/schema.test.ts packages/catalog-builder/test/metadata.test.ts packages/registry-api/test/profilePage.test.ts packages/registry-api/test/server.test.ts`
- `npm test`
- `npm run typecheck`
- `npm run build`
- `npm run catalog:build` (7746 entries, 9 existing catalog errors)
