### PR TITLE
Add catalog health check automation

### DIFF
--- a/.github/scripts/check-catalog-health.mjs
+++ b/.github/scripts/check-catalog-health.mjs
@@ -1,0 +1,490 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const API_BASE = "https://api.github.com";
+const DEFAULT_CATALOG_PATH = "data/catalog.json";
+const DEFAULT_MAX_GITHUB_REPOS = 250;
+const DEFAULT_MAX_ISSUES = 5;
+const HEALTH_MARKER_PREFIX = "<!-- tensorblock-mcp-catalog-health:v1";
+
+const BROKEN_ENTRY_ISSUE_TYPES = [
+  "Dead link",
+  "Duplicate entry",
+  "Wrong category",
+  "Incorrect install command",
+  "Incorrect auth or transport metadata",
+  "Stale project",
+  "Security or safety concern",
+  "Other",
+];
+
+const LABEL_DEFINITIONS = {
+  "broken-entry": {
+    color: "D73A4A",
+    description: "Duplicate, dead, stale, unsafe, or incorrect MCP Index entry.",
+  },
+  "catalog-health": {
+    color: "5319E7",
+    description: "Automatically generated MCP catalog health report.",
+  },
+};
+
+export function githubRepoFromUrl(value) {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const url = new URL(value);
+    if (!["github.com", "www.github.com"].includes(url.hostname.toLowerCase())) {
+      return null;
+    }
+
+    const [owner, rawRepo] = url.pathname.split("/").filter(Boolean);
+    if (!owner || !rawRepo) {
+      return null;
+    }
+
+    const repo = rawRepo.replace(/\.git$/i, "");
+    const key = `${owner.toLowerCase()}/${repo.toLowerCase()}`;
+
+    return {
+      owner,
+      repo,
+      key,
+      apiPath: `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`,
+      htmlUrl: `https://github.com/${owner}/${repo}`,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function findDuplicatePrimaryLinkFindings(catalog) {
+  const groups = new Map();
+
+  for (const entry of catalog) {
+    const primary = normalizeUrl(entry.links?.primary);
+    if (!primary) {
+      continue;
+    }
+
+    const existing = groups.get(primary) ?? [];
+    existing.push(entry);
+    groups.set(primary, existing);
+  }
+
+  return Array.from(groups.entries())
+    .filter(([, entries]) => entries.length > 1)
+    .map(([url, entries]) => {
+      const serverIds = entries.map((entry) => entry.id).sort();
+      const categoryLines = entries.map((entry) => {
+        return `- ${entry.id} (${entry.category || "unknown category"}, ${entry.source?.docsPath || "unknown source"})`;
+      });
+
+      return {
+        kind: "duplicate-primary-link",
+        key: `duplicate-primary-link:${serverIds.join("-")}`,
+        priority: 10,
+        entryReference: url,
+        titleTarget: url,
+        issueTypes: ["Duplicate entry"],
+        serverIds,
+        source: url,
+        details: [
+          `The primary link ${url} appears ${entries.length} times in the generated catalog.`,
+          "",
+          "Duplicate indexed entries:",
+          ...categoryLines,
+          "",
+          "A maintainer should verify whether these are intentional aliases, then remove or merge duplicate docs entries if needed.",
+        ].join("\n"),
+      };
+    });
+}
+
+export function buildGithubRepoFindings(catalog, repoChecks) {
+  const entriesByRepo = new Map();
+
+  for (const entry of catalog) {
+    const repo = githubRepoFromEntry(entry);
+    if (!repo) {
+      continue;
+    }
+
+    const entries = entriesByRepo.get(repo.key) ?? [];
+    entries.push(entry);
+    entriesByRepo.set(repo.key, entries);
+  }
+
+  const findings = [];
+  for (const [repoKey, check] of repoChecks.entries()) {
+    const entries = entriesByRepo.get(repoKey) ?? [];
+    for (const entry of entries) {
+      const repo = githubRepoFromEntry(entry);
+      if (!repo) {
+        continue;
+      }
+
+      const base = {
+        entryReference: repo.htmlUrl,
+        titleTarget: entry.name || repo.htmlUrl,
+        serverIds: [entry.id],
+        source: repo.htmlUrl,
+      };
+
+      if (check.status === 404) {
+        findings.push({
+          ...base,
+          kind: "github-repo-not-found",
+          key: `github-repo-not-found:${entry.id}`,
+          priority: 20,
+          issueTypes: ["Dead link"],
+          details: [
+            `GitHub API returned 404 for ${repo.htmlUrl}.`,
+            "",
+            entrySummary(entry),
+            "",
+            "A maintainer should verify whether the project moved, became private, or should be removed from the catalog.",
+          ].join("\n"),
+        });
+      } else if (check.status === 200 && check.data?.archived) {
+        findings.push({
+          ...base,
+          kind: "github-repo-archived",
+          key: `github-repo-archived:${entry.id}`,
+          priority: 30,
+          issueTypes: ["Stale project"],
+          details: [
+            `${repo.htmlUrl} is archived on GitHub.`,
+            "",
+            entrySummary(entry),
+            "",
+            "A maintainer should verify whether the archived project should stay indexed, be marked stale, or be replaced by an active fork.",
+          ].join("\n"),
+        });
+      } else if (check.status === 200 && check.data?.disabled) {
+        findings.push({
+          ...base,
+          kind: "github-repo-disabled",
+          key: `github-repo-disabled:${entry.id}`,
+          priority: 25,
+          issueTypes: ["Stale project"],
+          details: [
+            `${repo.htmlUrl} is disabled on GitHub.`,
+            "",
+            entrySummary(entry),
+            "",
+            "A maintainer should verify whether the project should be removed or replaced with an active source.",
+          ].join("\n"),
+        });
+      }
+    }
+  }
+
+  return findings;
+}
+
+export function healthFindingMarker(finding) {
+  return `${HEALTH_MARKER_PREFIX} ${finding.key} -->`;
+}
+
+export function buildHealthIssueTitle(finding) {
+  return compactTitle(`Report broken MCP entry: ${finding.titleTarget || finding.entryReference}`);
+}
+
+export function buildHealthIssueBody(finding) {
+  const checkedTypes = new Set(finding.issueTypes);
+  return [
+    healthFindingMarker(finding),
+    "",
+    "### TensorBlock profile URL, server id, or project URL",
+    "",
+    finding.entryReference,
+    "",
+    "### What is wrong?",
+    "",
+    ...BROKEN_ENTRY_ISSUE_TYPES.map((issueType) => {
+      return `- [${checkedTypes.has(issueType) ? "x" : " "}] ${issueType}`;
+    }),
+    "",
+    "### Details",
+    "",
+    finding.details,
+    "",
+    "### Source or proof",
+    "",
+    finding.source || "_No response_",
+    "",
+    "### Generated by",
+    "",
+    "TensorBlock MCP catalog health check.",
+  ].join("\n");
+}
+
+export function planIssueCreations({ findings, existingIssues, maxIssues }) {
+  const existingMarkers = new Set(
+    existingIssues
+      .flatMap((issue) => markersInText(issue.body ?? ""))
+      .filter(Boolean),
+  );
+
+  return findings
+    .filter((finding) => !existingMarkers.has(healthFindingMarker(finding)))
+    .sort(compareFindings)
+    .slice(0, maxIssues)
+    .map((finding) => ({
+      finding,
+      title: buildHealthIssueTitle(finding),
+      body: buildHealthIssueBody(finding),
+      labels: ["broken-entry", "catalog-health"],
+    }));
+}
+
+export function uniqueGithubReposFromCatalog(catalog, { limit = DEFAULT_MAX_GITHUB_REPOS, offset = 0 } = {}) {
+  const repos = [];
+  const seen = new Set();
+
+  for (const entry of catalog) {
+    const repo = githubRepoFromEntry(entry);
+    if (!repo || seen.has(repo.key)) {
+      continue;
+    }
+
+    seen.add(repo.key);
+    repos.push(repo);
+  }
+
+  if (repos.length === 0) {
+    return [];
+  }
+
+  const normalizedOffset = Math.max(0, offset) % repos.length;
+  return [...repos.slice(normalizedOffset), ...repos.slice(0, normalizedOffset)].slice(0, limit);
+}
+
+function githubRepoFromEntry(entry) {
+  return githubRepoFromUrl(entry.links?.repo || entry.links?.primary);
+}
+
+function normalizeUrl(value) {
+  if (!value) {
+    return "";
+  }
+
+  try {
+    const url = new URL(value);
+    url.hash = "";
+    url.search = "";
+    const pathname = url.pathname.replace(/\/+$/g, "");
+    return `${url.protocol}//${url.hostname.toLowerCase()}${pathname}`;
+  } catch {
+    return value.trim().replace(/\/+$/g, "");
+  }
+}
+
+function entrySummary(entry) {
+  return [
+    `Indexed server id: ${entry.id}`,
+    `Name: ${entry.name}`,
+    `Category: ${entry.category || "unknown"}`,
+    `Source docs: ${entry.source?.docsPath || "unknown"}`,
+  ].join("\n");
+}
+
+function markersInText(value) {
+  return value.match(new RegExp(`${escapeRegex(HEALTH_MARKER_PREFIX)} [^>]+-->`, "g")) ?? [];
+}
+
+function compareFindings(a, b) {
+  return a.priority - b.priority || a.key.localeCompare(b.key);
+}
+
+function compactTitle(value) {
+  return value.length <= 120 ? value : `${value.slice(0, 117).trimEnd()}...`;
+}
+
+function parsePositiveInteger(value, fallback) {
+  const parsed = Number.parseInt(value ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function offsetForToday(totalRepos, value) {
+  const parsed = Number.parseInt(value ?? "", 10);
+  if (Number.isFinite(parsed) && parsed >= 0) {
+    return parsed;
+  }
+
+  if (totalRepos <= 0) {
+    return 0;
+  }
+
+  const now = new Date();
+  const start = Date.UTC(now.getUTCFullYear(), 0, 0);
+  const dayOfYear = Math.floor((Date.now() - start) / 86400000);
+  return (dayOfYear * DEFAULT_MAX_GITHUB_REPOS) % totalRepos;
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+async function main() {
+  const token = process.env.GITHUB_TOKEN;
+  const repository = process.env.GITHUB_REPOSITORY;
+  const catalogPath = process.env.CATALOG_PATH || DEFAULT_CATALOG_PATH;
+  const maxIssues = parsePositiveInteger(process.env.HEALTH_CHECK_MAX_ISSUES, DEFAULT_MAX_ISSUES);
+  const maxGithubRepos = parsePositiveInteger(process.env.HEALTH_CHECK_MAX_GITHUB_REPOS, DEFAULT_MAX_GITHUB_REPOS);
+  const dryRun = process.env.HEALTH_CHECK_DRY_RUN === "1";
+
+  const catalog = JSON.parse(fs.readFileSync(catalogPath, "utf8"));
+  const duplicateFindings = findDuplicatePrimaryLinkFindings(catalog);
+  const githubRepos = uniqueGithubReposFromCatalog(catalog, { limit: Number.MAX_SAFE_INTEGER });
+  const githubReposToCheck = uniqueGithubReposFromCatalog(catalog, {
+    limit: maxGithubRepos,
+    offset: offsetForToday(githubRepos.length, process.env.HEALTH_CHECK_OFFSET),
+  });
+
+  const repoChecks = token
+    ? await checkGithubRepos({ token, repos: githubReposToCheck })
+    : new Map();
+  const findings = [...duplicateFindings, ...buildGithubRepoFindings(catalog, repoChecks)].sort(compareFindings);
+
+  if (dryRun) {
+    console.log(JSON.stringify({
+      catalogEntries: catalog.length,
+      duplicateFindings: duplicateFindings.length,
+      githubReposChecked: repoChecks.size,
+      findings: findings.map((finding) => ({
+        key: finding.key,
+        kind: finding.kind,
+        entryReference: finding.entryReference,
+        issueTypes: finding.issueTypes,
+      })),
+    }, null, 2));
+    return;
+  }
+
+  if (!token || !repository) {
+    throw new Error("GITHUB_TOKEN and GITHUB_REPOSITORY are required unless HEALTH_CHECK_DRY_RUN=1.");
+  }
+
+  const [owner, repo] = repository.split("/");
+  const request = createGitHubRequest({ token, owner, repo });
+
+  await ensureLabels(request, ["broken-entry", "catalog-health"]);
+
+  const existingIssues = await listExistingHealthIssues(request);
+  const plannedIssues = planIssueCreations({
+    findings,
+    existingIssues,
+    maxIssues,
+  });
+
+  for (const issue of plannedIssues) {
+    const created = await request("/issues", {
+      method: "POST",
+      body: {
+        title: issue.title,
+        body: issue.body,
+        labels: issue.labels,
+      },
+    });
+    console.log(`Created catalog health issue #${created.number}: ${created.html_url}`);
+  }
+
+  console.log(`Catalog health check complete: ${findings.length} finding(s), ${plannedIssues.length} new issue(s).`);
+}
+
+async function checkGithubRepos({ token, repos }) {
+  const checks = new Map();
+  for (const repo of repos) {
+    const response = await fetch(`${API_BASE}${repo.apiPath}`, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+    const text = await response.text();
+    const data = text ? JSON.parse(text) : null;
+    checks.set(repo.key, {
+      status: response.status,
+      data,
+    });
+  }
+
+  return checks;
+}
+
+function createGitHubRequest({ token, owner, repo }) {
+  return async function request(pathname, options = {}) {
+    const response = await fetch(`${API_BASE}/repos/${owner}/${repo}${pathname}`, {
+      method: options.method ?? "GET",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      body: options.body ? JSON.stringify(options.body) : undefined,
+    });
+
+    const text = await response.text();
+    const data = text ? JSON.parse(text) : null;
+
+    if (!response.ok) {
+      const error = new Error(`GitHub API ${options.method ?? "GET"} ${pathname} failed: ${response.status}`);
+      error.status = response.status;
+      error.data = data;
+      throw error;
+    }
+
+    return data;
+  };
+}
+
+async function ensureLabels(request, labelNames) {
+  for (const name of labelNames) {
+    const definition = LABEL_DEFINITIONS[name];
+    if (!definition) {
+      continue;
+    }
+
+    try {
+      await request(`/labels/${encodeURIComponent(name)}`);
+    } catch (error) {
+      if (error.status !== 404) {
+        throw error;
+      }
+
+      await request("/labels", {
+        method: "POST",
+        body: {
+          name,
+          color: definition.color,
+          description: definition.description,
+        },
+      });
+      console.log(`Created missing label: ${name}`);
+    }
+  }
+}
+
+async function listExistingHealthIssues(request) {
+  const query = new URLSearchParams({
+    state: "open",
+    labels: "catalog-health",
+    per_page: "100",
+  });
+  return request(`/issues?${query.toString()}`);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/.github/scripts/check-catalog-health.test.mjs
+++ b/.github/scripts/check-catalog-health.test.mjs
@@ -1,0 +1,189 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildGithubRepoFindings,
+  buildHealthIssueBody,
+  buildHealthIssueTitle,
+  findDuplicatePrimaryLinkFindings,
+  githubRepoFromUrl,
+  healthFindingMarker,
+  planIssueCreations,
+} from "./check-catalog-health.mjs";
+
+const catalog = [
+  {
+    id: "github-owner-alpha-11111111",
+    name: "owner/alpha",
+    category: "Developer Productivity & Utilities",
+    links: {
+      primary: "https://github.com/owner/alpha",
+      repo: "https://github.com/owner/alpha",
+    },
+    source: {
+      docsPath: "docs/developer-productivity--utilities.md",
+    },
+  },
+  {
+    id: "github-owner-alpha-22222222",
+    name: "owner/alpha duplicate",
+    category: "Utilities & Helpers",
+    links: {
+      primary: "https://github.com/owner/alpha/",
+      repo: "https://github.com/owner/alpha/",
+    },
+    source: {
+      docsPath: "docs/utilities--helpers.md",
+    },
+  },
+  {
+    id: "github-owner-archived-33333333",
+    name: "owner/archived",
+    category: "Search",
+    links: {
+      primary: "https://github.com/owner/archived",
+      repo: "https://github.com/owner/archived",
+    },
+    source: {
+      docsPath: "docs/search.md",
+    },
+  },
+  {
+    id: "github-owner-missing-44444444",
+    name: "owner/missing",
+    category: "Databases",
+    links: {
+      primary: "https://github.com/owner/missing",
+      repo: "https://github.com/owner/missing",
+    },
+    source: {
+      docsPath: "docs/databases.md",
+    },
+  },
+  {
+    id: "github-owner-disabled-55555555",
+    name: "owner/disabled",
+    category: "Security",
+    links: {
+      primary: "https://github.com/owner/disabled",
+      repo: "https://github.com/owner/disabled",
+    },
+    source: {
+      docsPath: "docs/security.md",
+    },
+  },
+];
+
+test("normalizes GitHub repository URLs from catalog links", () => {
+  assert.deepEqual(githubRepoFromUrl("https://github.com/Owner/Example"), {
+    owner: "Owner",
+    repo: "Example",
+    key: "owner/example",
+    apiPath: "/repos/Owner/Example",
+    htmlUrl: "https://github.com/Owner/Example",
+  });
+  assert.deepEqual(githubRepoFromUrl("https://github.com/owner/example/tree/main"), {
+    owner: "owner",
+    repo: "example",
+    key: "owner/example",
+    apiPath: "/repos/owner/example",
+    htmlUrl: "https://github.com/owner/example",
+  });
+  assert.equal(githubRepoFromUrl("https://example.com/owner/example"), null);
+});
+
+test("finds duplicate primary links as broken-entry findings", () => {
+  const findings = findDuplicatePrimaryLinkFindings(catalog);
+
+  assert.equal(findings.length, 1);
+  assert.deepEqual(findings[0].issueTypes, ["Duplicate entry"]);
+  assert.equal(findings[0].entryReference, "https://github.com/owner/alpha");
+  assert.deepEqual(findings[0].serverIds, ["github-owner-alpha-11111111", "github-owner-alpha-22222222"]);
+  assert.match(findings[0].details, /appears 2 times/);
+  assert.match(findings[0].details, /docs\/developer-productivity--utilities\.md/);
+  assert.match(findings[0].details, /docs\/utilities--helpers\.md/);
+});
+
+test("builds GitHub repo findings from real API-shaped repo checks", () => {
+  const findings = buildGithubRepoFindings(catalog, new Map([
+    ["owner/alpha", {
+      status: 200,
+      data: {
+        html_url: "https://github.com/owner/alpha",
+        archived: false,
+        disabled: false,
+      },
+    }],
+    ["owner/archived", {
+      status: 200,
+      data: {
+        html_url: "https://github.com/owner/archived",
+        archived: true,
+        disabled: false,
+      },
+    }],
+    ["owner/missing", {
+      status: 404,
+      data: {
+        message: "Not Found",
+        documentation_url: "https://docs.github.com/rest/repos/repos#get-a-repository",
+      },
+    }],
+    ["owner/disabled", {
+      status: 200,
+      data: {
+        html_url: "https://github.com/owner/disabled",
+        archived: false,
+        disabled: true,
+      },
+    }],
+  ]));
+
+  assert.deepEqual(
+    findings.map((finding) => [finding.entryReference, finding.issueTypes]),
+    [
+      ["https://github.com/owner/archived", ["Stale project"]],
+      ["https://github.com/owner/missing", ["Dead link"]],
+      ["https://github.com/owner/disabled", ["Stale project"]],
+    ],
+  );
+  assert.match(findings[0].details, /archived on GitHub/);
+  assert.match(findings[1].details, /GitHub API returned 404/);
+  assert.match(findings[2].details, /disabled on GitHub/);
+});
+
+test("builds broken-entry issue titles and bodies with stable health markers", () => {
+  const [finding] = findDuplicatePrimaryLinkFindings(catalog);
+  const title = buildHealthIssueTitle(finding);
+  const body = buildHealthIssueBody(finding);
+
+  assert.equal(title, "Report broken MCP entry: https://github.com/owner/alpha");
+  assert.match(body, /tensorblock-mcp-catalog-health:v1 duplicate-primary-link:github-owner-alpha-11111111-github-owner-alpha-22222222/);
+  assert.match(body, /### TensorBlock profile URL, server id, or project URL/);
+  assert.match(body, /https:\/\/github\.com\/owner\/alpha/);
+  assert.match(body, /- \[x\] Duplicate entry/);
+  assert.match(body, /### Details/);
+  assert.match(body, /### Source or proof/);
+});
+
+test("plans new issue creations without duplicating existing health reports", () => {
+  const findings = [
+    ...findDuplicatePrimaryLinkFindings(catalog),
+    ...buildGithubRepoFindings(catalog, new Map([
+      ["owner/missing", { status: 404, data: { message: "Not Found" } }],
+      ["owner/archived", { status: 200, data: { html_url: "https://github.com/owner/archived", archived: true, disabled: false } }],
+    ])),
+  ];
+  const existingIssues = [
+    {
+      number: 12,
+      body: `${healthFindingMarker(findings[0])}\nAlready tracking this duplicate.`,
+    },
+  ];
+  const planned = planIssueCreations({ findings, existingIssues, maxIssues: 1 });
+
+  assert.equal(planned.length, 1);
+  assert.equal(planned[0].finding.kind, "github-repo-not-found");
+  assert.equal(planned[0].labels.includes("broken-entry"), true);
+  assert.equal(planned[0].labels.includes("catalog-health"), true);
+});

--- a/.github/workflows/catalog-health-check.yml
+++ b/.github/workflows/catalog-health-check.yml
@@ -1,0 +1,71 @@
+name: MCP Catalog Health Check
+
+on:
+  schedule:
+    - cron: "23 4 * * *"
+  workflow_dispatch:
+    inputs:
+      max_github_repos:
+        description: "Maximum unique GitHub repositories to probe in this run"
+        required: false
+        default: "250"
+      max_issues:
+        description: "Maximum new catalog-health issues to create"
+        required: false
+        default: "5"
+      offset:
+        description: "Optional GitHub repository scan offset"
+        required: false
+        default: ""
+      dry_run:
+        description: "Print findings without creating issues"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: mcp-catalog-health-check
+  cancel-in-progress: false
+
+jobs:
+  health-check:
+    name: Check catalog health
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.MCP_AUTOMATION_TOKEN }}
+      HEALTH_CHECK_MAX_GITHUB_REPOS: ${{ github.event.inputs.max_github_repos || '250' }}
+      HEALTH_CHECK_MAX_ISSUES: ${{ github.event.inputs.max_issues || '5' }}
+      HEALTH_CHECK_OFFSET: ${{ github.event.inputs.offset || '' }}
+      HEALTH_CHECK_DRY_RUN: ${{ github.event.inputs.dry_run == 'true' && '1' || '0' }}
+
+    steps:
+      - name: Check automation token
+        if: env.GITHUB_TOKEN == '' && env.HEALTH_CHECK_DRY_RUN != '1'
+        run: |
+          echo "MCP_AUTOMATION_TOKEN is required so generated issues can trigger downstream triage and report PR workflows."
+          exit 1
+
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate catalog
+        run: npm run catalog:build
+
+      - name: Run catalog health check
+        run: npm run catalog:health

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Choose the path that matches what you want to do.
 
 - Fix duplicate, stale, broken, or poorly categorized entries. Use the [broken entry issue form](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=report-broken-entry.yml) when you want maintainers to triage it; clear reports generate a draft investigation PR so cleanup work can be reviewed and tracked.
 - Add missing metadata that makes search and install generation more accurate.
-- Propose verification signals, health checks, ranking improvements, or better category rules.
+- Propose verification signals, ranking improvements, or better category rules. The catalog health checker also runs on a schedule to flag duplicate primary links, missing GitHub repos, archived repos, and disabled repos as broken-entry reports.
 - Join the [TensorBlock Discord](https://discord.com/invite/Ej5NmeHFf2) to discuss roadmap work before opening a larger PR.
 
 Issue forms are routed automatically. When you submit a server, metadata update, profile claim, client config request, or broken-entry report, the repo adds the right triage labels and posts the next steps so contributors and maintainers can keep the workflow moving. Server submissions with a clear category can generate draft docs PRs, structured metadata updates or profile claims can generate draft metadata PRs, clear client-config requests can generate draft spec PRs, and clear broken-entry reports can generate draft investigation PRs.
@@ -75,6 +75,8 @@ New server entries can be simple, but high-quality metadata makes the profile mu
 - Where are the setup docs, source repo, license, and public endpoint?
 
 After a PR lands on `main`, the deploy workflow rebuilds the catalog and profiles. The hosted API and public profile pages refresh after the Railway deployment succeeds.
+
+The scheduled catalog health check uses the generated catalog to open `catalog-health` issues for duplicate links and stale or unreachable GitHub repositories. Those issues feed back into the same broken-entry report workflow, so cleanup work can become reviewable PRs instead of staying as loose maintainer notes.
 
 ## TensorBlock MCP Index
 

--- a/docs/broken-entry-reports/README.md
+++ b/docs/broken-entry-reports/README.md
@@ -5,3 +5,5 @@ This directory stores generated investigation specs from the broken entry issue 
 Each report captures the affected TensorBlock profile, server id, or project URL, the reported problem types, submitted details, source proof, and a maintainer checklist. Reports keep cleanup work reviewable before maintainers edit category markdown, metadata sidecars, or remove stale entries.
 
 Generated report files are starting points, not final catalog data. After a report is verified, the actual fix should land in the relevant `docs/*.md` category page or `data/server-metadata/*.json` sidecar.
+
+Reports may come from community-submitted broken-entry issues or from the scheduled catalog health check, which flags duplicate primary links and stale or unreachable GitHub repositories.

--- a/docs/index-alpha/contribution-guide.md
+++ b/docs/index-alpha/contribution-guide.md
@@ -38,6 +38,8 @@ When the profile id matches the index and the values are clear, automation draft
 
 For duplicate, stale, broken, unsafe, or poorly categorized entries, use the broken entry issue form with the TensorBlock profile URL, server id, or project URL. Clear reports can generate a draft investigation PR under `docs/broken-entry-reports/` so maintainers can verify the problem before editing catalog docs or metadata sidecars.
 
+TensorBlock also runs a scheduled catalog health check. It scans the generated catalog for duplicate primary links and rotates through indexed GitHub repositories to detect 404, archived, or disabled projects. New findings open `catalog-health` issues that feed into the same broken-entry report workflow.
+
 Complete metadata helps TensorBlock generate:
 
 - server profiles,

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc -p tsconfig.base.json --noEmit",
     "catalog:build": "tsx packages/catalog-builder/src/cli.ts",
+    "catalog:health": "node .github/scripts/check-catalog-health.mjs",
     "profiles:build": "tsx packages/profile-renderer/src/cli.ts",
     "config:generate": "tsx packages/config-generator/src/cli.ts",
     "registry:mcp": "tsx packages/registry-mcp/src/server.ts",


### PR DESCRIPTION
## Summary
- add a scheduled/manual catalog health checker for duplicate primary links and stale GitHub repos
- create catalog-health broken-entry issues with stable markers so reports are not duplicated
- document the proactive cleanup flow in README and contributor docs

## Validation
- node --test .github/scripts/check-catalog-health.test.mjs .github/scripts/create-broken-entry-report-pr.test.mjs .github/scripts/triage-issue.test.mjs .github/scripts/create-client-config-request-pr.test.mjs .github/scripts/create-improve-metadata-pr.test.mjs .github/scripts/create-claim-profile-pr.test.mjs .github/scripts/create-add-server-pr.test.mjs .github/scripts/comment-merged-pr.test.mjs
- npm test
- npm run typecheck
- npm run build
- npm run catalog:build
- HEALTH_CHECK_DRY_RUN=1 npm run catalog:health
- GITHUB_TOKEN=*** HEALTH_CHECK_DRY_RUN=1 HEALTH_CHECK_MAX_GITHUB_REPOS=5 npm run catalog:health
- npm run profiles:build
- node .github/scripts/validate-issue-forms.mjs