### PR TITLE
Add community cleanup queue

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,6 +6,9 @@ contact_links:
   - name: Hosted MCP Index API
     url: https://mcp-index.tensorblock.co
     about: Explore the live API discovery page, search endpoints, profile endpoints, badges, and install-config generation.
+  - name: MCP Index Community Cleanup Queue
+    url: https://github.com/TensorBlock/awesome-mcp-servers/blob/main/docs/community-cleanup-queue.md
+    about: Pick a scoped cleanup task for metadata, broken entries, catalog-health reports, client config requests, or profile claims.
   - name: MCP Index API docs
     url: https://github.com/TensorBlock/awesome-mcp-servers/blob/main/docs/index-api.md
     about: Read the HTTP API docs before building against the index.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ TensorBlock MCP Index turns this community-curated MCP server directory into a h
 
 **Hosted API:** [https://mcp-index.tensorblock.co](https://mcp-index.tensorblock.co)
 
+**Community cleanup queue:** [Help verify and improve indexed MCP servers](docs/community-cleanup-queue.md)
+
 ## MCP Maintainer Quick Start
 
 If you maintain an MCP server, the index can give your project a public profile, install-config previews, API metadata, and a README badge.
@@ -35,6 +37,12 @@ If you maintain an MCP server, the index can give your project a public profile,
 ## Coverage
 
 This repo currently indexes **7,747 unique MCP server links** from the category docs. The README stays lightweight while the full directory lives in `docs/*.md`, `data/catalog.json`, and the registry MCP server.
+
+## Community Cleanup Queue
+
+Want to contribute without adding a new server? Start with the [MCP Index Community Cleanup Queue](docs/community-cleanup-queue.md). It links to live GitHub issue queues for good first metadata fixes, broken entries, catalog-health reports, new server submissions, client config requests, and profile claims.
+
+Cleanup work improves the value of the hosted index: fewer duplicates, fresher source links, better install metadata, clearer categories, and more trustworthy profiles.
 
 ## How to Participate
 
@@ -60,6 +68,7 @@ Choose the path that matches what you want to do.
 
 - Fix duplicate, stale, broken, or poorly categorized entries. Use the [broken entry issue form](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=report-broken-entry.yml) when you want maintainers to triage it; clear reports generate a draft investigation PR so cleanup work can be reviewed and tracked.
 - Add missing metadata that makes search and install generation more accurate.
+- Pick a scoped cleanup task from the [community cleanup queue](docs/community-cleanup-queue.md).
 - Propose verification signals, ranking improvements, or better category rules. The catalog health checker also runs on a schedule to flag duplicate primary links, missing GitHub repos, archived repos, and disabled repos as broken-entry reports.
 - Join the [TensorBlock Discord](https://discord.com/invite/Ej5NmeHFf2) to discuss roadmap work before opening a larger PR.
 

--- a/docs/community-cleanup-queue.md
+++ b/docs/community-cleanup-queue.md
@@ -1,0 +1,83 @@
+# MCP Index Community Cleanup Queue
+
+The cleanup queue is the fastest way to make the TensorBlock MCP Index more useful without adding a brand-new server.
+
+Use it when you want a focused contribution: verify a stale entry, improve metadata, fix a category, close a duplicate, or help turn an automated health finding into a clean PR.
+
+## Open Task Lanes
+
+| Lane | Best for | Queue |
+| --- | --- | --- |
+| Good first metadata | Small install, docs, auth, transport, license, or tool metadata fixes | [Open good-first-metadata issues](https://github.com/TensorBlock/awesome-mcp-servers/issues?q=is%3Aissue%20is%3Aopen%20label%3Agood-first-metadata) |
+| Broken entries | Dead links, duplicate entries, stale projects, bad categories, or unsafe entries | [Open broken-entry issues](https://github.com/TensorBlock/awesome-mcp-servers/issues?q=is%3Aissue%20is%3Aopen%20label%3Abroken-entry) |
+| Catalog health | Automated reports from the scheduled catalog health checker | [Open catalog-health issues](https://github.com/TensorBlock/awesome-mcp-servers/issues?q=is%3Aissue%20is%3Aopen%20label%3Acatalog-health) |
+| Needs triage | New community reports that need routing or verification | [Open needs-triage issues](https://github.com/TensorBlock/awesome-mcp-servers/issues?q=is%3Aissue%20is%3Aopen%20label%3Aneeds-triage) |
+| Server submissions | New MCP server requests that need duplicate checks and category review | [Open server-submission issues](https://github.com/TensorBlock/awesome-mcp-servers/issues?q=is%3Aissue%20is%3Aopen%20label%3Aserver-submission) |
+| Client config requests | New MCP client or install target formats | [Open client-config issues](https://github.com/TensorBlock/awesome-mcp-servers/issues?q=is%3Aissue%20is%3Aopen%20label%3Aclient-config) |
+| Profile claims | Maintainer verification for indexed profiles | [Open claim-profile issues](https://github.com/TensorBlock/awesome-mcp-servers/issues?q=is%3Aissue%20is%3Aopen%20label%3Aclaim-profile) |
+
+## How To Pick A Task
+
+Start with a task that has a clear source link. Good cleanup issues usually include a TensorBlock profile URL, server id, project URL, or generated catalog-health marker.
+
+Before editing, check:
+
+- whether the project URL already appears elsewhere in `docs/*.md`,
+- whether the public project README or docs confirm the proposed change,
+- whether the fix belongs in a category markdown file or `data/server-metadata/*.json`,
+- whether the issue already has an automation-generated draft PR.
+
+Comment on the issue before doing larger cleanup work so two contributors do not handle the same task.
+
+## What To Change
+
+Most cleanup PRs fall into one of these shapes:
+
+- Edit a category page under `docs/*.md` to remove a duplicate, fix a broken link, or move an entry to a better category.
+- Add or update a `data/server-metadata/{serverId}.json` sidecar for install, auth, transport, docs, license, client, tool, maintainer, or verification metadata.
+- Update a generated investigation spec under `docs/broken-entry-reports/` with the maintainer decision.
+- Add client config support after a request spec under `docs/client-config-requests/` is reviewed.
+
+If you are fixing metadata, prefer structured labels in the issue or PR body:
+
+```text
+Install: npx -y example-mcp
+Transport: stdio
+Auth: api-key, requires EXAMPLE_API_KEY
+Docs URL: https://docs.example.com/mcp
+License: MIT
+Tools: search, fetch_profile
+Tool count: 2
+```
+
+## Validation
+
+For docs-only cleanup, run the smallest useful check:
+
+```bash
+npm run catalog:build
+```
+
+For metadata, generator, API, or workflow changes, run:
+
+```bash
+npm run catalog:build
+npm run profiles:build
+npm test
+npm run typecheck
+npm run build
+```
+
+Generated files such as `data/catalog.json`, `data/catalog-errors.json`, and `data/profiles/*.json` are build outputs. Do not include them in a cleanup PR unless a maintainer explicitly asks for generated data.
+
+## Community Flow
+
+The queue is meant to turn drive-by reports into visible contribution opportunities:
+
+- issue forms add route labels and next-step comments,
+- clear reports can create draft PRs,
+- catalog-health issues surface stale or broken entries proactively,
+- merged server PRs post profile, API, install-config, and badge links,
+- cleanup contributors can point maintainers to verified sources instead of leaving loose notes.
+
+Join the [TensorBlock Discord](https://discord.com/invite/Ej5NmeHFf2) when a cleanup decision needs maintainer context or broader community discussion.

--- a/docs/index-alpha/contribution-guide.md
+++ b/docs/index-alpha/contribution-guide.md
@@ -40,6 +40,8 @@ For duplicate, stale, broken, unsafe, or poorly categorized entries, use the bro
 
 TensorBlock also runs a scheduled catalog health check. It scans the generated catalog for duplicate primary links and rotates through indexed GitHub repositories to detect 404, archived, or disabled projects. New findings open `catalog-health` issues that feed into the same broken-entry report workflow.
 
+For scoped community work, start from the [MCP Index Community Cleanup Queue](../community-cleanup-queue.md). It links to live issue queues for good first metadata fixes, broken entries, catalog-health findings, server submissions, client config requests, and profile claims.
+
 Complete metadata helps TensorBlock generate:
 
 - server profiles,


### PR DESCRIPTION
## Summary
- add a community cleanup queue page with live issue links for metadata, broken-entry, catalog-health, server-submission, client-config, and profile-claim work
- surface the cleanup queue from the README and issue template contact links
- connect the metadata contribution guide to the new queue

## Validation
- node .github/scripts/validate-issue-forms.mjs
- npm run catalog:build
- npm test
- npm run typecheck
- npm run build
- npm run profiles:build