### PR TITLE
Add batch server intake refresh

### DIFF
--- a/.github/scripts/refresh-add-server-intake.mjs
+++ b/.github/scripts/refresh-add-server-intake.mjs
@@ -1,0 +1,244 @@
+#!/usr/bin/env node
+
+import { fileURLToPath } from "node:url";
+import {
+  buildIntakeLabelPlan,
+  findDuplicateByUrl,
+  INTAKE_STATUS_LABELS,
+  parseAddServerIssue,
+  validateSubmission,
+} from "./create-add-server-pr.mjs";
+
+const API_BASE = "https://api.github.com";
+const COMMENT_MARKER = "<!-- tensorblock-mcp-add-server-pr:v1 -->";
+const SERVER_SUBMISSION_LABEL = "server-submission";
+
+export function classifyAddServerIssue({ issue, docsDir = "docs", comments = [], pullRequests = [] }) {
+  const submission = parseAddServerIssue(issue.body ?? "");
+  const errors = validateSubmission(submission);
+  const duplicate = errors.length > 0 ? null : findDuplicateByUrl(submission.projectUrl, docsDir);
+  const pullRequest = errors.length > 0 || duplicate ? null : findGeneratedPullRequest(issue.number, comments, pullRequests);
+  const statusLabel = statusLabelFor({ errors, duplicate, pullRequest });
+  const plan = buildIntakeLabelPlan({ issue, errors, duplicate, pullRequest });
+
+  return {
+    issue,
+    submission,
+    errors,
+    duplicate,
+    pullRequest,
+    statusLabel,
+    plan,
+  };
+}
+
+export async function applyRefreshResult(request, result, { dryRun = true } = {}) {
+  if (dryRun || (result.plan.add.length === 0 && result.plan.remove.length === 0)) {
+    return false;
+  }
+
+  await ensureIntakeLabels(request, result.plan.add);
+
+  for (const label of result.plan.remove) {
+    try {
+      await request(`/issues/${result.issue.number}/labels/${encodeURIComponent(label)}`, {
+        method: "DELETE",
+      });
+    } catch (error) {
+      if (error.status !== 404) {
+        throw error;
+      }
+    }
+  }
+
+  if (result.plan.add.length > 0) {
+    await request(`/issues/${result.issue.number}/labels`, {
+      method: "POST",
+      body: {
+        labels: result.plan.add,
+      },
+    });
+  }
+
+  return true;
+}
+
+export function summarizeRefreshResults(results) {
+  const lines = [`${results.length} server submissions inspected.`];
+
+  for (const result of results) {
+    lines.push(
+      [
+        `#${result.issue.number}`,
+        result.statusLabel ?? "no-status",
+        `add=${formatLabels(result.plan.add)}`,
+        `remove=${formatLabels(result.plan.remove)}`,
+        result.issue.title,
+      ].join(" "),
+    );
+  }
+
+  return lines.join("\n");
+}
+
+function statusLabelFor({ errors, duplicate, pullRequest }) {
+  if (errors.length > 0) {
+    return "needs-metadata";
+  }
+
+  if (duplicate) {
+    return "duplicate";
+  }
+
+  if (pullRequest?.blocked) {
+    return "automation-blocked";
+  }
+
+  if (pullRequest) {
+    return "ready-for-pr";
+  }
+
+  return null;
+}
+
+function findGeneratedPullRequest(issueNumber, comments, pullRequests) {
+  const generatedBranch = `mcp/add-server-issue-${issueNumber}`;
+  const openPullRequest = pullRequests.find((pullRequest) => pullRequest.head?.ref === generatedBranch);
+
+  if (openPullRequest) {
+    return openPullRequest;
+  }
+
+  const automationComment = comments.find((comment) => comment.body?.includes(COMMENT_MARKER));
+  if (!automationComment) {
+    return null;
+  }
+
+  if (/could not open the draft PR automatically/i.test(automationComment.body)) {
+    return {
+      blocked: true,
+      branch: generatedBranch,
+    };
+  }
+
+  const pullRequestUrl = automationComment.body.match(/https:\/\/github\.com\/[^\s)]+\/pull\/\d+/)?.[0];
+  return pullRequestUrl ? { html_url: pullRequestUrl } : null;
+}
+
+async function ensureIntakeLabels(request, labels) {
+  for (const label of labels) {
+    const definition = INTAKE_STATUS_LABELS[label];
+    if (!definition) {
+      continue;
+    }
+
+    try {
+      await request(`/labels/${encodeURIComponent(label)}`);
+    } catch (error) {
+      if (error.status !== 404) {
+        throw error;
+      }
+
+      await request("/labels", {
+        method: "POST",
+        body: {
+          name: label,
+          color: definition.color,
+          description: definition.description,
+        },
+      });
+    }
+  }
+}
+
+async function main() {
+  const token = process.env.GITHUB_TOKEN;
+  const repository = process.env.GITHUB_REPOSITORY;
+
+  if (!token || !repository) {
+    throw new Error("GITHUB_TOKEN and GITHUB_REPOSITORY are required.");
+  }
+
+  const dryRun = parseBoolean(process.env.INPUT_DRY_RUN ?? "true");
+  const limit = Number.parseInt(process.env.INPUT_LIMIT ?? "100", 10);
+  const issueNumber = process.env.INPUT_ISSUE_NUMBER ? Number.parseInt(process.env.INPUT_ISSUE_NUMBER, 10) : null;
+  const [owner, repo] = repository.split("/");
+  const request = createGitHubRequest({ token, owner, repo });
+  const issues = issueNumber
+    ? [await request(`/issues/${issueNumber}`)]
+    : await listServerSubmissionIssues(request, { limit });
+  const pullRequests = await request("/pulls?state=open&per_page=100");
+  const results = [];
+
+  for (const issue of issues) {
+    const comments = await request(`/issues/${issue.number}/comments?per_page=100`);
+    const result = classifyAddServerIssue({ issue, comments, pullRequests });
+    await applyRefreshResult(request, result, { dryRun });
+    results.push(result);
+  }
+
+  console.log(dryRun ? "Dry run only. No labels were changed." : "Applied intake label refresh.");
+  console.log(summarizeRefreshResults(results));
+}
+
+async function listServerSubmissionIssues(request, { limit }) {
+  const issues = [];
+  let page = 1;
+
+  while (issues.length < limit) {
+    const pageIssues = await request(
+      `/issues?state=open&labels=${encodeURIComponent(SERVER_SUBMISSION_LABEL)}&per_page=100&page=${page}`,
+    );
+
+    if (pageIssues.length === 0) {
+      break;
+    }
+
+    issues.push(...pageIssues.filter((issue) => !issue.pull_request));
+    page += 1;
+  }
+
+  return issues.slice(0, limit);
+}
+
+function createGitHubRequest({ token, owner, repo }) {
+  return async function request(pathname, options = {}) {
+    const response = await fetch(`${API_BASE}/repos/${owner}/${repo}${pathname}`, {
+      method: options.method ?? "GET",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      body: options.body ? JSON.stringify(options.body) : undefined,
+    });
+
+    const text = await response.text();
+    const data = text ? JSON.parse(text) : null;
+
+    if (!response.ok) {
+      const error = new Error(`GitHub API ${options.method ?? "GET"} ${pathname} failed: ${response.status}`);
+      error.status = response.status;
+      error.data = data;
+      throw error;
+    }
+
+    return data;
+  };
+}
+
+function parseBoolean(value) {
+  return /^(1|true|yes)$/i.test(String(value));
+}
+
+function formatLabels(labels) {
+  return labels.length > 0 ? labels.join(",") : "-";
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/.github/scripts/refresh-add-server-intake.test.mjs
+++ b/.github/scripts/refresh-add-server-intake.test.mjs
@@ -1,0 +1,212 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  applyRefreshResult,
+  classifyAddServerIssue,
+  summarizeRefreshResults,
+} from "./refresh-add-server-intake.mjs";
+
+function issueBody({ url = "https://github.com/owner/example-mcp", category = "Databases" } = {}) {
+  return [
+    "### Server name",
+    "",
+    "owner/example-mcp",
+    "",
+    "### Project URL",
+    "",
+    url,
+    "",
+    "### Best category",
+    "",
+    category,
+    "",
+    "### What can an agent do with this server?",
+    "",
+    "Lets agents inspect example database schemas",
+  ].join("\n");
+}
+
+function issue(overrides = {}) {
+  return {
+    number: 123,
+    title: "Add MCP server: owner/example-mcp",
+    body: issueBody(),
+    labels: ["server-submission"],
+    html_url: "https://github.com/TensorBlock/awesome-mcp-servers/issues/123",
+    ...overrides,
+  };
+}
+
+test("classifies incomplete server submissions as needs-metadata", () => {
+  const result = classifyAddServerIssue({
+    issue: issue({
+      body: [
+        "### Server name",
+        "",
+        "owner/example-mcp",
+        "",
+        "### Best category",
+        "",
+        "Databases",
+        "",
+        "### What can an agent do with this server?",
+        "",
+        "Lets agents inspect example database schemas",
+      ].join("\n"),
+      labels: ["server-submission", "ready-for-pr"],
+    }),
+  });
+
+  assert.equal(result.statusLabel, "needs-metadata");
+  assert.deepEqual(result.errors, ["Project URL is required."]);
+  assert.deepEqual(result.plan, {
+    add: ["needs-metadata"],
+    remove: ["ready-for-pr"],
+  });
+});
+
+test("classifies duplicate server submissions from docs", () => {
+  const docsDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-docs-"));
+  fs.writeFileSync(
+    path.join(docsDir, "databases.md"),
+    "- [owner/example-mcp](https://github.com/owner/example-mcp): Existing entry.\n",
+  );
+
+  const result = classifyAddServerIssue({
+    docsDir,
+    issue: issue({
+      labels: ["server-submission", "needs-metadata"],
+    }),
+  });
+
+  assert.equal(result.statusLabel, "duplicate");
+  assert.equal(result.duplicate.path, path.join(docsDir, "databases.md"));
+  assert.deepEqual(result.plan, {
+    add: ["duplicate"],
+    remove: ["needs-metadata"],
+  });
+});
+
+test("classifies submissions with generated open PRs as ready-for-pr", () => {
+  const result = classifyAddServerIssue({
+    issue: issue({
+      number: 456,
+      labels: ["server-submission", "needs-metadata", "automation-blocked"],
+    }),
+    pullRequests: [
+      {
+        html_url: "https://github.com/TensorBlock/awesome-mcp-servers/pull/999",
+        head: {
+          ref: "mcp/add-server-issue-456",
+        },
+      },
+    ],
+  });
+
+  assert.equal(result.statusLabel, "ready-for-pr");
+  assert.equal(result.pullRequest.html_url, "https://github.com/TensorBlock/awesome-mcp-servers/pull/999");
+  assert.deepEqual(result.plan, {
+    add: ["ready-for-pr"],
+    remove: ["automation-blocked", "needs-metadata"],
+  });
+});
+
+test("dry-run refresh does not call GitHub label APIs", async () => {
+  const calls = [];
+  const request = async (pathname, options = {}) => {
+    calls.push({ pathname, options });
+    return {};
+  };
+
+  const result = classifyAddServerIssue({
+    issue: issue({
+      body: issueBody({ url: "" }),
+      labels: ["server-submission"],
+    }),
+  });
+
+  const applied = await applyRefreshResult(request, result, { dryRun: true });
+
+  assert.equal(applied, false);
+  assert.deepEqual(calls, []);
+});
+
+test("apply refresh creates missing status labels and reconciles stale labels", async () => {
+  const calls = [];
+  const request = async (pathname, options = {}) => {
+    calls.push({ pathname, options });
+    if (pathname === "/labels/needs-metadata") {
+      const error = new Error("Missing label");
+      error.status = 404;
+      throw error;
+    }
+
+    return {};
+  };
+
+  const result = classifyAddServerIssue({
+    issue: issue({
+      body: issueBody({ url: "" }),
+      labels: ["server-submission", "ready-for-pr"],
+    }),
+  });
+
+  const applied = await applyRefreshResult(request, result, { dryRun: false });
+
+  assert.equal(applied, true);
+  assert.deepEqual(calls, [
+    {
+      pathname: "/labels/needs-metadata",
+      options: {},
+    },
+    {
+      pathname: "/labels",
+      options: {
+        method: "POST",
+        body: {
+          name: "needs-metadata",
+          color: "F9D0C4",
+          description: "Server submission needs required fields or category routing.",
+        },
+      },
+    },
+    {
+      pathname: "/issues/123/labels/ready-for-pr",
+      options: {
+        method: "DELETE",
+      },
+    },
+    {
+      pathname: "/issues/123/labels",
+      options: {
+        method: "POST",
+        body: {
+          labels: ["needs-metadata"],
+        },
+      },
+    },
+  ]);
+});
+
+test("summarizes refresh results for workflow logs", () => {
+  const summary = summarizeRefreshResults([
+    {
+      issue: { number: 1, title: "Add MCP server: missing" },
+      statusLabel: "needs-metadata",
+      plan: { add: ["needs-metadata"], remove: [] },
+    },
+    {
+      issue: { number: 2, title: "Add MCP server: ready" },
+      statusLabel: "ready-for-pr",
+      plan: { add: [], remove: [] },
+    },
+  ]);
+
+  assert.match(summary, /2 server submissions inspected/);
+  assert.match(summary, /#1 needs-metadata add=needs-metadata remove=- Add MCP server: missing/);
+  assert.match(summary, /#2 ready-for-pr add=- remove=- Add MCP server: ready/);
+});

--- a/.github/workflows/refresh-add-server-intake.yml
+++ b/.github/workflows/refresh-add-server-intake.yml
@@ -1,0 +1,54 @@
+name: MCP Add Server Intake Refresh
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Preview label changes without mutating issues."
+        required: true
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      issue_number:
+        description: "Optional single issue number to refresh."
+        required: false
+        type: string
+      limit:
+        description: "Maximum open server-submission issues to inspect."
+        required: true
+        default: "100"
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: mcp-add-server-intake-refresh
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    name: Refresh add-server issue status labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Refresh intake labels
+        run: node .github/scripts/refresh-add-server-intake.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.MCP_AUTOMATION_TOKEN || github.token }}
+          INPUT_DRY_RUN: ${{ inputs.dry_run }}
+          INPUT_ISSUE_NUMBER: ${{ inputs.issue_number }}
+          INPUT_LIMIT: ${{ inputs.limit }}

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ New server submissions also get intake status labels so the queue is easier to r
 - `ready-for-pr` means automation created or updated a draft docs PR for maintainer review.
 - `automation-blocked` means automation generated a branch but GitHub permissions blocked PR creation.
 
+Maintainers can run **MCP Add Server Intake Refresh** from GitHub Actions to backfill or repair these labels across open server submissions. Run it with `dry_run=true` first to preview changes, then rerun with `dry_run=false` to apply them.
+
 New server entries can be simple, but high-quality metadata makes the profile much more useful. The best entries answer:
 
 - What can an agent do with this server?

--- a/docs/community-cleanup-queue.md
+++ b/docs/community-cleanup-queue.md
@@ -37,6 +37,8 @@ For server submissions, use the intake labels to pick the next action:
 - `ready-for-pr`: review the generated draft PR instead of hand-editing the issue.
 - `automation-blocked`: open the PR from the generated branch or fix workflow permissions, then rerun by editing the issue.
 
+Maintainers can backfill these labels with the **MCP Add Server Intake Refresh** workflow. Use `dry_run=true` to inspect the planned changes across open `server-submission` issues, then rerun with `dry_run=false` to apply the labels. Set `issue_number` when you only want to refresh one issue.
+
 Comment on the issue before doing larger cleanup work so two contributors do not handle the same task.
 
 ## What To Change

--- a/docs/index-alpha/contribution-guide.md
+++ b/docs/index-alpha/contribution-guide.md
@@ -29,6 +29,8 @@ Server submission issues are automatically tagged with intake status labels:
 - `ready-for-pr`: automation created or updated a draft docs PR for maintainer review.
 - `automation-blocked`: automation generated a branch, but GitHub permissions blocked PR creation.
 
+The manual **MCP Add Server Intake Refresh** workflow can backfill these labels for old open submissions. It defaults to dry-run mode so maintainers can inspect the planned label changes before applying them.
+
 For existing indexed servers, use the metadata improvement issue form with the TensorBlock profile id and structured values such as:
 
 ```text


### PR DESCRIPTION
## Summary
- Add a manual MCP Add Server Intake Refresh workflow for old open server-submission issues
- Add a refresh script that classifies submissions as needs-metadata, duplicate, ready-for-pr, automation-blocked, or no-status
- Default the workflow to dry-run mode and document how maintainers can apply label backfills safely

## Tests
- node --test .github/scripts/refresh-add-server-intake.test.mjs
- node --test .github/scripts/*.test.mjs
- node .github/scripts/validate-issue-forms.mjs
- npm test
- npm run typecheck
- npm run build
- Local dry run with live GitHub data: inspected 0 open server-submission issues; no labels changed