### PR TITLE
Add server intake status labels

### DIFF
--- a/.github/scripts/create-add-server-pr.mjs
+++ b/.github/scripts/create-add-server-pr.mjs
@@ -11,6 +11,27 @@ const API_BASE = "https://api.github.com";
 const COMMENT_MARKER = "<!-- tensorblock-mcp-add-server-pr:v1 -->";
 const DEFAULT_BASE_BRANCH = "main";
 
+export const INTAKE_STATUS_LABELS = {
+  "needs-metadata": {
+    color: "F9D0C4",
+    description: "Server submission needs required fields or category routing.",
+  },
+  duplicate: {
+    color: "CFD3D7",
+    description: "Server submission appears to duplicate an existing catalog entry.",
+  },
+  "ready-for-pr": {
+    color: "0E8A16",
+    description: "Server submission has a generated PR ready for maintainer review.",
+  },
+  "automation-blocked": {
+    color: "D93F0B",
+    description: "Automation generated a branch but could not complete the next GitHub action.",
+  },
+};
+
+const INTAKE_STATUS_LABEL_NAMES = Object.keys(INTAKE_STATUS_LABELS);
+
 export const CATEGORY_TO_DOCS_PATH = {
   "AI & LLM Integration": "docs/ai--llm-integration.md",
   "Art, Culture & Media": "docs/art-culture--media.md",
@@ -90,6 +111,33 @@ export function validateSubmission(submission) {
   }
 
   return errors;
+}
+
+export function buildIntakeLabelPlan({ issue = {}, errors = [], duplicate = null, pullRequest = null } = {}) {
+  const existingLabels = new Set(labelNames(issue));
+  let targetLabel = null;
+
+  if (errors.length > 0) {
+    targetLabel = "needs-metadata";
+  } else if (duplicate) {
+    targetLabel = "duplicate";
+  } else if (pullRequest?.blocked) {
+    targetLabel = "automation-blocked";
+  } else if (pullRequest) {
+    targetLabel = "ready-for-pr";
+  }
+
+  if (!targetLabel) {
+    return {
+      add: [],
+      remove: [],
+    };
+  }
+
+  return {
+    add: existingLabels.has(targetLabel) ? [] : [targetLabel],
+    remove: INTAKE_STATUS_LABEL_NAMES.filter((label) => label !== targetLabel && existingLabels.has(label)).sort(),
+  };
 }
 
 export function buildMarkdownEntry(submission) {
@@ -552,6 +600,7 @@ async function main() {
   const errors = validateSubmission(submission);
 
   if (errors.length > 0) {
+    await applyIntakeLabelPlan(request, issue.number, buildIntakeLabelPlan({ issue, errors }));
     await upsertIssueComment(request, issue.number, buildIssueComment({ issue, submission, errors }));
     console.log(`Issue #${issue.number} cannot be converted to a draft PR: ${errors.join(" ")}`);
     return;
@@ -559,6 +608,7 @@ async function main() {
 
   const duplicate = findDuplicateByUrl(submission.projectUrl);
   if (duplicate) {
+    await applyIntakeLabelPlan(request, issue.number, buildIntakeLabelPlan({ issue, duplicate }));
     await upsertIssueComment(request, issue.number, buildIssueComment({ issue, submission, duplicate }));
     console.log(`Issue #${issue.number} matches an existing entry at ${duplicate.path}:${duplicate.line}.`);
     return;
@@ -602,17 +652,27 @@ async function main() {
     }
 
     const compareUrl = `https://github.com/${owner}/${repo}/compare/${DEFAULT_BASE_BRANCH}...${branch}?expand=1`;
+    const blockedPullRequest = {
+      blocked: true,
+      branch,
+      compareUrl,
+    };
+
+    await applyIntakeLabelPlan(
+      request,
+      issue.number,
+      buildIntakeLabelPlan({
+        issue,
+        pullRequest: blockedPullRequest,
+      }),
+    );
     await upsertIssueComment(
       request,
       issue.number,
       buildIssueComment({
         issue,
         submission,
-        pullRequest: {
-          blocked: true,
-          branch,
-          compareUrl,
-        },
+        pullRequest: blockedPullRequest,
       }),
     );
     console.log(`Generated branch ${branch} for issue #${issue.number}, but Actions cannot create pull requests.`);
@@ -620,6 +680,7 @@ async function main() {
     return;
   }
 
+  await applyIntakeLabelPlan(request, issue.number, buildIntakeLabelPlan({ issue, pullRequest }));
   await upsertIssueComment(request, issue.number, buildIssueComment({ issue, submission, pullRequest }));
   console.log(`Created or updated draft PR ${pullRequest.html_url} for issue #${issue.number}.`);
 }
@@ -690,6 +751,61 @@ async function createOrUpdatePullRequest(request, { owner, branch, title, body }
       maintainer_can_modify: true,
     },
   });
+}
+
+function labelNames(issue) {
+  return (issue.labels ?? []).map((label) => (typeof label === "string" ? label : label.name)).filter(Boolean);
+}
+
+async function applyIntakeLabelPlan(request, issueNumber, plan) {
+  await ensureIntakeLabels(request, plan.add);
+
+  for (const label of plan.remove) {
+    try {
+      await request(`/issues/${issueNumber}/labels/${encodeURIComponent(label)}`, {
+        method: "DELETE",
+      });
+    } catch (error) {
+      if (error.status !== 404) {
+        throw error;
+      }
+    }
+  }
+
+  if (plan.add.length > 0) {
+    await request(`/issues/${issueNumber}/labels`, {
+      method: "POST",
+      body: {
+        labels: plan.add,
+      },
+    });
+  }
+}
+
+async function ensureIntakeLabels(request, labels) {
+  for (const label of labels) {
+    const definition = INTAKE_STATUS_LABELS[label];
+    if (!definition) {
+      continue;
+    }
+
+    try {
+      await request(`/labels/${encodeURIComponent(label)}`);
+    } catch (error) {
+      if (error.status !== 404) {
+        throw error;
+      }
+
+      await request("/labels", {
+        method: "POST",
+        body: {
+          name: label,
+          color: definition.color,
+          description: definition.description,
+        },
+      });
+    }
+  }
 }
 
 function isPullRequestCreationBlocked(error) {

--- a/.github/scripts/create-add-server-pr.test.mjs
+++ b/.github/scripts/create-add-server-pr.test.mjs
@@ -6,11 +6,13 @@ import test from "node:test";
 
 import {
   buildIssueComment,
+  buildIntakeLabelPlan,
   buildPrBody,
   buildMetadataSidecar,
   buildMarkdownEntry,
   docPathForCategory,
   findDuplicateByUrl,
+  INTAKE_STATUS_LABELS,
   parseAddServerIssue,
   validateSubmission,
 } from "./create-add-server-pr.mjs";
@@ -355,4 +357,65 @@ test("builds issue comment when Actions cannot create a pull request", () => {
   assert.match(comment, /could not open the draft PR automatically/);
   assert.match(comment, /mcp\/add-server-issue-123/);
   assert.match(comment, /compare\/main\.\.\.mcp\/add-server-issue-123/);
+});
+
+test("plans needs-metadata label for incomplete server submissions", () => {
+  const plan = buildIntakeLabelPlan({
+    issue: {
+      labels: ["server-submission", "ready-for-pr", "duplicate"],
+    },
+    errors: ["Project URL is required."],
+  });
+
+  assert.equal(
+    INTAKE_STATUS_LABELS["needs-metadata"].description,
+    "Server submission needs required fields or category routing.",
+  );
+  assert.deepEqual(plan.add, ["needs-metadata"]);
+  assert.deepEqual(plan.remove, ["duplicate", "ready-for-pr"]);
+});
+
+test("plans duplicate label when the submitted project URL already exists", () => {
+  const plan = buildIntakeLabelPlan({
+    issue: {
+      labels: ["server-submission", "needs-metadata"],
+    },
+    duplicate: {
+      path: "docs/databases.md",
+      line: 42,
+      entry: "- [owner/example](https://github.com/owner/example): Existing.",
+    },
+  });
+
+  assert.deepEqual(plan.add, ["duplicate"]);
+  assert.deepEqual(plan.remove, ["needs-metadata"]);
+});
+
+test("plans automation-blocked label when a branch is generated but no PR can be opened", () => {
+  const plan = buildIntakeLabelPlan({
+    issue: {
+      labels: ["server-submission", "needs-metadata"],
+    },
+    pullRequest: {
+      blocked: true,
+      branch: "mcp/add-server-issue-123",
+    },
+  });
+
+  assert.deepEqual(plan.add, ["automation-blocked"]);
+  assert.deepEqual(plan.remove, ["needs-metadata"]);
+});
+
+test("plans ready-for-pr label when a draft PR is created", () => {
+  const plan = buildIntakeLabelPlan({
+    issue: {
+      labels: ["server-submission", "needs-metadata", "automation-blocked"],
+    },
+    pullRequest: {
+      html_url: "https://github.com/TensorBlock/awesome-mcp-servers/pull/999",
+    },
+  });
+
+  assert.deepEqual(plan.add, ["ready-for-pr"]);
+  assert.deepEqual(plan.remove, ["automation-blocked", "needs-metadata"]);
 });

--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ Choose the path that matches what you want to do.
 
 Issue forms are routed automatically. When you submit a server, metadata update, profile claim, client config request, or broken-entry report, the repo adds the right triage labels and posts the next steps so contributors and maintainers can keep the workflow moving. Server submissions with a clear category can generate draft docs PRs, structured metadata updates or profile claims can generate draft metadata PRs, clear client-config requests can generate draft spec PRs, and clear broken-entry reports can generate draft investigation PRs.
 
+New server submissions also get intake status labels so the queue is easier to review at scale:
+
+- `needs-metadata` means required fields, a valid project URL, or category routing still need contributor/maintainer input.
+- `duplicate` means the submitted project URL already appears in the catalog.
+- `ready-for-pr` means automation created or updated a draft docs PR for maintainer review.
+- `automation-blocked` means automation generated a branch but GitHub permissions blocked PR creation.
+
 New server entries can be simple, but high-quality metadata makes the profile much more useful. The best entries answer:
 
 - What can an agent do with this server?

--- a/docs/community-cleanup-queue.md
+++ b/docs/community-cleanup-queue.md
@@ -13,6 +13,9 @@ Use it when you want a focused contribution: verify a stale entry, improve metad
 | Catalog health | Automated reports from the scheduled catalog health checker | [Open catalog-health issues](https://github.com/TensorBlock/awesome-mcp-servers/issues?q=is%3Aissue%20is%3Aopen%20label%3Acatalog-health) |
 | Needs triage | New community reports that need routing or verification | [Open needs-triage issues](https://github.com/TensorBlock/awesome-mcp-servers/issues?q=is%3Aissue%20is%3Aopen%20label%3Aneeds-triage) |
 | Server submissions | New MCP server requests that need duplicate checks and category review | [Open server-submission issues](https://github.com/TensorBlock/awesome-mcp-servers/issues?q=is%3Aissue%20is%3Aopen%20label%3Aserver-submission) |
+| Needs metadata | Server submissions missing required fields or category routing | [Open needs-metadata submissions](https://github.com/TensorBlock/awesome-mcp-servers/issues?q=is%3Aissue%20is%3Aopen%20label%3Aserver-submission%20label%3Aneeds-metadata) |
+| Ready server PRs | Server submissions with automation-generated PRs ready for maintainer review | [Open ready-for-pr submissions](https://github.com/TensorBlock/awesome-mcp-servers/issues?q=is%3Aissue%20is%3Aopen%20label%3Aserver-submission%20label%3Aready-for-pr) |
+| Duplicate submissions | Server submissions matching an existing project URL | [Open duplicate submissions](https://github.com/TensorBlock/awesome-mcp-servers/issues?q=is%3Aissue%20is%3Aopen%20label%3Aserver-submission%20label%3Aduplicate) |
 | Client config requests | New MCP client or install target formats | [Open client-config issues](https://github.com/TensorBlock/awesome-mcp-servers/issues?q=is%3Aissue%20is%3Aopen%20label%3Aclient-config) |
 | Profile claims | Maintainer verification for indexed profiles | [Open claim-profile issues](https://github.com/TensorBlock/awesome-mcp-servers/issues?q=is%3Aissue%20is%3Aopen%20label%3Aclaim-profile) |
 
@@ -26,6 +29,13 @@ Before editing, check:
 - whether the public project README or docs confirm the proposed change,
 - whether the fix belongs in a category markdown file or `data/server-metadata/*.json`,
 - whether the issue already has an automation-generated draft PR.
+
+For server submissions, use the intake labels to pick the next action:
+
+- `needs-metadata`: ask for the missing URL, category, or description before editing docs.
+- `duplicate`: close or link to the existing entry unless the submitter shows it is a distinct MCP server.
+- `ready-for-pr`: review the generated draft PR instead of hand-editing the issue.
+- `automation-blocked`: open the PR from the generated branch or fix workflow permissions, then rerun by editing the issue.
 
 Comment on the issue before doing larger cleanup work so two contributors do not handle the same task.
 

--- a/docs/index-alpha/contribution-guide.md
+++ b/docs/index-alpha/contribution-guide.md
@@ -22,6 +22,13 @@ When adding a server, include as much of this metadata as possible in the issue 
 
 For short markdown entries, structured metadata can live in `data/server-metadata/{serverId}.json`. Server submissions created through the Add MCP server issue form can generate this sidecar automatically, so the category page stays readable while the profile/API still get install, transport, auth, client, and license fields.
 
+Server submission issues are automatically tagged with intake status labels:
+
+- `needs-metadata`: required fields, URL validation, or category routing still need attention.
+- `duplicate`: the submitted project URL already matches an existing catalog entry.
+- `ready-for-pr`: automation created or updated a draft docs PR for maintainer review.
+- `automation-blocked`: automation generated a branch, but GitHub permissions blocked PR creation.
+
 For existing indexed servers, use the metadata improvement issue form with the TensorBlock profile id and structured values such as:
 
 ```text


### PR DESCRIPTION
## Summary
- Add server-submission intake status labels: needs-metadata, duplicate, ready-for-pr, automation-blocked
- Update the add-server automation to reconcile stale status labels when validation, duplicate detection, PR creation, or PR-blocked states change
- Document the new queues in the README, contribution guide, and community cleanup queue

## Tests
- node --test .github/scripts/create-add-server-pr.test.mjs
- node --test .github/scripts/*.test.mjs
- node .github/scripts/validate-issue-forms.mjs
- npm test
- npm run typecheck
- npm run build