### PR TITLE
Investigate broken MCP entry report #775

### DIFF
--- a/docs/broken-entry-reports/775-github-austin-thesing-remote-mcp-server-test.md
+++ b/docs/broken-entry-reports/775-github-austin-thesing-remote-mcp-server-test.md
@@ -1,0 +1,39 @@
+# Broken entry report: https://github.com/austin-thesing/remote-mcp-server-test
+
+Status: needs verification
+Source issue: https://github.com/TensorBlock/awesome-mcp-servers/issues/775
+
+## Entry Reference
+
+https://github.com/austin-thesing/remote-mcp-server-test
+
+## Normalized Server Id
+
+Not available
+
+## Reported Issue Types
+
+- Dead link
+
+## Details
+
+GitHub API returned 404 for https://github.com/austin-thesing/remote-mcp-server-test.
+
+Indexed server id: github-austin-thesing-remote-mcp-server-test-e8795bb9
+Name: austin-thesing/remote-mcp-server-test
+Category: Developer Productivity & Utilities
+Source docs: docs/developer-productivity--utilities.md
+
+A maintainer should verify whether the project moved, became private, or should be removed from the catalog.
+
+## Source Or Proof
+
+https://github.com/austin-thesing/remote-mcp-server-test
+
+## Maintainer checklist
+
+- Verify the report against the indexed profile, source project, and generated API profile.
+- Check whether the fix belongs in a category markdown entry, metadata sidecar, or removal PR.
+- Search the repo for duplicate project URLs before changing category docs.
+- For safety or security concerns, verify with source links before exposing the profile as healthy.
+- Close the source issue after the fix, removal, or no-action decision is merged.


### PR DESCRIPTION
## Summary
- capture broken-entry report for `https://github.com/austin-thesing/remote-mcp-server-test`
- add structured investigation spec at `docs/broken-entry-reports/775-github-austin-thesing-remote-mcp-server-test.md`
- keep the report reviewable before editing catalog docs or metadata sidecars

## Reported issue types
- Dead link

## Details

```text
GitHub API returned 404 for https://github.com/austin-thesing/remote-mcp-server-test.

Indexed server id: github-austin-thesing-remote-mcp-server-test-e8795bb9
Name: austin-thesing/remote-mcp-server-test
Category: Developer Productivity & Utilities
Source docs: docs/developer-productivity--utilities.md

A maintainer should verify whether the project moved, became private, or should be removed from the catalog.
```

## Source or proof
https://github.com/austin-thesing/remote-mcp-server-test

## Generated report

`docs/broken-entry-reports/775-github-austin-thesing-remote-mcp-server-test.md`

https://github.com/TensorBlock/awesome-mcp-servers/issues/775

Closes #775