### PR TITLE
Add broken entry report automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/report-broken-entry.yml
+++ b/.github/ISSUE_TEMPLATE/report-broken-entry.yml
@@ -1,5 +1,5 @@
 name: Report broken entry
-description: Report a duplicate, dead link, bad category, stale metadata, or unsafe entry.
+description: Report a duplicate, dead link, bad category, stale metadata, or unsafe entry. Clear reports can generate a draft investigation PR.
 title: "Report broken MCP entry: "
 labels:
   - broken-entry

--- a/.github/scripts/create-broken-entry-report-pr.mjs
+++ b/.github/scripts/create-broken-entry-report-pr.mjs
@@ -1,0 +1,419 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { extractField, serverIdFromProfileReference } from "./triage-issue.mjs";
+
+const API_BASE = "https://api.github.com";
+const COMMENT_MARKER = "<!-- tensorblock-mcp-broken-entry-report-pr:v1 -->";
+const DEFAULT_BASE_BRANCH = "main";
+const REPORT_DIR = "docs/broken-entry-reports";
+
+export function parseBrokenEntryIssue(body) {
+  const entryReference = normalizeField(extractField(body, "TensorBlock profile URL, server id, or project URL"));
+
+  return {
+    entryReference,
+    serverId: serverIdFromProfileReference(entryReference),
+    issueTypes: parseCheckedIssueTypes(extractField(body, "What is wrong?")),
+    details: normalizeField(extractField(body, "Details")),
+    source: normalizeField(extractField(body, "Source or proof")),
+  };
+}
+
+export function validateBrokenEntryReport(report) {
+  const errors = [];
+
+  if (!report.entryReference) {
+    errors.push("TensorBlock profile URL, server id, or project URL is required.");
+  }
+
+  if (report.issueTypes.length === 0) {
+    errors.push("Select at least one broken-entry issue type.");
+  }
+
+  if (!report.details) {
+    errors.push("Details are required.");
+  }
+
+  if (report.source && !isValidHttpUrl(report.source)) {
+    errors.push("Source or proof must be a valid HTTP or HTTPS URL.");
+  }
+
+  return errors;
+}
+
+export function slugFromEntryReference(value) {
+  const serverId = serverIdFromProfileReference(value);
+  if (serverId) {
+    return serverId;
+  }
+
+  const reference = firstUrl(value) || value;
+  try {
+    const url = new URL(reference);
+    const hostname = url.hostname.replace(/^www\./, "").toLowerCase();
+    const segments = url.pathname.split("/").filter(Boolean);
+    const parts = hostname === "github.com" ? ["github", ...segments] : [hostname, ...segments];
+    return slugify(parts.join("-")) || "unknown-entry";
+  } catch {
+    return slugify(reference) || "unknown-entry";
+  }
+}
+
+export function buildBrokenEntryReportSpec({ issue, report }) {
+  const slug = slugFromEntryReference(report.serverId || report.entryReference);
+  const sourceIssue = issue.html_url ?? `#${issue.number}`;
+  const source = report.source || "Not provided";
+  const titleTarget = report.serverId || report.entryReference;
+  const content = [
+    `# Broken entry report: ${titleTarget}`,
+    "",
+    "Status: needs verification",
+    `Source issue: ${sourceIssue}`,
+    "",
+    "## Entry Reference",
+    "",
+    report.entryReference,
+    "",
+    "## Normalized Server Id",
+    "",
+    report.serverId || "Not available",
+    "",
+    "## Reported Issue Types",
+    "",
+    ...report.issueTypes.map((issueType) => `- ${issueType}`),
+    "",
+    "## Details",
+    "",
+    report.details,
+    "",
+    "## Source Or Proof",
+    "",
+    source,
+    "",
+    "## Maintainer checklist",
+    "",
+    "- Verify the report against the indexed profile, source project, and generated API profile.",
+    "- Check whether the fix belongs in a category markdown entry, metadata sidecar, or removal PR.",
+    "- Search the repo for duplicate project URLs before changing category docs.",
+    "- For safety or security concerns, verify with source links before exposing the profile as healthy.",
+    "- Close the source issue after the fix, removal, or no-action decision is merged.",
+    "",
+  ].join("\n");
+
+  return {
+    path: `${REPORT_DIR}/${issue.number}-${slug}.md`,
+    content,
+  };
+}
+
+export function buildIssueComment({ issue, report, pullRequest, errors }) {
+  if (errors?.length) {
+    return [
+      COMMENT_MARKER,
+      "I could not create a broken-entry report PR yet.",
+      "",
+      "What needs attention:",
+      ...errors.map((error) => `- ${error}`),
+      "",
+      "Update this issue with the entry reference, at least one issue type, details, and an HTTP/HTTPS source link if available. The automation will try again when the issue is edited.",
+    ].join("\n");
+  }
+
+  if (pullRequest?.blocked) {
+    return [
+      COMMENT_MARKER,
+      `Generated branch \`${pullRequest.branch}\` for this broken-entry report, but GitHub Actions could not create the pull request automatically.`,
+      "",
+      `Open the PR manually: ${pullRequest.compareUrl}`,
+    ].join("\n");
+  }
+
+  const target = report.serverId || report.entryReference;
+  return [
+    COMMENT_MARKER,
+    `Created a draft broken-entry report PR for \`${target}\`: ${pullRequest.html_url}`,
+    "",
+    "A maintainer should verify the report, decide whether the fix belongs in docs or metadata, then close the source issue through the PR.",
+    "",
+    `Source issue: #${issue.number}`,
+  ].join("\n");
+}
+
+export function buildPrBody({ issue, report, spec }) {
+  const target = report.serverId || report.entryReference;
+  return [
+    "## Summary",
+    `- capture broken-entry report for \`${target}\``,
+    `- add structured investigation spec at \`${spec.path}\``,
+    "- keep the report reviewable before editing catalog docs or metadata sidecars",
+    "",
+    "## Reported issue types",
+    report.issueTypes.map((issueType) => `- ${issueType}`).join("\n"),
+    "",
+    "## Details",
+    "",
+    "```text",
+    report.details,
+    "```",
+    ...(report.source
+      ? [
+          "",
+          "## Source or proof",
+          report.source,
+        ]
+      : []),
+    "",
+    "## Generated report",
+    "",
+    `\`${spec.path}\``,
+    "",
+    issue.html_url ?? `#${issue.number}`,
+    "",
+    `Closes #${issue.number}`,
+  ].join("\n");
+}
+
+function writeSpec(spec) {
+  fs.mkdirSync(path.dirname(spec.path), { recursive: true });
+  fs.writeFileSync(spec.path, spec.content);
+}
+
+function parseCheckedIssueTypes(value) {
+  return value
+    .split("\n")
+    .map((line) => line.match(/^\s*-\s+\[[xX]\]\s+(.+?)\s*$/)?.[1])
+    .filter(Boolean);
+}
+
+function normalizeField(value) {
+  const normalized = value
+    .replace(/<!--[\s\S]*?-->/g, "")
+    .trim();
+
+  if (!normalized || normalized === "_No response_") {
+    return "";
+  }
+
+  return normalized;
+}
+
+function firstUrl(value) {
+  return value.match(/https?:\/\/\S+/i)?.[0]?.replace(/[),.;]+$/g, "") ?? "";
+}
+
+function slugify(value) {
+  return value
+    .toLowerCase()
+    .replace(/&/g, " and ")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-")
+    .slice(0, 100);
+}
+
+function isValidHttpUrl(value) {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+async function main() {
+  const token = process.env.GITHUB_TOKEN;
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  const repository = process.env.GITHUB_REPOSITORY;
+
+  if (!token || !eventPath || !repository) {
+    throw new Error("GITHUB_TOKEN, GITHUB_EVENT_PATH, and GITHUB_REPOSITORY are required.");
+  }
+
+  const event = JSON.parse(fs.readFileSync(eventPath, "utf8"));
+  const issue = event.issue;
+  if (!issue) {
+    console.log("No issue payload found; skipping.");
+    return;
+  }
+
+  const [owner, repo] = repository.split("/");
+  const report = parseBrokenEntryIssue(issue.body ?? "");
+  const request = createGitHubRequest({ token, owner, repo });
+  const errors = validateBrokenEntryReport(report);
+
+  if (errors.length > 0) {
+    await upsertIssueComment(request, issue.number, buildIssueComment({ issue, report, errors }));
+    console.log(`Issue #${issue.number} cannot be converted to a broken-entry report PR: ${errors.join(" ")}`);
+    return;
+  }
+
+  const spec = buildBrokenEntryReportSpec({ issue, report });
+  const branch = `mcp/broken-entry-issue-${issue.number}`;
+  const title = `Investigate broken MCP entry report #${issue.number}`;
+  const body = buildPrBody({ issue, report, spec });
+
+  run("git", ["config", "user.name", "github-actions[bot]"]);
+  run("git", ["config", "user.email", "41898282+github-actions[bot]@users.noreply.github.com"]);
+  run("git", ["fetch", "origin", DEFAULT_BASE_BRANCH]);
+  run("git", ["checkout", "-B", branch, `origin/${DEFAULT_BASE_BRANCH}`]);
+
+  writeSpec(spec);
+  run("git", ["add", spec.path]);
+
+  if (!hasStagedChanges()) {
+    console.log(`No broken-entry report changes generated for issue #${issue.number}.`);
+    return;
+  }
+
+  run("git", ["commit", "-m", title]);
+  run("git", ["push", "--force-with-lease", "origin", `HEAD:${branch}`]);
+
+  let pullRequest;
+  try {
+    pullRequest = await createOrUpdatePullRequest(request, {
+      owner,
+      branch,
+      title,
+      body,
+    });
+  } catch (error) {
+    if (!isPullRequestCreationBlocked(error)) {
+      throw error;
+    }
+
+    const compareUrl = `https://github.com/${owner}/${repo}/compare/${DEFAULT_BASE_BRANCH}...${branch}?expand=1`;
+    await upsertIssueComment(
+      request,
+      issue.number,
+      buildIssueComment({
+        issue,
+        report,
+        pullRequest: {
+          blocked: true,
+          branch,
+          compareUrl,
+        },
+      }),
+    );
+    console.log(`Generated branch ${branch} for issue #${issue.number}, but Actions cannot create pull requests.`);
+    console.log(formatGitHubError(error));
+    return;
+  }
+
+  await upsertIssueComment(request, issue.number, buildIssueComment({ issue, report, pullRequest }));
+  console.log(`Created or updated draft PR ${pullRequest.html_url} for issue #${issue.number}.`);
+}
+
+function run(command, args) {
+  execFileSync(command, args, { stdio: "inherit" });
+}
+
+function hasStagedChanges() {
+  try {
+    execFileSync("git", ["diff", "--cached", "--quiet"], { stdio: "ignore" });
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+function createGitHubRequest({ token, owner, repo }) {
+  return async function request(pathname, options = {}) {
+    const response = await fetch(`${API_BASE}/repos/${owner}/${repo}${pathname}`, {
+      method: options.method ?? "GET",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      body: options.body ? JSON.stringify(options.body) : undefined,
+    });
+
+    const text = await response.text();
+    const data = text ? JSON.parse(text) : null;
+
+    if (!response.ok) {
+      const error = new Error(`GitHub API ${options.method ?? "GET"} ${pathname} failed: ${response.status}`);
+      error.status = response.status;
+      error.data = data;
+      throw error;
+    }
+
+    return data;
+  };
+}
+
+async function createOrUpdatePullRequest(request, { owner, branch, title, body }) {
+  const query = new URLSearchParams({
+    head: `${owner}:${branch}`,
+    state: "open",
+  });
+  const existingPulls = await request(`/pulls?${query.toString()}`);
+  const existingPull = existingPulls[0];
+
+  if (existingPull) {
+    return request(`/pulls/${existingPull.number}`, {
+      method: "PATCH",
+      body: { title, body },
+    });
+  }
+
+  return request("/pulls", {
+    method: "POST",
+    body: {
+      title,
+      body,
+      head: branch,
+      base: DEFAULT_BASE_BRANCH,
+      draft: true,
+      maintainer_can_modify: true,
+    },
+  });
+}
+
+function isPullRequestCreationBlocked(error) {
+  if (error?.status !== 403) {
+    return false;
+  }
+
+  const message = `${error.data?.message ?? ""} ${JSON.stringify(error.data?.errors ?? [])}`;
+  return /not permitted to create|Resource not accessible by integration|pull request/i.test(message);
+}
+
+function formatGitHubError(error) {
+  if (!error?.data) {
+    return error?.message ?? String(error);
+  }
+
+  return `${error.message}: ${JSON.stringify(error.data)}`;
+}
+
+async function upsertIssueComment(request, issueNumber, body) {
+  const comments = await request(`/issues/${issueNumber}/comments?per_page=100`);
+  const existing = comments.find((comment) => comment.body?.includes(COMMENT_MARKER));
+
+  if (existing) {
+    await request(`/issues/comments/${existing.id}`, {
+      method: "PATCH",
+      body: { body },
+    });
+    return;
+  }
+
+  await request(`/issues/${issueNumber}/comments`, {
+    method: "POST",
+    body: { body },
+  });
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/.github/scripts/create-broken-entry-report-pr.test.mjs
+++ b/.github/scripts/create-broken-entry-report-pr.test.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildBrokenEntryReportSpec,
+  buildIssueComment,
+  buildPrBody,
+  parseBrokenEntryIssue,
+  slugFromEntryReference,
+  validateBrokenEntryReport,
+} from "./create-broken-entry-report-pr.mjs";
+
+const issueBody = [
+  "### TensorBlock profile URL, server id, or project URL",
+  "",
+  "https://www.tensorblock.co/mcp/servers/github-owner-demo-mcp-12345678",
+  "",
+  "### What is wrong?",
+  "",
+  "- [x] Dead link",
+  "- [ ] Duplicate entry",
+  "- [x] Wrong category",
+  "- [ ] Incorrect install command",
+  "- [ ] Incorrect auth or transport metadata",
+  "- [ ] Stale project",
+  "- [ ] Security or safety concern",
+  "- [ ] Other",
+  "",
+  "### Details",
+  "",
+  "The project moved from the Utilities category to Databases and the README link now redirects.",
+  "",
+  "### Source or proof",
+  "",
+  "https://github.com/owner/demo-mcp#readme",
+].join("\n");
+
+test("parses broken-entry report issue fields", () => {
+  assert.deepEqual(parseBrokenEntryIssue(issueBody), {
+    entryReference: "https://www.tensorblock.co/mcp/servers/github-owner-demo-mcp-12345678",
+    serverId: "github-owner-demo-mcp-12345678",
+    issueTypes: ["Dead link", "Wrong category"],
+    details: "The project moved from the Utilities category to Databases and the README link now redirects.",
+    source: "https://github.com/owner/demo-mcp#readme",
+  });
+});
+
+test("validates required broken-entry report fields and optional proof URL", () => {
+  const report = parseBrokenEntryIssue(issueBody);
+
+  assert.deepEqual(validateBrokenEntryReport(report), []);
+  assert.deepEqual(validateBrokenEntryReport({ ...report, entryReference: "", serverId: "" }), ["TensorBlock profile URL, server id, or project URL is required."]);
+  assert.deepEqual(validateBrokenEntryReport({ ...report, issueTypes: [] }), ["Select at least one broken-entry issue type."]);
+  assert.deepEqual(validateBrokenEntryReport({ ...report, details: "" }), ["Details are required."]);
+  assert.deepEqual(validateBrokenEntryReport({ ...report, source: "not-a-url" }), ["Source or proof must be a valid HTTP or HTTPS URL."]);
+});
+
+test("normalizes broken-entry report slugs for stable spec paths", () => {
+  assert.equal(slugFromEntryReference("github-owner-demo-mcp-12345678"), "github-owner-demo-mcp-12345678");
+  assert.equal(slugFromEntryReference("https://github.com/owner/demo-mcp"), "github-owner-demo-mcp");
+  assert.equal(slugFromEntryReference("https://example.com/mcp-servers/demo"), "example-com-mcp-servers-demo");
+});
+
+test("builds a broken-entry report markdown spec", () => {
+  const report = parseBrokenEntryIssue(issueBody);
+  const spec = buildBrokenEntryReportSpec({
+    issue: {
+      number: 901,
+      html_url: "https://github.com/TensorBlock/awesome-mcp-servers/issues/901",
+    },
+    report,
+  });
+
+  assert.equal(spec.path, "docs/broken-entry-reports/901-github-owner-demo-mcp-12345678.md");
+  assert.match(spec.content, /^# Broken entry report: github-owner-demo-mcp-12345678/m);
+  assert.match(spec.content, /Status: needs verification/);
+  assert.match(spec.content, /Source issue: https:\/\/github\.com\/TensorBlock\/awesome-mcp-servers\/issues\/901/);
+  assert.match(spec.content, /- Dead link/);
+  assert.match(spec.content, /- Wrong category/);
+  assert.match(spec.content, /https:\/\/github\.com\/owner\/demo-mcp#readme/);
+  assert.match(spec.content, /Maintainer checklist/);
+});
+
+test("builds actionable comments and PR body", () => {
+  const report = parseBrokenEntryIssue(issueBody);
+  const spec = buildBrokenEntryReportSpec({
+    issue: { number: 901 },
+    report,
+  });
+  const comment = buildIssueComment({
+    issue: { number: 901 },
+    report,
+    pullRequest: {
+      html_url: "https://github.com/TensorBlock/awesome-mcp-servers/pull/902",
+    },
+  });
+  const body = buildPrBody({
+    issue: { number: 901, html_url: "https://github.com/TensorBlock/awesome-mcp-servers/issues/901" },
+    report,
+    spec,
+  });
+
+  assert.match(comment, /tensorblock-mcp-broken-entry-report-pr:v1/);
+  assert.match(comment, /draft broken-entry report PR/);
+  assert.match(comment, /github-owner-demo-mcp-12345678/);
+  assert.match(body, /## Summary/);
+  assert.match(body, /docs\/broken-entry-reports\/901-github-owner-demo-mcp-12345678\.md/);
+  assert.match(body, /Closes #901/);
+});

--- a/.github/scripts/triage-issue.mjs
+++ b/.github/scripts/triage-issue.mjs
@@ -174,6 +174,7 @@ export function buildTriageComment(issue) {
       "",
       "What happens next:",
       "- We will verify the duplicate, dead link, stale metadata, wrong category, or safety concern.",
+      "- If the entry reference, issue type, and details are clear, automation will draft a broken-entry report spec PR for maintainer review.",
       "- If there is a clear correction, a direct PR against the matching `docs/*.md` entry is welcome.",
       "- Safety or security reports are routed with higher priority.",
       "",

--- a/.github/scripts/triage-issue.test.mjs
+++ b/.github/scripts/triage-issue.test.mjs
@@ -63,6 +63,25 @@ const clientConfigIssue = {
   ].join("\n"),
 };
 
+const brokenEntryIssue = {
+  number: 99,
+  title: "Report broken MCP entry: github-owner-demo-mcp",
+  labels: [{ name: "broken-entry" }],
+  body: [
+    "### TensorBlock profile URL, server id, or project URL",
+    "",
+    "github-owner-demo-mcp-12345678",
+    "",
+    "### What is wrong?",
+    "",
+    "- [x] Dead link",
+    "",
+    "### Details",
+    "",
+    "The project URL is now 404.",
+  ].join("\n"),
+};
+
 test("routes issues by issue-form label", () => {
   assert.equal(routeIssue(metadataIssue)?.id, "metadata");
 });
@@ -152,6 +171,14 @@ test("builds client config comments that mention the generated request spec", ()
   assert.match(comment, /tensorblock-mcp-issue-triage:v1:client-config/);
   assert.match(comment, /automation will draft a client-config request spec PR/);
   assert.match(comment, /Windsurf/);
+});
+
+test("builds broken-entry comments that mention the generated report spec", () => {
+  const comment = buildTriageComment(brokenEntryIssue);
+
+  assert.match(comment, /tensorblock-mcp-issue-triage:v1:broken-entry/);
+  assert.match(comment, /automation will draft a broken-entry report spec PR/);
+  assert.match(comment, /github-owner-demo-mcp-12345678/);
 });
 
 test("issue forms avoid GitHub reserved dropdown options", () => {

--- a/.github/workflows/broken-entry-report-pr.yml
+++ b/.github/workflows/broken-entry-report-pr.yml
@@ -1,0 +1,39 @@
+name: MCP Broken Entry Report Draft PR
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - reopened
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: mcp-broken-entry-report-pr-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  draft-pr:
+    name: Draft broken-entry report PR
+    if: contains(github.event.issue.labels.*.name, 'broken-entry') || startsWith(github.event.issue.title, 'Report broken MCP entry:')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Create or update draft broken-entry report PR
+        run: node .github/scripts/create-broken-entry-report-pr.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.MCP_AUTOMATION_TOKEN || github.token }}

--- a/README.md
+++ b/README.md
@@ -58,12 +58,12 @@ Choose the path that matches what you want to do.
 
 **If you want to improve the index itself:**
 
-- Fix duplicate, stale, broken, or poorly categorized entries. Use the [broken entry issue form](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=report-broken-entry.yml) when you want maintainers to triage it.
+- Fix duplicate, stale, broken, or poorly categorized entries. Use the [broken entry issue form](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=report-broken-entry.yml) when you want maintainers to triage it; clear reports generate a draft investigation PR so cleanup work can be reviewed and tracked.
 - Add missing metadata that makes search and install generation more accurate.
 - Propose verification signals, health checks, ranking improvements, or better category rules.
 - Join the [TensorBlock Discord](https://discord.com/invite/Ej5NmeHFf2) to discuss roadmap work before opening a larger PR.
 
-Issue forms are routed automatically. When you submit a server, metadata update, profile claim, client config request, or broken-entry report, the repo adds the right triage labels and posts the next steps so contributors and maintainers can keep the workflow moving. Server submissions with a clear category can generate draft docs PRs, structured metadata updates or profile claims can generate draft metadata PRs, and clear client-config requests can generate draft spec PRs.
+Issue forms are routed automatically. When you submit a server, metadata update, profile claim, client config request, or broken-entry report, the repo adds the right triage labels and posts the next steps so contributors and maintainers can keep the workflow moving. Server submissions with a clear category can generate draft docs PRs, structured metadata updates or profile claims can generate draft metadata PRs, clear client-config requests can generate draft spec PRs, and clear broken-entry reports can generate draft investigation PRs.
 
 New server entries can be simple, but high-quality metadata makes the profile much more useful. The best entries answer:
 

--- a/docs/broken-entry-reports/README.md
+++ b/docs/broken-entry-reports/README.md
@@ -1,0 +1,7 @@
+# Broken Entry Reports
+
+This directory stores generated investigation specs from the broken entry issue form.
+
+Each report captures the affected TensorBlock profile, server id, or project URL, the reported problem types, submitted details, source proof, and a maintainer checklist. Reports keep cleanup work reviewable before maintainers edit category markdown, metadata sidecars, or remove stale entries.
+
+Generated report files are starting points, not final catalog data. After a report is verified, the actual fix should land in the relevant `docs/*.md` category page or `data/server-metadata/*.json` sidecar.

--- a/docs/index-alpha/contribution-guide.md
+++ b/docs/index-alpha/contribution-guide.md
@@ -36,6 +36,8 @@ Tool count: 2
 
 When the profile id matches the index and the values are clear, automation drafts a metadata sidecar PR for maintainer review.
 
+For duplicate, stale, broken, unsafe, or poorly categorized entries, use the broken entry issue form with the TensorBlock profile URL, server id, or project URL. Clear reports can generate a draft investigation PR under `docs/broken-entry-reports/` so maintainers can verify the problem before editing catalog docs or metadata sidecars.
+
 Complete metadata helps TensorBlock generate:
 
 - server profiles,


### PR DESCRIPTION
## Summary
- add automation that converts clear broken-entry issue reports into draft investigation PRs
- add generated report specs under docs/broken-entry-reports
- update issue triage, issue form, README, and contribution guide to explain the workflow

## Validation
- node --test .github/scripts/create-broken-entry-report-pr.test.mjs .github/scripts/triage-issue.test.mjs .github/scripts/create-client-config-request-pr.test.mjs .github/scripts/create-improve-metadata-pr.test.mjs .github/scripts/create-claim-profile-pr.test.mjs .github/scripts/create-add-server-pr.test.mjs .github/scripts/comment-merged-pr.test.mjs
- npm test
- npm run typecheck
- npm run build
- npm run catalog:build
- npm run profiles:build
- node .github/scripts/validate-issue-forms.mjs