### PR TITLE
Add client config request automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/request-client-config.yml
+++ b/.github/ISSUE_TEMPLATE/request-client-config.yml
@@ -1,5 +1,5 @@
 name: Request client config support
-description: Request install-config generation for another MCP client or format.
+description: Request install-config generation for another MCP client or format. Clear requests can generate a draft spec PR.
 title: "Request client config support: "
 labels:
   - client-config

--- a/.github/scripts/create-client-config-request-pr.mjs
+++ b/.github/scripts/create-client-config-request-pr.mjs
@@ -1,0 +1,388 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { extractField } from "./triage-issue.mjs";
+
+const API_BASE = "https://api.github.com";
+const COMMENT_MARKER = "<!-- tensorblock-mcp-client-config-request-pr:v1 -->";
+const DEFAULT_BASE_BRANCH = "main";
+const SPEC_DIR = "docs/client-config-requests";
+
+export function parseClientConfigRequestIssue(body) {
+  return {
+    client: normalizeField(extractField(body, "Client or install target")),
+    configShape: stripCodeFence(normalizeField(extractField(body, "Expected config shape"))),
+    docsUrl: normalizeField(extractField(body, "Official docs or reference")),
+    notes: normalizeField(extractField(body, "Notes")),
+  };
+}
+
+export function validateClientConfigRequest(request) {
+  const errors = [];
+
+  if (!request.client) {
+    errors.push("Client or install target is required.");
+  }
+
+  if (!request.configShape) {
+    errors.push("Expected config shape is required.");
+  }
+
+  if (request.docsUrl && !isValidHttpUrl(request.docsUrl)) {
+    errors.push("Official docs or reference must be a valid HTTP or HTTPS URL.");
+  }
+
+  return errors;
+}
+
+export function slugFromClientTarget(value) {
+  return value
+    .toLowerCase()
+    .replace(/&/g, " and ")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+}
+
+export function buildClientConfigSpec({ issue, request }) {
+  const slug = slugFromClientTarget(request.client);
+  const sourceIssue = issue.html_url ?? `#${issue.number}`;
+  const docs = request.docsUrl || "Not provided";
+  const notes = request.notes || "Not provided";
+  const content = [
+    `# ${request.client} client config support`,
+    "",
+    "Status: requested",
+    `Source issue: ${sourceIssue}`,
+    "",
+    "## Client Or Install Target",
+    "",
+    request.client,
+    "",
+    "## Official Docs Or Reference",
+    "",
+    docs,
+    "",
+    "## Expected Config Shape",
+    "",
+    "```json",
+    request.configShape,
+    "```",
+    "",
+    "## Notes",
+    "",
+    notes,
+    "",
+    "## Implementation checklist",
+    "",
+    "- Confirm the target's official MCP config file location or API endpoint.",
+    "- Map stdio server configs from generated command, args, and env values.",
+    "- Map remote server configs from generated URL values.",
+    "- Add config-generator tests for this client or install target.",
+    "- Expose the target through the HTTP API install-config endpoint after support lands.",
+    "",
+  ].join("\n");
+
+  return {
+    path: `${SPEC_DIR}/${slug}.md`,
+    content,
+  };
+}
+
+export function buildIssueComment({ issue, request, pullRequest, errors }) {
+  if (errors?.length) {
+    return [
+      COMMENT_MARKER,
+      "I could not create a client-config request PR yet.",
+      "",
+      "What needs attention:",
+      ...errors.map((error) => `- ${error}`),
+      "",
+      "Update this issue with the requested client name, expected config shape, and official docs if available. The automation will try again when the issue is edited.",
+    ].join("\n");
+  }
+
+  if (pullRequest?.blocked) {
+    return [
+      COMMENT_MARKER,
+      `Generated branch \`${pullRequest.branch}\` for this client-config request, but GitHub Actions could not create the pull request automatically.`,
+      "",
+      `Open the PR manually: ${pullRequest.compareUrl}`,
+    ].join("\n");
+  }
+
+  return [
+    COMMENT_MARKER,
+    `Created a draft client-config request PR for \`${request.client}\`: ${pullRequest.html_url}`,
+    "",
+    "A maintainer should verify the config shape against official docs before implementing generator support.",
+    "",
+    `Source issue: #${issue.number}`,
+  ].join("\n");
+}
+
+export function buildPrBody({ issue, request, spec }) {
+  return [
+    "## Summary",
+    `- capture requested install-config support for \`${request.client}\``,
+    `- add structured request spec at \`${spec.path}\``,
+    "- keep the request reviewable before adding generator behavior",
+    "",
+    "## Expected config shape",
+    "",
+    "```json",
+    request.configShape,
+    "```",
+    ...(request.docsUrl
+      ? [
+          "",
+          "## Official docs",
+          request.docsUrl,
+        ]
+      : []),
+    ...(request.notes
+      ? [
+          "",
+          "## Notes",
+          request.notes,
+        ]
+      : []),
+    "",
+    "## Generated spec",
+    "",
+    `\`${spec.path}\``,
+    "",
+    issue.html_url ?? `#${issue.number}`,
+    "",
+    `Closes #${issue.number}`,
+  ].join("\n");
+}
+
+function writeSpec(spec) {
+  fs.mkdirSync(path.dirname(spec.path), { recursive: true });
+  fs.writeFileSync(spec.path, spec.content);
+}
+
+function normalizeField(value) {
+  const normalized = value
+    .replace(/<!--[\s\S]*?-->/g, "")
+    .trim();
+
+  if (!normalized || normalized === "_No response_") {
+    return "";
+  }
+
+  return normalized;
+}
+
+function stripCodeFence(value) {
+  const trimmed = value.trim();
+  const match = trimmed.match(/^```[a-zA-Z0-9_-]*\s*\n([\s\S]*?)\n```$/);
+  return (match?.[1] ?? trimmed).trim();
+}
+
+function isValidHttpUrl(value) {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+async function main() {
+  const token = process.env.GITHUB_TOKEN;
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  const repository = process.env.GITHUB_REPOSITORY;
+
+  if (!token || !eventPath || !repository) {
+    throw new Error("GITHUB_TOKEN, GITHUB_EVENT_PATH, and GITHUB_REPOSITORY are required.");
+  }
+
+  const event = JSON.parse(fs.readFileSync(eventPath, "utf8"));
+  const issue = event.issue;
+  if (!issue) {
+    console.log("No issue payload found; skipping.");
+    return;
+  }
+
+  const [owner, repo] = repository.split("/");
+  const requestClientConfig = parseClientConfigRequestIssue(issue.body ?? "");
+  const request = createGitHubRequest({ token, owner, repo });
+  const errors = validateClientConfigRequest(requestClientConfig);
+
+  if (errors.length > 0) {
+    await upsertIssueComment(request, issue.number, buildIssueComment({ issue, request: requestClientConfig, errors }));
+    console.log(`Issue #${issue.number} cannot be converted to a client-config request PR: ${errors.join(" ")}`);
+    return;
+  }
+
+  const spec = buildClientConfigSpec({ issue, request: requestClientConfig });
+  const branch = `mcp/client-config-issue-${issue.number}`;
+  const title = `Request ${requestClientConfig.client} client config support`;
+  const body = buildPrBody({ issue, request: requestClientConfig, spec });
+
+  run("git", ["config", "user.name", "github-actions[bot]"]);
+  run("git", ["config", "user.email", "41898282+github-actions[bot]@users.noreply.github.com"]);
+  run("git", ["fetch", "origin", DEFAULT_BASE_BRANCH]);
+  run("git", ["checkout", "-B", branch, `origin/${DEFAULT_BASE_BRANCH}`]);
+
+  writeSpec(spec);
+  run("git", ["add", spec.path]);
+
+  if (!hasStagedChanges()) {
+    console.log(`No client-config request changes generated for issue #${issue.number}.`);
+    return;
+  }
+
+  run("git", ["commit", "-m", title]);
+  run("git", ["push", "--force-with-lease", "origin", `HEAD:${branch}`]);
+
+  let pullRequest;
+  try {
+    pullRequest = await createOrUpdatePullRequest(request, {
+      owner,
+      branch,
+      title,
+      body,
+    });
+  } catch (error) {
+    if (!isPullRequestCreationBlocked(error)) {
+      throw error;
+    }
+
+    const compareUrl = `https://github.com/${owner}/${repo}/compare/${DEFAULT_BASE_BRANCH}...${branch}?expand=1`;
+    await upsertIssueComment(
+      request,
+      issue.number,
+      buildIssueComment({
+        issue,
+        request: requestClientConfig,
+        pullRequest: {
+          blocked: true,
+          branch,
+          compareUrl,
+        },
+      }),
+    );
+    console.log(`Generated branch ${branch} for issue #${issue.number}, but Actions cannot create pull requests.`);
+    console.log(formatGitHubError(error));
+    return;
+  }
+
+  await upsertIssueComment(request, issue.number, buildIssueComment({ issue, request: requestClientConfig, pullRequest }));
+  console.log(`Created or updated draft PR ${pullRequest.html_url} for issue #${issue.number}.`);
+}
+
+function run(command, args) {
+  execFileSync(command, args, { stdio: "inherit" });
+}
+
+function hasStagedChanges() {
+  try {
+    execFileSync("git", ["diff", "--cached", "--quiet"], { stdio: "ignore" });
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+function createGitHubRequest({ token, owner, repo }) {
+  return async function request(pathname, options = {}) {
+    const response = await fetch(`${API_BASE}/repos/${owner}/${repo}${pathname}`, {
+      method: options.method ?? "GET",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      body: options.body ? JSON.stringify(options.body) : undefined,
+    });
+
+    const text = await response.text();
+    const data = text ? JSON.parse(text) : null;
+
+    if (!response.ok) {
+      const error = new Error(`GitHub API ${options.method ?? "GET"} ${pathname} failed: ${response.status}`);
+      error.status = response.status;
+      error.data = data;
+      throw error;
+    }
+
+    return data;
+  };
+}
+
+async function createOrUpdatePullRequest(request, { owner, branch, title, body }) {
+  const query = new URLSearchParams({
+    head: `${owner}:${branch}`,
+    state: "open",
+  });
+  const existingPulls = await request(`/pulls?${query.toString()}`);
+  const existingPull = existingPulls[0];
+
+  if (existingPull) {
+    return request(`/pulls/${existingPull.number}`, {
+      method: "PATCH",
+      body: { title, body },
+    });
+  }
+
+  return request("/pulls", {
+    method: "POST",
+    body: {
+      title,
+      body,
+      head: branch,
+      base: DEFAULT_BASE_BRANCH,
+      draft: true,
+      maintainer_can_modify: true,
+    },
+  });
+}
+
+function isPullRequestCreationBlocked(error) {
+  if (error?.status !== 403) {
+    return false;
+  }
+
+  const message = `${error.data?.message ?? ""} ${JSON.stringify(error.data?.errors ?? [])}`;
+  return /not permitted to create|Resource not accessible by integration|pull request/i.test(message);
+}
+
+function formatGitHubError(error) {
+  if (!error?.data) {
+    return error?.message ?? String(error);
+  }
+
+  return `${error.message}: ${JSON.stringify(error.data)}`;
+}
+
+async function upsertIssueComment(request, issueNumber, body) {
+  const comments = await request(`/issues/${issueNumber}/comments?per_page=100`);
+  const existing = comments.find((comment) => comment.body?.includes(COMMENT_MARKER));
+
+  if (existing) {
+    await request(`/issues/comments/${existing.id}`, {
+      method: "PATCH",
+      body: { body },
+    });
+    return;
+  }
+
+  await request(`/issues/${issueNumber}/comments`, {
+    method: "POST",
+    body: { body },
+  });
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/.github/scripts/create-client-config-request-pr.test.mjs
+++ b/.github/scripts/create-client-config-request-pr.test.mjs
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildClientConfigSpec,
+  buildIssueComment,
+  buildPrBody,
+  parseClientConfigRequestIssue,
+  slugFromClientTarget,
+  validateClientConfigRequest,
+} from "./create-client-config-request-pr.mjs";
+
+const issueBody = [
+  "### Client or install target",
+  "",
+  "Windsurf",
+  "",
+  "### Expected config shape",
+  "",
+  "```json",
+  "{",
+  '  "mcpServers": {',
+  '    "example": {',
+  '      "command": "npx",',
+  '      "args": ["-y", "example-mcp"],',
+  '      "env": {',
+  '        "EXAMPLE_API_KEY": "${EXAMPLE_API_KEY}"',
+  "      }",
+  "    }",
+  "  }",
+  "}",
+  "```",
+  "",
+  "### Official docs or reference",
+  "",
+  "https://docs.windsurf.com/mcp",
+  "",
+  "### Notes",
+  "",
+  "Uses the same top-level mcpServers shape as Claude Desktop, but docs mention workspace-level settings.",
+].join("\n");
+
+test("parses client-config request issue fields", () => {
+  assert.deepEqual(parseClientConfigRequestIssue(issueBody), {
+    client: "Windsurf",
+    configShape: [
+      "{",
+      '  "mcpServers": {',
+      '    "example": {',
+      '      "command": "npx",',
+      '      "args": ["-y", "example-mcp"],',
+      '      "env": {',
+      '        "EXAMPLE_API_KEY": "${EXAMPLE_API_KEY}"',
+      "      }",
+      "    }",
+      "  }",
+      "}",
+    ].join("\n"),
+    docsUrl: "https://docs.windsurf.com/mcp",
+    notes: "Uses the same top-level mcpServers shape as Claude Desktop, but docs mention workspace-level settings.",
+  });
+});
+
+test("validates required client-config request fields and optional docs URL", () => {
+  const request = parseClientConfigRequestIssue(issueBody);
+
+  assert.deepEqual(validateClientConfigRequest(request), []);
+  assert.deepEqual(validateClientConfigRequest({ ...request, client: "" }), ["Client or install target is required."]);
+  assert.deepEqual(validateClientConfigRequest({ ...request, configShape: "" }), ["Expected config shape is required."]);
+  assert.deepEqual(validateClientConfigRequest({ ...request, docsUrl: "not-a-url" }), ["Official docs or reference must be a valid HTTP or HTTPS URL."]);
+});
+
+test("normalizes client target slugs for stable spec paths", () => {
+  assert.equal(slugFromClientTarget("Claude Code"), "claude-code");
+  assert.equal(slugFromClientTarget("VS Code / Continue"), "vs-code-continue");
+});
+
+test("builds a client-config request spec markdown file", () => {
+  const request = parseClientConfigRequestIssue(issueBody);
+  const spec = buildClientConfigSpec({
+    issue: {
+      number: 812,
+      html_url: "https://github.com/TensorBlock/awesome-mcp-servers/issues/812",
+    },
+    request,
+  });
+
+  assert.equal(spec.path, "docs/client-config-requests/windsurf.md");
+  assert.match(spec.content, /^# Windsurf client config support/m);
+  assert.match(spec.content, /Status: requested/);
+  assert.match(spec.content, /Source issue: https:\/\/github\.com\/TensorBlock\/awesome-mcp-servers\/issues\/812/);
+  assert.match(spec.content, /https:\/\/docs\.windsurf\.com\/mcp/);
+  assert.match(spec.content, /"mcpServers"/);
+  assert.match(spec.content, /Implementation checklist/);
+});
+
+test("builds actionable comments and PR body", () => {
+  const request = parseClientConfigRequestIssue(issueBody);
+  const spec = buildClientConfigSpec({
+    issue: { number: 812 },
+    request,
+  });
+  const comment = buildIssueComment({
+    issue: { number: 812 },
+    request,
+    pullRequest: {
+      html_url: "https://github.com/TensorBlock/awesome-mcp-servers/pull/813",
+    },
+  });
+  const body = buildPrBody({
+    issue: { number: 812, html_url: "https://github.com/TensorBlock/awesome-mcp-servers/issues/812" },
+    request,
+    spec,
+  });
+
+  assert.match(comment, /tensorblock-mcp-client-config-request-pr:v1/);
+  assert.match(comment, /draft client-config request PR/);
+  assert.match(comment, /Windsurf/);
+  assert.match(body, /## Summary/);
+  assert.match(body, /docs\/client-config-requests\/windsurf\.md/);
+  assert.match(body, /Closes #812/);
+});

--- a/.github/scripts/triage-issue.mjs
+++ b/.github/scripts/triage-issue.mjs
@@ -163,6 +163,7 @@ export function buildTriageComment(issue) {
       "",
       "What happens next:",
       "- We will compare the requested config shape with the existing Claude Desktop, Cursor, Codex, and VS Code generators.",
+      "- If the client name and config shape are clear, automation will draft a client-config request spec PR for maintainer review.",
       "- Official docs and real examples are the fastest way to add reliable support for a new client or install target.",
       "- Once support lands, indexed profiles can expose generated install-config previews for that target.",
       "",

--- a/.github/scripts/triage-issue.test.mjs
+++ b/.github/scripts/triage-issue.test.mjs
@@ -48,6 +48,21 @@ const claimProfileIssue = {
   ].join("\n"),
 };
 
+const clientConfigIssue = {
+  number: 88,
+  title: "Request client config support: Windsurf",
+  labels: [{ name: "client-config" }],
+  body: [
+    "### Client or install target",
+    "",
+    "Windsurf",
+    "",
+    "### Expected config shape",
+    "",
+    "{\"mcpServers\":{\"example\":{\"command\":\"npx\",\"args\":[\"-y\",\"example-mcp\"]}}}",
+  ].join("\n"),
+};
+
 test("routes issues by issue-form label", () => {
   assert.equal(routeIssue(metadataIssue)?.id, "metadata");
 });
@@ -129,6 +144,14 @@ test("builds claim profile comments with normalized profile links and verificati
   assert.match(comment, /badge\.svg/);
   assert.match(comment, /Maintainer verification checklist:/);
   assert.match(comment, /official project source/);
+});
+
+test("builds client config comments that mention the generated request spec", () => {
+  const comment = buildTriageComment(clientConfigIssue);
+
+  assert.match(comment, /tensorblock-mcp-issue-triage:v1:client-config/);
+  assert.match(comment, /automation will draft a client-config request spec PR/);
+  assert.match(comment, /Windsurf/);
 });
 
 test("issue forms avoid GitHub reserved dropdown options", () => {

--- a/.github/workflows/client-config-request-pr.yml
+++ b/.github/workflows/client-config-request-pr.yml
@@ -1,0 +1,39 @@
+name: MCP Client Config Request Draft PR
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - reopened
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: mcp-client-config-request-pr-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  draft-pr:
+    name: Draft client-config request PR
+    if: contains(github.event.issue.labels.*.name, 'client-config') || startsWith(github.event.issue.title, 'Request client config support:')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Create or update draft client-config request PR
+        run: node .github/scripts/create-client-config-request-pr.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.MCP_AUTOMATION_TOKEN || github.token }}

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Choose the path that matches what you want to do.
 **If you build MCP clients, agents, or developer tools:**
 
 - Use the hosted API at [https://mcp-index.tensorblock.co](https://mcp-index.tensorblock.co) to search servers, fetch normalized profiles, list categories, or generate install-config previews.
-- Request another install target with the [client config issue form](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=request-client-config.yml). Include the client name, expected config shape, example config, and official docs.
+- Request another install target with the [client config issue form](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=request-client-config.yml). Include the client name, expected config shape, example config, and official docs. Clear requests generate a draft client-config spec PR so maintainers can review the target before implementation.
 - Help improve the config generator for Claude Desktop, Cursor, Codex, VS Code, and future clients.
 
 **If you want to improve the index itself:**
@@ -63,7 +63,7 @@ Choose the path that matches what you want to do.
 - Propose verification signals, health checks, ranking improvements, or better category rules.
 - Join the [TensorBlock Discord](https://discord.com/invite/Ej5NmeHFf2) to discuss roadmap work before opening a larger PR.
 
-Issue forms are routed automatically. When you submit a server, metadata update, profile claim, client config request, or broken-entry report, the repo adds the right triage labels and posts the next steps so contributors and maintainers can keep the workflow moving. Server submissions with a clear category can generate draft docs PRs, and structured metadata updates or profile claims can generate draft metadata PRs.
+Issue forms are routed automatically. When you submit a server, metadata update, profile claim, client config request, or broken-entry report, the repo adds the right triage labels and posts the next steps so contributors and maintainers can keep the workflow moving. Server submissions with a clear category can generate draft docs PRs, structured metadata updates or profile claims can generate draft metadata PRs, and clear client-config requests can generate draft spec PRs.
 
 New server entries can be simple, but high-quality metadata makes the profile much more useful. The best entries answer:
 

--- a/docs/client-config-requests/README.md
+++ b/docs/client-config-requests/README.md
@@ -1,0 +1,12 @@
+# Client Config Requests
+
+This folder captures requested MCP client and install target formats before generator support is implemented.
+
+Each request should include:
+
+- the client or install target name,
+- an expected config shape,
+- official docs or reference links,
+- notes about env vars, auth handling, workspace scope, or platform differences.
+
+Once a request is reviewed, maintainers can use the spec to add config-generator support and expose the target through the hosted install-config API.


### PR DESCRIPTION
## Summary
- add client-config request issue automation that drafts a structured spec PR under `docs/client-config-requests/`
- add a workflow for `client-config` issues and update the triage response to describe the generated spec PR
- update README and issue form copy so contributors know clear client target requests become reviewable specs

## Validation
- `node --test .github/scripts/create-client-config-request-pr.test.mjs .github/scripts/triage-issue.test.mjs .github/scripts/create-improve-metadata-pr.test.mjs .github/scripts/create-claim-profile-pr.test.mjs .github/scripts/create-add-server-pr.test.mjs .github/scripts/comment-merged-pr.test.mjs`
- `npm test`
- `npm run typecheck`
- `npm run build`
- `npm run catalog:build` -> 7747 entries, 9 existing errors
- `npm run profiles:build` -> 7747 profiles
