### PR TITLE
Add metadata improvement automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/improve-metadata.yml
+++ b/.github/ISSUE_TEMPLATE/improve-metadata.yml
@@ -38,11 +38,16 @@ body:
     id: changes
     attributes:
       label: Correct metadata
-      description: Include the exact values we should index and links to source docs when possible.
+      description: Include exact values using labels like Install, Transport, Auth, Docs URL, License, Tools, Tool count, or Verification.
       placeholder: |
+        Description: Short profile description to show in search results.
         Transport: stdio
         Auth: api-key, requires EXAMPLE_API_KEY
-        Install: npx -y example-mcp
+        Install: `npx -y example-mcp`
+        Docs URL: https://docs.example.com/example-mcp
+        License: MIT
+        Tools: search, fetch_profile
+        Tool count: 2
     validations:
       required: true
   - type: textarea

--- a/.github/scripts/create-improve-metadata-pr.mjs
+++ b/.github/scripts/create-improve-metadata-pr.mjs
@@ -1,0 +1,776 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { CATEGORY_TO_DOCS_PATH } from "./create-add-server-pr.mjs";
+import { extractField, serverIdFromProfileReference } from "./triage-issue.mjs";
+
+const API_BASE = "https://api.github.com";
+const COMMENT_MARKER = "<!-- tensorblock-mcp-improve-metadata-pr:v1 -->";
+const DEFAULT_BASE_BRANCH = "main";
+const DEFAULT_SCHEMA = "../../schemas/server-metadata.schema.json";
+
+const FIELD_ALIASES = new Map([
+  ["description", "description"],
+  ["summary", "description"],
+  ["category", "category"],
+  ["install", "install"],
+  ["install command", "install"],
+  ["install commands", "install"],
+  ["command", "install"],
+  ["commands", "install"],
+  ["environment variables", "env"],
+  ["environment variable", "env"],
+  ["env", "env"],
+  ["transport", "transport"],
+  ["auth", "auth"],
+  ["authentication", "auth"],
+  ["auth requirements", "auth"],
+  ["supported clients", "clients"],
+  ["clients", "clients"],
+  ["tool names or tool count", "tools"],
+  ["tool names", "tools"],
+  ["tools", "tools"],
+  ["tool count", "tool_count"],
+  ["docs url", "docs"],
+  ["docs", "docs"],
+  ["documentation", "docs"],
+  ["endpoint", "endpoint"],
+  ["mcp endpoint", "endpoint"],
+  ["license", "license"],
+  ["health or verification status", "verification"],
+  ["verification", "verification"],
+  ["verification status", "verification"],
+  ["health", "verification"],
+  ["status", "verification"],
+]);
+
+export function parseImproveMetadataIssue(body) {
+  const profileReference = normalizeField(extractField(body, "TensorBlock profile URL or server id"));
+
+  return {
+    profileReference,
+    serverId: serverIdFromProfileReference(profileReference),
+    projectUrl: normalizeField(extractField(body, "Project URL")),
+    fields: parseCheckedFields(extractField(body, "Metadata to update")),
+    changes: normalizeField(extractField(body, "Correct metadata")),
+    source: normalizeField(extractField(body, "Source or proof")),
+  };
+}
+
+export function validateMetadataSubmission(submission, entry, existingMetadata) {
+  const errors = [];
+
+  if (!submission.serverId) {
+    errors.push("A valid TensorBlock profile URL or server id is required.");
+  }
+
+  if (!entry) {
+    errors.push(`Indexed profile not found for server id "${submission.serverId || submission.profileReference}".`);
+  }
+
+  if (submission.projectUrl) {
+    if (!isValidHttpUrl(submission.projectUrl)) {
+      errors.push("Project URL must be a valid HTTP or HTTPS URL.");
+    } else if (entry && !projectUrlMatchesEntry(submission.projectUrl, entry, existingMetadata)) {
+      errors.push("Project URL must match the indexed profile source URL, repository, homepage, docs URL, or existing sidecar project URL.");
+    }
+  }
+
+  const patch = parseMetadataPatch(submission);
+  if (!hasStructuredPatch(patch)) {
+    errors.push("Correct metadata must include at least one recognizable field such as Description:, Install:, Transport:, Auth:, Docs URL:, License:, Tools:, or Verification:.");
+  }
+
+  if (patch.category && !CATEGORY_TO_DOCS_PATH[patch.category]) {
+    errors.push(`Category "${patch.category}" must match one of the existing MCP Index categories.`);
+  }
+
+  return errors;
+}
+
+export function buildImproveMetadataSidecar({ issue, submission, entry, existingMetadata = {} }) {
+  const patch = parseMetadataPatch(submission);
+  const source = {
+    ...(existingMetadata.source ?? {}),
+    issue: issue.number,
+    projectUrl: submission.projectUrl || existingMetadata.source?.projectUrl || entry.links.primary,
+  };
+  const metadata = {
+    "$schema": existingMetadata.$schema ?? DEFAULT_SCHEMA,
+    ...existingMetadata,
+    id: entry.id,
+    source,
+  };
+
+  if (patch.description) metadata.description = patch.description;
+  if (patch.category) metadata.category = patch.category;
+
+  if (patch.links) {
+    metadata.links = {
+      ...(existingMetadata.links ?? {}),
+      ...patch.links,
+    };
+  }
+
+  if (patch.install) {
+    metadata.install = {
+      ...(existingMetadata.install ?? {}),
+      ...patch.install,
+    };
+  }
+
+  if (patch.transport) metadata.transport = patch.transport;
+  if (patch.auth) metadata.auth = patch.auth;
+  if (patch.clients) metadata.clients = patch.clients;
+  if (patch.tools) {
+    metadata.tools = {
+      ...(existingMetadata.tools ?? {}),
+      ...patch.tools,
+    };
+  }
+  if (patch.license) metadata.license = patch.license;
+
+  metadata.verification = {
+    ...(existingMetadata.verification ?? {}),
+    ...(patch.verification ?? {}),
+    status: patch.verification?.status ?? existingMetadata.verification?.status ?? "self_reported",
+    notes: unique([
+      ...(existingMetadata.verification?.notes ?? []),
+      ...(patch.verification?.notes ?? []),
+      buildSourceNote(issue.number, submission),
+    ].filter(Boolean)),
+  };
+
+  return {
+    path: `data/server-metadata/${entry.id}.json`,
+    content: `${JSON.stringify(metadata, null, 2)}\n`,
+  };
+}
+
+export function findCatalogEntry(catalog, serverId) {
+  return catalog.find((entry) => entry.id === serverId) ?? null;
+}
+
+export function buildIssueComment({ issue, submission, pullRequest, errors }) {
+  if (errors?.length) {
+    return [
+      COMMENT_MARKER,
+      "I could not create an improve-metadata PR yet.",
+      "",
+      "What needs attention:",
+      ...errors.map((error) => `- ${error}`),
+      "",
+      "Update this issue with the corrected profile id and structured metadata fields. The automation will try again when the issue is edited.",
+    ].join("\n");
+  }
+
+  if (pullRequest?.blocked) {
+    return [
+      COMMENT_MARKER,
+      `Generated branch \`${pullRequest.branch}\` for this metadata update, but GitHub Actions could not create the pull request automatically.`,
+      "",
+      `Open the PR manually: ${pullRequest.compareUrl}`,
+    ].join("\n");
+  }
+
+  return [
+    COMMENT_MARKER,
+    `Created a draft metadata PR for this profile update: ${pullRequest.html_url}`,
+    "",
+    "A maintainer should verify the submitted source links before merging. Once merged and deployed, the public profile and API metadata will reflect the update.",
+    "",
+    `Updated profile id: \`${submission.serverId}\``,
+  ].join("\n");
+}
+
+export function buildPrBody({ issue, submission, entry, sidecar }) {
+  return [
+    "## Summary",
+    `- improve TensorBlock MCP metadata for \`${entry.id}\` / \`${entry.name}\``,
+    `- update structured sidecar \`${sidecar.path}\` from community issue #${issue.number}`,
+    "- preserve existing sidecar metadata unless this issue explicitly provides a replacement",
+    "",
+    "## Submitted fields",
+    submission.fields.length ? submission.fields.map((field) => `- ${field}`).join("\n") : "- Not specified",
+    "",
+    "## Correct metadata",
+    "",
+    "```text",
+    submission.changes,
+    "```",
+    ...(submission.source
+      ? [
+          "",
+          "## Source or proof",
+          "",
+          "```text",
+          submission.source,
+          "```",
+        ]
+      : []),
+    "",
+    "## Generated metadata sidecar",
+    "",
+    `\`${sidecar.path}\``,
+    "",
+    "```json",
+    sidecar.content.trimEnd(),
+    "```",
+    "",
+    issue.html_url ?? `#${issue.number}`,
+    "",
+    `Closes #${issue.number}`,
+  ].join("\n");
+}
+
+function parseMetadataPatch(submission) {
+  const values = labeledValues(submission.changes);
+
+  if (values.size === 0 && submission.fields.length === 1) {
+    const key = canonicalFieldName(submission.fields[0]);
+    if (key) {
+      values.set(key, submission.changes);
+    }
+  }
+
+  const patch = {};
+  const description = compactText(values.get("description") ?? "", 520);
+  const category = normalizeCategory(values.get("category") ?? "");
+  const installValue = values.get("install") ?? "";
+  const envValue = values.get("env") ?? "";
+  const docsValue = values.get("docs") ?? "";
+  const endpointValue = values.get("endpoint") ?? "";
+  const transport = parseTransportMetadata(values.get("transport") ?? installValue);
+  const auth = buildAuthMetadata(values.get("auth") ?? "");
+  const clients = parseListMetadata(values.get("clients") ?? "");
+  const tools = buildToolsMetadata(values.get("tools") ?? "", values.get("tool_count") ?? "");
+  const license = normalizeMetadataScalar(values.get("license") ?? "");
+  const verification = buildVerificationMetadata(values.get("verification") ?? "");
+  const install = buildInstallMetadata(installValue, envValue);
+  const links = definedObject({
+    docs: extractFirstUrl(docsValue),
+    endpoint: extractFirstUrl(endpointValue),
+  });
+
+  if (description) patch.description = description;
+  if (category) patch.category = category;
+  if (Object.keys(links).length > 0) patch.links = links;
+  if (install) patch.install = install;
+  if (transport) patch.transport = transport;
+  if (auth) patch.auth = auth;
+  if (clients) patch.clients = clients;
+  if (tools) patch.tools = tools;
+  if (license) patch.license = license;
+  if (verification) patch.verification = verification;
+
+  return patch;
+}
+
+function hasStructuredPatch(patch) {
+  return [
+    "description",
+    "category",
+    "links",
+    "install",
+    "transport",
+    "auth",
+    "clients",
+    "tools",
+    "license",
+    "verification",
+  ].some((key) => patch[key] !== undefined);
+}
+
+function labeledValues(changes) {
+  const values = new Map();
+  let activeKey = "";
+
+  for (const rawLine of changes.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) {
+      continue;
+    }
+
+    const match = line.match(/^([A-Za-z][A-Za-z /_-]{1,80}):\s*(.*)$/);
+    const key = match ? canonicalFieldName(match[1]) : "";
+
+    if (key) {
+      activeKey = key;
+      appendValue(values, key, match[2]);
+      continue;
+    }
+
+    if (activeKey) {
+      appendValue(values, activeKey, line);
+    }
+  }
+
+  return values;
+}
+
+function appendValue(values, key, value) {
+  const cleaned = cleanMetadataLine(value);
+  if (!cleaned) {
+    return;
+  }
+
+  const previous = values.get(key);
+  values.set(key, previous ? `${previous}\n${cleaned}` : cleaned);
+}
+
+function canonicalFieldName(value) {
+  return FIELD_ALIASES.get(value.toLowerCase().trim()) ?? "";
+}
+
+function parseCheckedFields(value) {
+  return value
+    .split(/\r?\n/)
+    .map((line) => line.match(/-\s+\[[xX]\]\s+(.+)/)?.[1]?.trim() ?? "")
+    .filter(Boolean);
+}
+
+function buildInstallMetadata(installValue, envValue) {
+  const commands = parseInstallCommands(installValue);
+  const env = unique([
+    ...parseListMetadata(envValue) ?? [],
+    ...extractEnvVars(`${installValue}\n${envValue}`),
+  ]);
+
+  if (commands.length === 0 && env.length === 0) {
+    return null;
+  }
+
+  return {
+    commands,
+    env,
+    confidence: commands.length > 0 ? "medium" : "low",
+  };
+}
+
+function parseInstallCommands(value) {
+  const backtickCommands = Array.from(value.matchAll(/`([^`]+)`/g))
+    .map((match) => cleanMetadataLine(match[1]))
+    .filter(isLikelyLaunchCommand);
+
+  if (backtickCommands.length > 0) {
+    return unique(backtickCommands);
+  }
+
+  return unique(
+    value
+      .split(/\r?\n/)
+      .map(cleanMetadataLine)
+      .filter(isLikelyLaunchCommand),
+  );
+}
+
+function parseTransportMetadata(value) {
+  const lower = value.toLowerCase();
+  const transports = [];
+
+  if (/\bstdio\b/.test(lower)) transports.push("stdio");
+  if (/\bsse\b/.test(lower)) transports.push("sse");
+  if (/\bstreamable\b/.test(lower) || /\bhttp\b/.test(lower)) transports.push("streamable-http");
+  if (/\bunknown\b/.test(lower) && transports.length === 0) transports.push("unknown");
+
+  return transports.length > 0 ? unique(transports) : null;
+}
+
+function buildAuthMetadata(value) {
+  if (!value) {
+    return null;
+  }
+
+  const lower = value.toLowerCase();
+  let type = "unknown";
+
+  if (/\b(no auth|none|not required|no authentication)\b/.test(lower)) type = "none";
+  else if (lower.includes("oauth")) type = "oauth";
+  else if (lower.includes("api key") || lower.includes("api-key") || /\b[A-Z][A-Z0-9_]*API_KEY\b/.test(value)) type = "api-key";
+  else if (lower.includes("bearer")) type = "bearer";
+
+  return {
+    type,
+    notes: type === "none" ? [] : [compactText(value, 240)],
+  };
+}
+
+function buildToolsMetadata(toolsValue, countValue) {
+  const combined = [toolsValue, countValue].filter(Boolean).join("\n");
+  if (!combined) {
+    return null;
+  }
+
+  const explicitCount = countValue.match(/\d+/)?.[0];
+  const inlineCount = combined.match(/\b(\d+)\s+(?:mcp\s+)?tools?\b/i)?.[1];
+  const count = explicitCount ?? inlineCount;
+  const names = parseListMetadata(toolsValue)
+    ?.filter((item) => !/^\d+\s*(?:mcp\s+)?tools?$/i.test(item))
+    ?? [];
+
+  return definedObject({
+    count: count === undefined ? undefined : Number(count),
+    names,
+    source: "self_reported",
+  });
+}
+
+function buildVerificationMetadata(value) {
+  if (!value) {
+    return null;
+  }
+
+  const lower = value.toLowerCase().replace(/[-\s]+/g, "_");
+  const status = ["verified", "partial", "failing", "unknown", "self_reported"].find((candidate) => lower.includes(candidate));
+
+  return {
+    status: status ?? "self_reported",
+    notes: status && lower === status ? [] : [compactText(value, 240)],
+  };
+}
+
+function normalizeCategory(value) {
+  const normalized = value.trim();
+  if (!normalized) {
+    return "";
+  }
+
+  return Object.keys(CATEGORY_TO_DOCS_PATH).find((category) => category.toLowerCase() === normalized.toLowerCase()) ?? normalized;
+}
+
+function parseListMetadata(value) {
+  const values = value
+    .split(/[,;\n]/)
+    .map(cleanMetadataLine)
+    .filter(Boolean);
+
+  return values.length > 0 ? unique(values) : null;
+}
+
+function normalizeMetadataScalar(value) {
+  const normalized = compactText(value, 120);
+  return normalized || null;
+}
+
+function extractEnvVars(value) {
+  const matches = value.match(/\b[A-Z][A-Z0-9_]{2,}\b/g) ?? [];
+  return unique(matches.filter((match) => /(KEY|TOKEN|SECRET|PASSWORD|ENDPOINT|URL)$/.test(match)));
+}
+
+function extractFirstUrl(value) {
+  const raw = value.match(/https?:\/\/[^\s`,)\]]+/i)?.[0] ?? "";
+  return raw ? stripUrlPunctuation(raw) : null;
+}
+
+function cleanMetadataLine(value) {
+  return value
+    .trim()
+    .replace(/^[-*]\s+/, "")
+    .replace(/^```[a-z]*|```$/gi, "")
+    .replace(/^`+|`+$/g, "")
+    .trim();
+}
+
+function isLikelyLaunchCommand(value) {
+  return /^(?:npx|uvx|npm|docker|node|python3?|pip|[a-z0-9._-]*mcp)\b/i.test(value);
+}
+
+function buildSourceNote(issueNumber, submission) {
+  const source = submission.source ? ` Source: ${compactText(submission.source, 220)}` : "";
+  return `Metadata updated from issue #${issueNumber}.${source}`;
+}
+
+function loadExistingMetadata(serverId) {
+  const metadataPath = `data/server-metadata/${serverId}.json`;
+  if (!fs.existsSync(metadataPath)) {
+    return {};
+  }
+
+  return JSON.parse(fs.readFileSync(metadataPath, "utf8"));
+}
+
+function writeSidecar(sidecar) {
+  fs.mkdirSync(path.dirname(sidecar.path), { recursive: true });
+  fs.writeFileSync(sidecar.path, sidecar.content);
+}
+
+function normalizeField(value) {
+  const normalized = value
+    .replace(/<!--[\s\S]*?-->/g, "")
+    .trim();
+
+  if (!normalized || normalized === "_No response_") {
+    return "";
+  }
+
+  return normalized;
+}
+
+function isValidHttpUrl(value) {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function projectUrlMatchesEntry(projectUrl, entry, existingMetadata) {
+  const submitted = canonicalizeUrl(projectUrl);
+  const candidates = [
+    entry.links.primary,
+    entry.links.repo,
+    entry.links.homepage,
+    entry.links.docs,
+    existingMetadata?.source?.projectUrl,
+  ].filter(Boolean);
+
+  return candidates.some((candidate) => canonicalizeUrl(candidate) === submitted);
+}
+
+function canonicalizeUrl(value) {
+  try {
+    const parsed = new URL(value.trim());
+    parsed.hash = "";
+    parsed.protocol = parsed.protocol.toLowerCase();
+    parsed.hostname = parsed.hostname.toLowerCase().replace(/^www\./, "");
+
+    if ((parsed.protocol === "https:" && parsed.port === "443") || (parsed.protocol === "http:" && parsed.port === "80")) {
+      parsed.port = "";
+    }
+
+    parsed.pathname = parsed.pathname.replace(/\.git$/i, "").replace(/\/+$/g, "");
+    return parsed.toString().replace(/\/$/g, "");
+  } catch {
+    return value.trim();
+  }
+}
+
+function compactText(value, maxLength) {
+  const compacted = value.replace(/\s+/g, " ").trim();
+  if (compacted.length <= maxLength) {
+    return compacted;
+  }
+
+  const slice = compacted.slice(0, Math.max(0, maxLength - 3)).trimEnd();
+  const lastSpace = slice.lastIndexOf(" ");
+  const wordBoundary = lastSpace > maxLength * 0.6 ? slice.slice(0, lastSpace) : slice;
+  return `${wordBoundary.trimEnd()}...`;
+}
+
+function stripUrlPunctuation(url) {
+  return url.replace(/[.;:!?"']+$/, "");
+}
+
+function definedObject(entries) {
+  return Object.fromEntries(Object.entries(entries).filter(([, value]) => value !== null && value !== undefined && value !== ""));
+}
+
+function unique(values) {
+  return Array.from(new Set(values));
+}
+
+async function main() {
+  const token = process.env.GITHUB_TOKEN;
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  const repository = process.env.GITHUB_REPOSITORY;
+
+  if (!token || !eventPath || !repository) {
+    throw new Error("GITHUB_TOKEN, GITHUB_EVENT_PATH, and GITHUB_REPOSITORY are required.");
+  }
+
+  const event = JSON.parse(fs.readFileSync(eventPath, "utf8"));
+  const issue = event.issue;
+  if (!issue) {
+    console.log("No issue payload found; skipping.");
+    return;
+  }
+
+  const [owner, repo] = repository.split("/");
+  const request = createGitHubRequest({ token, owner, repo });
+  const submission = parseImproveMetadataIssue(issue.body ?? "");
+  const catalog = JSON.parse(fs.readFileSync("data/catalog.json", "utf8"));
+  const entry = findCatalogEntry(catalog, submission.serverId);
+  const existingMetadata = entry ? loadExistingMetadata(entry.id) : {};
+  const errors = validateMetadataSubmission(submission, entry, existingMetadata);
+
+  if (errors.length > 0) {
+    await upsertIssueComment(request, issue.number, buildIssueComment({ issue, submission, errors }));
+    console.log(`Issue #${issue.number} cannot be converted to a metadata PR: ${errors.join(" ")}`);
+    return;
+  }
+
+  const sidecar = buildImproveMetadataSidecar({
+    issue,
+    submission,
+    entry,
+    existingMetadata,
+  });
+  const branch = `mcp/improve-metadata-issue-${issue.number}`;
+  const title = `Improve ${entry.name} MCP metadata`;
+  const body = buildPrBody({ issue, submission, entry, sidecar });
+
+  run("git", ["config", "user.name", "github-actions[bot]"]);
+  run("git", ["config", "user.email", "41898282+github-actions[bot]@users.noreply.github.com"]);
+  run("git", ["fetch", "origin", DEFAULT_BASE_BRANCH]);
+  run("git", ["checkout", "-B", branch, `origin/${DEFAULT_BASE_BRANCH}`]);
+
+  writeSidecar(sidecar);
+  run("git", ["add", sidecar.path]);
+
+  if (!hasStagedChanges()) {
+    console.log(`No metadata changes generated for issue #${issue.number}.`);
+    return;
+  }
+
+  run("git", ["commit", "-m", title]);
+  run("git", ["push", "--force-with-lease", "origin", `HEAD:${branch}`]);
+
+  let pullRequest;
+  try {
+    pullRequest = await createOrUpdatePullRequest(request, {
+      owner,
+      branch,
+      title,
+      body,
+    });
+  } catch (error) {
+    if (!isPullRequestCreationBlocked(error)) {
+      throw error;
+    }
+
+    const compareUrl = `https://github.com/${owner}/${repo}/compare/${DEFAULT_BASE_BRANCH}...${branch}?expand=1`;
+    await upsertIssueComment(
+      request,
+      issue.number,
+      buildIssueComment({
+        issue,
+        submission,
+        pullRequest: {
+          blocked: true,
+          branch,
+          compareUrl,
+        },
+      }),
+    );
+    console.log(`Generated branch ${branch} for issue #${issue.number}, but Actions cannot create pull requests.`);
+    console.log(formatGitHubError(error));
+    return;
+  }
+
+  await upsertIssueComment(request, issue.number, buildIssueComment({ issue, submission, pullRequest }));
+  console.log(`Created or updated draft PR ${pullRequest.html_url} for issue #${issue.number}.`);
+}
+
+function run(command, args) {
+  execFileSync(command, args, { stdio: "inherit" });
+}
+
+function hasStagedChanges() {
+  try {
+    execFileSync("git", ["diff", "--cached", "--quiet"], { stdio: "ignore" });
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+function createGitHubRequest({ token, owner, repo }) {
+  return async function request(pathname, options = {}) {
+    const response = await fetch(`${API_BASE}/repos/${owner}/${repo}${pathname}`, {
+      method: options.method ?? "GET",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      body: options.body ? JSON.stringify(options.body) : undefined,
+    });
+
+    const text = await response.text();
+    const data = text ? JSON.parse(text) : null;
+
+    if (!response.ok) {
+      const error = new Error(`GitHub API ${options.method ?? "GET"} ${pathname} failed: ${response.status}`);
+      error.status = response.status;
+      error.data = data;
+      throw error;
+    }
+
+    return data;
+  };
+}
+
+async function createOrUpdatePullRequest(request, { owner, branch, title, body }) {
+  const query = new URLSearchParams({
+    head: `${owner}:${branch}`,
+    state: "open",
+  });
+  const existingPulls = await request(`/pulls?${query.toString()}`);
+  const existingPull = existingPulls[0];
+
+  if (existingPull) {
+    return request(`/pulls/${existingPull.number}`, {
+      method: "PATCH",
+      body: { title, body },
+    });
+  }
+
+  return request("/pulls", {
+    method: "POST",
+    body: {
+      title,
+      body,
+      head: branch,
+      base: DEFAULT_BASE_BRANCH,
+      draft: true,
+      maintainer_can_modify: true,
+    },
+  });
+}
+
+function isPullRequestCreationBlocked(error) {
+  if (error?.status !== 403) {
+    return false;
+  }
+
+  const message = `${error.data?.message ?? ""} ${JSON.stringify(error.data?.errors ?? [])}`;
+  return /not permitted to create|Resource not accessible by integration|pull request/i.test(message);
+}
+
+function formatGitHubError(error) {
+  if (!error?.data) {
+    return error?.message ?? String(error);
+  }
+
+  return `${error.message}: ${JSON.stringify(error.data)}`;
+}
+
+async function upsertIssueComment(request, issueNumber, body) {
+  const comments = await request(`/issues/${issueNumber}/comments?per_page=100`);
+  const existing = comments.find((comment) => comment.body?.includes(COMMENT_MARKER));
+
+  if (existing) {
+    await request(`/issues/comments/${existing.id}`, {
+      method: "PATCH",
+      body: { body },
+    });
+    return;
+  }
+
+  await request(`/issues/${issueNumber}/comments`, {
+    method: "POST",
+    body: { body },
+  });
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/.github/scripts/create-improve-metadata-pr.test.mjs
+++ b/.github/scripts/create-improve-metadata-pr.test.mjs
@@ -1,0 +1,231 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildImproveMetadataSidecar,
+  buildIssueComment,
+  buildPrBody,
+  findCatalogEntry,
+  parseImproveMetadataIssue,
+  validateMetadataSubmission,
+} from "./create-improve-metadata-pr.mjs";
+
+const issueBody = [
+  "### TensorBlock profile URL or server id",
+  "",
+  "https://tensorblock.co/mcp/servers/github-owner-demo-mcp-12345678",
+  "",
+  "### Project URL",
+  "",
+  "https://github.com/owner/demo-mcp",
+  "",
+  "### Metadata to update",
+  "",
+  "- [x] Description",
+  "- [x] Install command",
+  "- [x] Environment variables",
+  "- [x] Transport",
+  "- [x] Auth requirements",
+  "- [x] Supported clients",
+  "- [x] Tool names or tool count",
+  "- [x] Docs URL",
+  "- [x] License",
+  "- [x] Health or verification status",
+  "",
+  "### Correct metadata",
+  "",
+  "Description: Demo MCP exposes production project telemetry to AI agents.",
+  "Install: `npx -y @owner/demo-mcp`",
+  "Environment variables: DEMO_API_KEY, DEMO_API_URL",
+  "Transport: stdio",
+  "Auth: api-key, requires DEMO_API_KEY",
+  "Supported clients: Claude Desktop, Cursor",
+  "Tools: inspect_project, summarize_incidents",
+  "Tool count: 2",
+  "Docs URL: https://docs.example.com/demo-mcp",
+  "License: MIT",
+  "Verification: verified",
+  "",
+  "### Source or proof",
+  "",
+  "README documents the install and auth fields: https://github.com/owner/demo-mcp#readme",
+].join("\n");
+
+const catalogEntry = {
+  id: "github-owner-demo-mcp-12345678",
+  name: "owner/demo-mcp",
+  description: "Old description.",
+  category: "Developer Productivity & Utilities",
+  links: {
+    primary: "https://github.com/owner/demo-mcp",
+    repo: "https://github.com/owner/demo-mcp",
+    homepage: null,
+    docs: null,
+    endpoint: null,
+  },
+  install: {
+    commands: ["npx old-demo-mcp"],
+    env: [],
+    confidence: "low",
+  },
+  transport: ["unknown"],
+  auth: {
+    type: "unknown",
+    notes: [],
+  },
+  clients: [],
+  tools: {
+    count: null,
+    names: [],
+    source: "unknown",
+  },
+  license: "unknown",
+  verification: {
+    status: "unknown",
+    notes: [],
+  },
+  community: {
+    maintainedBy: ["@existing"],
+    verifiedBy: [],
+    claimed: true,
+  },
+};
+
+test("parses improve-metadata issue fields and checked update types", () => {
+  assert.deepEqual(parseImproveMetadataIssue(issueBody), {
+    profileReference: "https://tensorblock.co/mcp/servers/github-owner-demo-mcp-12345678",
+    serverId: "github-owner-demo-mcp-12345678",
+    projectUrl: "https://github.com/owner/demo-mcp",
+    fields: [
+      "Description",
+      "Install command",
+      "Environment variables",
+      "Transport",
+      "Auth requirements",
+      "Supported clients",
+      "Tool names or tool count",
+      "Docs URL",
+      "License",
+      "Health or verification status",
+    ],
+    changes: [
+      "Description: Demo MCP exposes production project telemetry to AI agents.",
+      "Install: `npx -y @owner/demo-mcp`",
+      "Environment variables: DEMO_API_KEY, DEMO_API_URL",
+      "Transport: stdio",
+      "Auth: api-key, requires DEMO_API_KEY",
+      "Supported clients: Claude Desktop, Cursor",
+      "Tools: inspect_project, summarize_incidents",
+      "Tool count: 2",
+      "Docs URL: https://docs.example.com/demo-mcp",
+      "License: MIT",
+      "Verification: verified",
+    ].join("\n"),
+    source: "README documents the install and auth fields: https://github.com/owner/demo-mcp#readme",
+  });
+});
+
+test("validates metadata submissions against indexed project URLs and structured changes", () => {
+  const submission = parseImproveMetadataIssue(issueBody);
+
+  assert.deepEqual(validateMetadataSubmission(submission, catalogEntry, {}), []);
+  assert.deepEqual(
+    validateMetadataSubmission({
+      ...submission,
+      projectUrl: "https://example.com/not-the-project",
+    }, catalogEntry, {}),
+    ["Project URL must match the indexed profile source URL, repository, homepage, docs URL, or existing sidecar project URL."],
+  );
+  assert.deepEqual(
+    validateMetadataSubmission({
+      ...submission,
+      changes: "Please make this better.",
+      fields: [],
+    }, catalogEntry, {}),
+    ["Correct metadata must include at least one recognizable field such as Description:, Install:, Transport:, Auth:, Docs URL:, License:, Tools:, or Verification:."],
+  );
+});
+
+test("builds an improve-metadata sidecar while preserving existing metadata", () => {
+  const submission = parseImproveMetadataIssue(issueBody);
+  const sidecar = buildImproveMetadataSidecar({
+    issue: { number: 812 },
+    submission,
+    entry: catalogEntry,
+    existingMetadata: {
+      id: catalogEntry.id,
+      source: {
+        issue: 700,
+        projectUrl: "https://github.com/owner/demo-mcp",
+      },
+      community: {
+        maintainedBy: ["@existing"],
+        claimed: true,
+      },
+    },
+  });
+  const metadata = JSON.parse(sidecar.content);
+
+  assert.equal(sidecar.path, "data/server-metadata/github-owner-demo-mcp-12345678.json");
+  assert.equal(metadata.source.issue, 812);
+  assert.equal(metadata.source.projectUrl, "https://github.com/owner/demo-mcp");
+  assert.equal(metadata.description, "Demo MCP exposes production project telemetry to AI agents.");
+  assert.deepEqual(metadata.links, {
+    docs: "https://docs.example.com/demo-mcp",
+  });
+  assert.deepEqual(metadata.install, {
+    commands: ["npx -y @owner/demo-mcp"],
+    env: ["DEMO_API_KEY", "DEMO_API_URL"],
+    confidence: "medium",
+  });
+  assert.deepEqual(metadata.transport, ["stdio"]);
+  assert.deepEqual(metadata.auth, {
+    type: "api-key",
+    notes: ["api-key, requires DEMO_API_KEY"],
+  });
+  assert.deepEqual(metadata.clients, ["Claude Desktop", "Cursor"]);
+  assert.deepEqual(metadata.tools, {
+    count: 2,
+    names: ["inspect_project", "summarize_incidents"],
+    source: "self_reported",
+  });
+  assert.equal(metadata.license, "MIT");
+  assert.equal(metadata.verification.status, "verified");
+  assert.ok(metadata.verification.notes.some((note) => /Metadata updated from issue #812/.test(note)));
+  assert.deepEqual(metadata.community, {
+    maintainedBy: ["@existing"],
+    claimed: true,
+  });
+});
+
+test("finds catalog entries and builds actionable comments and PR body", () => {
+  const submission = parseImproveMetadataIssue(issueBody);
+  const entry = findCatalogEntry([catalogEntry], catalogEntry.id);
+  const sidecar = buildImproveMetadataSidecar({
+    issue: { number: 812 },
+    submission,
+    entry,
+    existingMetadata: {},
+  });
+  const comment = buildIssueComment({
+    issue: { number: 812 },
+    submission,
+    pullRequest: {
+      html_url: "https://github.com/TensorBlock/awesome-mcp-servers/pull/812",
+    },
+  });
+  const body = buildPrBody({
+    issue: { number: 812, html_url: "https://github.com/TensorBlock/awesome-mcp-servers/issues/812" },
+    submission,
+    entry,
+    sidecar,
+  });
+
+  assert.equal(entry, catalogEntry);
+  assert.match(comment, /tensorblock-mcp-improve-metadata-pr:v1/);
+  assert.match(comment, /draft metadata PR/);
+  assert.match(comment, /github-owner-demo-mcp-12345678/);
+  assert.match(body, /## Summary/);
+  assert.match(body, /Generated metadata sidecar/);
+  assert.match(body, /Closes #812/);
+});

--- a/.github/scripts/triage-issue.mjs
+++ b/.github/scripts/triage-issue.mjs
@@ -133,7 +133,8 @@ export function buildTriageComment(issue) {
       "",
       "What happens next:",
       "- We will verify the corrected values against the source links or project docs.",
-      "- Small metadata fixes are good first contributions; a direct PR against the matching `docs/*.md` category page is welcome.",
+      "- If the profile id matches the index and the corrected values are structured, automation will draft a metadata sidecar PR for maintainer review.",
+      "- Direct PRs against `docs/*.md` category pages or `data/server-metadata/*.json` sidecars are also welcome.",
       "- Better install, transport, auth, docs, license, and tool metadata improves search and install-config generation.",
       "",
       describeCapturedFields(body, [

--- a/.github/scripts/triage-issue.test.mjs
+++ b/.github/scripts/triage-issue.test.mjs
@@ -116,6 +116,7 @@ test("builds a deduplicated route-specific comment", () => {
 
   assert.match(comment, /tensorblock-mcp-issue-triage:v1:metadata/);
   assert.match(comment, /Thanks for improving MCP metadata/);
+  assert.match(comment, /automation will draft a metadata sidecar PR/);
   assert.match(comment, /https:\/\/github.com\/owner\/example/);
 });
 

--- a/.github/workflows/improve-metadata-pr.yml
+++ b/.github/workflows/improve-metadata-pr.yml
@@ -1,0 +1,46 @@
+name: MCP Improve Metadata Draft PR
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - reopened
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: mcp-improve-metadata-pr-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  draft-pr:
+    name: Draft metadata PR from metadata issue
+    if: contains(github.event.issue.labels.*.name, 'metadata') || startsWith(github.event.issue.title, 'Improve metadata:')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate latest catalog
+        run: npm run catalog:build
+
+      - name: Create or update draft metadata PR
+        run: node .github/scripts/create-improve-metadata-pr.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.MCP_AUTOMATION_TOKEN || github.token }}

--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ If you maintain an MCP server, the index can give your project a public profile,
 2. Include install, transport, auth, supported clients, docs, license, endpoint, and tool details when you have them.
 3. After merge, the follow-up comment gives you the public profile URL, API profile URL, install-config links, and badge markdown.
 4. Add the TensorBlock MCP Index badge to your project README so users can jump back to the indexed profile.
-5. Claim your profile or send metadata fixes through the [claim profile](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=claim-profile.yml) and [metadata improvement](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=improve-metadata.yml) forms. Valid profile claims generate a metadata PR; once reviewed, merged, and deployed, the public profile shows the maintainer and verification status.
+5. Claim your profile or send metadata fixes through the [claim profile](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=claim-profile.yml) and [metadata improvement](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=improve-metadata.yml) forms. Valid profile claims and structured metadata updates generate draft metadata PRs; once reviewed, merged, and deployed, the public profile shows the maintainer, install, auth, docs, license, tool, and verification metadata.
 
 ## Coverage
 
-This repo currently indexes **7,746 unique MCP server links** from the category docs. The README stays lightweight while the full directory lives in `docs/*.md`, `data/catalog.json`, and the registry MCP server.
+This repo currently indexes **7,747 unique MCP server links** from the category docs. The README stays lightweight while the full directory lives in `docs/*.md`, `data/catalog.json`, and the registry MCP server.
 
 ## How to Participate
 
@@ -46,7 +46,7 @@ Choose the path that matches what you want to do.
 
 - Share your public MCP profile from [https://www.tensorblock.co/mcp](https://www.tensorblock.co/mcp) so users can inspect metadata, install configs, source links, and badges without reading the raw markdown.
 - Add your server to the best category under [Browse by Category](#browse-by-category), or use the [Add MCP server issue form](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=add-mcp-server.yml).
-- Improve your existing entry with install command, transport, auth requirements, supported clients, docs URL, license, endpoint, and tool details. Use the [metadata issue form](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=improve-metadata.yml) if you do not want to open a PR directly.
+- Improve your existing entry with install command, transport, auth requirements, supported clients, docs URL, license, endpoint, and tool details. Use the [metadata issue form](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=improve-metadata.yml) if you do not want to open a PR directly; when the profile id and structured values are clear, automation drafts a metadata sidecar PR for maintainer review.
 - Claim your TensorBlock MCP profile with the [claim profile issue form](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=claim-profile.yml).
 - Add the TensorBlock MCP Index badge to your project README so users can jump from your repo to the indexed profile.
 
@@ -63,7 +63,7 @@ Choose the path that matches what you want to do.
 - Propose verification signals, health checks, ranking improvements, or better category rules.
 - Join the [TensorBlock Discord](https://discord.com/invite/Ej5NmeHFf2) to discuss roadmap work before opening a larger PR.
 
-Issue forms are routed automatically. When you submit a server, metadata update, profile claim, client config request, or broken-entry report, the repo adds the right triage labels and posts the next steps so contributors and maintainers can keep the workflow moving. Server submissions with a clear category can also generate a draft docs PR automatically.
+Issue forms are routed automatically. When you submit a server, metadata update, profile claim, client config request, or broken-entry report, the repo adds the right triage labels and posts the next steps so contributors and maintainers can keep the workflow moving. Server submissions with a clear category can generate draft docs PRs, and structured metadata updates or profile claims can generate draft metadata PRs.
 
 New server entries can be simple, but high-quality metadata makes the profile much more useful. The best entries answer:
 
@@ -150,7 +150,7 @@ To add a new MCP server:
 
 If you are not sure where the server belongs, use the [Add MCP server issue form](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=add-mcp-server.yml) and we can help route it. When the form has enough information, automation can draft a PR with both the markdown entry and a metadata sidecar.
 
-To improve an existing server, edit the same markdown bullet where the server is listed. Add missing install, transport, auth, docs, license, client, tool, endpoint, or maintainer information in the description when possible.
+To improve an existing server, edit the same markdown bullet where the server is listed, or use the [metadata issue form](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=improve-metadata.yml) with the TensorBlock profile id and structured values such as `Install:`, `Transport:`, `Auth:`, `Docs URL:`, `License:`, and `Tools:`. Clear metadata issues can generate a draft sidecar PR automatically.
 
 `data/server-metadata/*.json` files are source metadata used by the indexer. Generated files such as `data/catalog.json` and `data/profiles/*.json` are maintained by the indexer. If you only add a simple server entry, editing the relevant `docs/*.md` category page is enough for the PR.
 
@@ -194,7 +194,7 @@ The README is now a lightweight entry point. Browse the full directory in the ca
 | Knowledge Management & Memory | 572 | [Browse](docs/knowledge-management--memory.md) |
 | Location & Maps | 92 | [Browse](docs/location--maps.md) |
 | Marketing, Sales & CRM | 189 | [Browse](docs/marketing-sales--crm.md) |
-| Monitoring & Observability | 87 | [Browse](docs/monitoring--observability.md) |
+| Monitoring & Observability | 88 | [Browse](docs/monitoring--observability.md) |
 | Multimedia Processing | 212 | [Browse](docs/multimedia-processing.md) |
 | Operating System & Command Line | 107 | [Browse](docs/operating-system--command-line.md) |
 | Project & Task Management | 222 | [Browse](docs/project--task-management.md) |

--- a/docs/index-alpha/contribution-guide.md
+++ b/docs/index-alpha/contribution-guide.md
@@ -22,6 +22,20 @@ When adding a server, include as much of this metadata as possible in the issue 
 
 For short markdown entries, structured metadata can live in `data/server-metadata/{serverId}.json`. Server submissions created through the Add MCP server issue form can generate this sidecar automatically, so the category page stays readable while the profile/API still get install, transport, auth, client, and license fields.
 
+For existing indexed servers, use the metadata improvement issue form with the TensorBlock profile id and structured values such as:
+
+```text
+Install: npx -y example-mcp
+Transport: stdio
+Auth: api-key, requires EXAMPLE_API_KEY
+Docs URL: https://docs.example.com/mcp
+License: MIT
+Tools: search, fetch_profile
+Tool count: 2
+```
+
+When the profile id matches the index and the values are clear, automation drafts a metadata sidecar PR for maintainer review.
+
 Complete metadata helps TensorBlock generate:
 
 - server profiles,

--- a/packages/catalog-builder/src/buildCatalog.ts
+++ b/packages/catalog-builder/src/buildCatalog.ts
@@ -223,6 +223,8 @@ function applyMetadataOverride(
 
   return {
     ...entry,
+    description: nonEmptyString(metadata.description) ?? entry.description,
+    category: nonEmptyString(metadata.category) ?? entry.category,
     links: {
       ...entry.links,
       ...(metadata.links?.docs ? { docs: metadata.links.docs } : {}),
@@ -241,6 +243,13 @@ function applyMetadataOverride(
         }
       : entry.auth,
     clients: nonEmptyArray(metadata.clients) ?? entry.clients,
+    tools: metadata.tools
+      ? {
+          count: metadata.tools.count ?? entry.tools.count,
+          names: nonEmptyArray(metadata.tools.names) ?? entry.tools.names,
+          source: metadata.tools.source ?? entry.tools.source,
+        }
+      : entry.tools,
     license: nonEmptyString(metadata.license) ?? entry.license,
     verification: metadata.verification
       ? {

--- a/packages/catalog-builder/src/types.ts
+++ b/packages/catalog-builder/src/types.ts
@@ -61,11 +61,14 @@ export interface CatalogMetadataOverride {
     issue?: number;
     projectUrl?: string;
   };
+  description?: string;
+  category?: string;
   links?: Partial<Pick<CatalogEntry["links"], "docs" | "endpoint">>;
   install?: Partial<CatalogEntry["install"]>;
   transport?: Transport[];
   auth?: Partial<CatalogEntry["auth"]>;
   clients?: string[];
+  tools?: Partial<CatalogEntry["tools"]>;
   license?: string;
   verification?: Partial<CatalogEntry["verification"]>;
   community?: Partial<CatalogEntry["community"]>;

--- a/packages/catalog-builder/test/buildCatalog.test.ts
+++ b/packages/catalog-builder/test/buildCatalog.test.ts
@@ -231,6 +231,11 @@ describe("buildCatalogFromMarkdown", () => {
       [
         id,
         {
+          description: "Structured sidecar description.",
+          category: "Monitoring & Observability",
+          links: {
+            docs: "https://docs.example.com/plain-mcp",
+          },
           install: {
             commands: ["npx -y plain-mcp"],
             env: ["PLAIN_API_KEY"],
@@ -242,6 +247,11 @@ describe("buildCatalogFromMarkdown", () => {
             notes: ["Submitted through the add-server issue form."],
           },
           clients: ["Claude Desktop", "Cursor"],
+          tools: {
+            count: 2,
+            names: ["inspect_project", "summarize_incidents"],
+            source: "self_reported",
+          },
           license: "MIT",
           verification: {
             status: "verified",
@@ -257,6 +267,9 @@ describe("buildCatalogFromMarkdown", () => {
     ]));
     const entry = result.entries[0];
 
+    expect(entry?.description).toBe("Structured sidecar description.");
+    expect(entry?.category).toBe("Monitoring & Observability");
+    expect(entry?.links.docs).toBe("https://docs.example.com/plain-mcp");
     expect(entry?.install).toEqual({
       commands: ["npx -y plain-mcp"],
       env: ["PLAIN_API_KEY"],
@@ -268,6 +281,11 @@ describe("buildCatalogFromMarkdown", () => {
       notes: ["Submitted through the add-server issue form."],
     });
     expect(entry?.clients).toEqual(["Claude Desktop", "Cursor"]);
+    expect(entry?.tools).toEqual({
+      count: 2,
+      names: ["inspect_project", "summarize_incidents"],
+      source: "self_reported",
+    });
     expect(entry?.license).toBe("MIT");
     expect(entry?.verification).toEqual({
       status: "verified",

--- a/packages/catalog-builder/test/metadata.test.ts
+++ b/packages/catalog-builder/test/metadata.test.ts
@@ -1,8 +1,14 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { createRequire } from "node:module";
+import type { FormatsPlugin } from "ajv-formats";
+import { Ajv2020 as Ajv } from "ajv/dist/2020.js";
 import { readMetadataSidecars } from "../src/metadata.js";
+
+const require = createRequire(import.meta.url);
+const addFormats = require("ajv-formats") as FormatsPlugin;
 
 describe("readMetadataSidecars", () => {
   it("returns an empty map when the metadata directory does not exist", () => {
@@ -30,5 +36,38 @@ describe("readMetadataSidecars", () => {
     } finally {
       rmSync(metadataDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("server-metadata.schema.json", () => {
+  it("accepts sidecars with description, category, docs, install, and tools metadata", () => {
+    const schema = JSON.parse(readFileSync("schemas/server-metadata.schema.json", "utf8"));
+    const ajv = new Ajv({ strict: false });
+    addFormats(ajv);
+    const validate = ajv.compile(schema);
+
+    expect(validate({
+      id: "github-owner-demo-mcp-12345678",
+      source: {
+        issue: 812,
+        projectUrl: "https://github.com/owner/demo-mcp",
+      },
+      description: "Structured sidecar description.",
+      category: "Monitoring & Observability",
+      links: {
+        docs: "https://docs.example.com/demo-mcp",
+      },
+      install: {
+        commands: ["npx -y @owner/demo-mcp"],
+        env: ["DEMO_API_KEY"],
+        confidence: "medium",
+      },
+      tools: {
+        count: 2,
+        names: ["inspect_project", "summarize_incidents"],
+        source: "self_reported",
+      },
+    })).toBe(true);
+    expect(validate.errors).toBeNull();
   });
 });

--- a/schemas/server-metadata.schema.json
+++ b/schemas/server-metadata.schema.json
@@ -18,6 +18,8 @@
       },
       "additionalProperties": false
     },
+    "description": { "type": "string", "minLength": 1 },
+    "category": { "type": "string", "minLength": 1 },
     "links": {
       "type": "object",
       "properties": {
@@ -61,6 +63,18 @@
     "clients": {
       "type": "array",
       "items": { "type": "string", "minLength": 1 }
+    },
+    "tools": {
+      "type": "object",
+      "properties": {
+        "count": { "type": "integer", "minimum": 0 },
+        "names": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "source": { "enum": ["self_reported", "verified", "unknown"] }
+      },
+      "additionalProperties": false
     },
     "license": { "type": "string", "minLength": 1 },
     "verification": {


### PR DESCRIPTION
## Summary
- add metadata improvement issue automation that drafts `data/server-metadata/{id}.json` PRs from structured metadata issues
- allow metadata sidecars to override description, category, docs URL, and tool metadata in addition to install/auth/transport/client/license fields
- update the issue form, triage response, README, and metadata contribution guide so contributors know how to use the flow

## Validation
- `node --test .github/scripts/create-improve-metadata-pr.test.mjs .github/scripts/triage-issue.test.mjs .github/scripts/create-add-server-pr.test.mjs .github/scripts/create-claim-profile-pr.test.mjs .github/scripts/comment-merged-pr.test.mjs`
- `npm test`
- `npm run typecheck`
- `npm run build`
- `npm run catalog:build` -> 7747 entries, 9 existing errors
- `npm run profiles:build` -> 7747 profiles
