### PR TITLE
Add recent and updated MCP server endpoints

### DIFF
--- a/.github/workflows/catalog-health-check.yml
+++ b/.github/workflows/catalog-health-check.yml
@@ -54,6 +54,8 @@ jobs:
 
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/deploy-registry-api.yml
+++ b/.github/workflows/deploy-registry-api.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ Useful endpoints:
 - `GET /v1/categories` - list categories with entry counts and source docs.
 - `GET /v1/servers?query=postgres&limit=5` - search servers by name, description, category, or URL.
 - `GET /v1/servers?category=Databases&transport=stdio` - filter by category, transport, auth type, and result limit.
+- `GET /v1/servers/recent?limit=12` - list recently added servers using git-derived catalog timestamps.
+- `GET /v1/servers/updated?limit=12` - list recently updated entries using git-derived catalog timestamps.
 - `GET /v1/servers/{id}` - fetch the normalized profile for one MCP server.
 - `GET /v1/servers/{id}/badge.svg` - render a TensorBlock MCP Index badge for project READMEs.
 - `GET /v1/servers/{id}/install-config?client=claude-desktop` - generate an MCP client config for Claude Desktop, Cursor, Codex, or VS Code.
@@ -131,6 +133,7 @@ What the API supports today:
 
 - Search MCP servers by keyword.
 - Filter by category, transport, auth type, and result limit.
+- Browse recently added and recently updated servers.
 - Browse all categories with entry counts.
 - Fetch a normalized server profile by stable server id.
 - Generate install-config previews for Claude Desktop, Cursor, Codex, and VS Code.

--- a/docs/index-api.md
+++ b/docs/index-api.md
@@ -16,6 +16,8 @@ GET /health
 GET /v1
 GET /v1/categories
 GET /v1/servers?query=&category=&transport=&auth=&limit=
+GET /v1/servers/recent?limit=
+GET /v1/servers/updated?limit=
 GET /v1/servers/{id}
 GET /v1/servers/{id}/badge.svg
 GET /v1/servers/{id}/install-config?client=claude-desktop|cursor|codex|vscode
@@ -40,6 +42,20 @@ Filter by category and transport:
 ```bash
 curl "$MCP_INDEX_API_URL/v1/servers?category=Databases&transport=stdio"
 ```
+
+Fetch recently added servers:
+
+```bash
+curl "$MCP_INDEX_API_URL/v1/servers/recent?limit=12"
+```
+
+Fetch recently updated catalog entries:
+
+```bash
+curl "$MCP_INDEX_API_URL/v1/servers/updated?limit=12"
+```
+
+Server summaries include `sourcePullRequest` when known and `lastUpdatedAt` when the catalog builder can derive it from git history. The `recent` and `updated` collections sort by `lastUpdatedAt`, using source pull request numbers as an additional ordering signal when timestamps tie.
 
 Fetch a full server profile:
 

--- a/packages/catalog-builder/src/buildCatalog.ts
+++ b/packages/catalog-builder/src/buildCatalog.ts
@@ -1,4 +1,10 @@
-import type { CatalogBuildError, CatalogEntry, CatalogMetadataOverride, ParsedMarkdownEntry } from "./types.js";
+import type {
+  CatalogBuildError,
+  CatalogEntry,
+  CatalogMetadataOverride,
+  CatalogSourceMetadata,
+  ParsedMarkdownEntry,
+} from "./types.js";
 import { CATEGORY_TO_DOCS_PATH } from "./category-map.js";
 import { parseMarkdownEntries, slugFromUrl } from "./parseMarkdown.js";
 
@@ -22,6 +28,7 @@ export function buildCatalogFromMarkdown(
   readmeMarkdown: string,
   docsByPath: Map<string, string>,
   metadataById: Map<string, CatalogMetadataOverride> = new Map(),
+  sourceMetadataByLocation: Map<string, CatalogSourceMetadata> = new Map(),
 ): CatalogBuildResult {
   const readmeEntries = parseMarkdownEntries(readmeMarkdown, "README.md");
   const docsEntries = parseDocsEntries(docsByPath);
@@ -51,6 +58,7 @@ export function buildCatalogFromMarkdown(
       docsEntry.entry.sourcePath,
       readmeEntriesByUrl.has(docsEntry.normalizedUrl),
       metadataById.get(id),
+      sourceMetadataByLocation.get(locationKey(docsEntry.entry)),
     ));
   }
 
@@ -74,7 +82,14 @@ export function buildCatalogFromMarkdown(
 
     const normalizedEntry = { entry: readmeEntry, normalizedUrl };
     seenUrls.set(normalizedUrl, normalizedEntry);
-    entries.push(toCatalogEntry(readmeEntry, id, null, true, metadataById.get(id)));
+    entries.push(toCatalogEntry(
+      readmeEntry,
+      id,
+      null,
+      true,
+      metadataById.get(id),
+      sourceMetadataByLocation.get(locationKey(readmeEntry)),
+    ));
   }
 
   return { entries, errors };
@@ -157,6 +172,7 @@ function toCatalogEntry(
   docsPath: string | null,
   featuredInReadme: boolean,
   metadata: CatalogMetadataOverride | undefined,
+  sourceMetadata: CatalogSourceMetadata | undefined,
 ): CatalogEntry {
   const repo = isGithubUrl(entry.url) ? entry.url : null;
   const installCommands = extractInstallCommands(entry.description);
@@ -171,6 +187,8 @@ function toCatalogEntry(
       readmePath: featuredInReadme ? "README.md" : null,
       docsPath,
       featuredInReadme,
+      ...(sourceMetadata?.pullRequest ? { pullRequest: sourceMetadata.pullRequest } : {}),
+      ...(sourceMetadata?.lastUpdatedAt ? { lastUpdatedAt: sourceMetadata.lastUpdatedAt } : {}),
     },
     links: {
       primary: entry.url,
@@ -211,6 +229,10 @@ function toCatalogEntry(
   };
 
   return applyMetadataOverride(catalogEntry, metadata);
+}
+
+function locationKey(entry: ParsedMarkdownEntry): string {
+  return `${entry.sourcePath}:${entry.line}`;
 }
 
 function applyMetadataOverride(

--- a/packages/catalog-builder/src/cli.ts
+++ b/packages/catalog-builder/src/cli.ts
@@ -2,6 +2,7 @@ import { mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { buildCatalogFromMarkdown } from "./buildCatalog.js";
 import { readMetadataSidecars } from "./metadata.js";
+import { readGitLineMetadata } from "./sourceMetadata.js";
 
 const readme = readFileSync("README.md", "utf8");
 const docsByPath = new Map<string, string>();
@@ -13,7 +14,16 @@ for (const file of readdirSync("docs")) {
   }
 }
 
-const result = buildCatalogFromMarkdown(readme, docsByPath, readMetadataSidecars());
+const sourceMetadataByLocation = readGitLineMetadata([
+  "README.md",
+  ...Array.from(docsByPath.keys()),
+]);
+const result = buildCatalogFromMarkdown(
+  readme,
+  docsByPath,
+  readMetadataSidecars(),
+  sourceMetadataByLocation,
+);
 
 mkdirSync("data", { recursive: true });
 writeFileSync("data/catalog.json", `${JSON.stringify(result.entries, null, 2)}\n`);

--- a/packages/catalog-builder/src/sourceMetadata.ts
+++ b/packages/catalog-builder/src/sourceMetadata.ts
@@ -1,0 +1,96 @@
+import { execFileSync } from "node:child_process";
+import type { CatalogSourceMetadata } from "./types.js";
+
+export const readGitLineMetadata = (
+  paths: string[],
+  cwd = process.cwd(),
+): Map<string, CatalogSourceMetadata> => {
+  const metadataByLocation = new Map<string, CatalogSourceMetadata>();
+
+  for (const path of paths) {
+    try {
+      const blameOutput = execFileSync("git", [
+        "blame",
+        "--line-porcelain",
+        "--",
+        path,
+      ], {
+        cwd,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+
+      for (const [location, metadata] of parseGitBlamePorcelain(path, blameOutput)) {
+        metadataByLocation.set(location, metadata);
+      }
+    } catch {
+      // Source timestamps are additive metadata. Builds should still work outside a git checkout.
+    }
+  }
+
+  return metadataByLocation;
+};
+
+export const parseGitBlamePorcelain = (
+  path: string,
+  blameOutput: string,
+): Map<string, CatalogSourceMetadata> => {
+  const metadataByLocation = new Map<string, CatalogSourceMetadata>();
+  let currentLine: number | null = null;
+  let currentUpdatedAt: string | null = null;
+  let currentPullRequest: number | null = null;
+
+  for (const line of blameOutput.split("\n")) {
+    const header = line.match(/^[0-9a-f]{40,64}\s+\d+\s+(\d+)(?:\s+\d+)?$/);
+
+    if (header) {
+      currentLine = Number(header[1]);
+      currentUpdatedAt = null;
+      currentPullRequest = null;
+      continue;
+    }
+
+    if (line.startsWith("committer-time ")) {
+      currentUpdatedAt = unixSecondsToIso(line.slice("committer-time ".length));
+      continue;
+    }
+
+    if (line.startsWith("author-time ") && currentUpdatedAt === null) {
+      currentUpdatedAt = unixSecondsToIso(line.slice("author-time ".length));
+      continue;
+    }
+
+    if (line.startsWith("summary ")) {
+      currentPullRequest = extractPullRequestNumber(line.slice("summary ".length));
+      continue;
+    }
+
+    if (line.startsWith("\t") && currentLine !== null) {
+      if (currentUpdatedAt || currentPullRequest) {
+        metadataByLocation.set(`${path}:${currentLine}`, {
+          ...(currentUpdatedAt ? { lastUpdatedAt: currentUpdatedAt } : {}),
+          ...(currentPullRequest ? { pullRequest: currentPullRequest } : {}),
+        });
+      }
+
+      currentLine += 1;
+    }
+  }
+
+  return metadataByLocation;
+};
+
+const extractPullRequestNumber = (summary: string): number | null => {
+  const match = summary.match(/(?:\(#|pull request #)(\d+)/i);
+  return match ? Number(match[1]) : null;
+};
+
+const unixSecondsToIso = (value: string): string | null => {
+  const seconds = Number(value);
+
+  if (!Number.isFinite(seconds)) {
+    return null;
+  }
+
+  return new Date(seconds * 1000).toISOString();
+};

--- a/packages/catalog-builder/src/types.ts
+++ b/packages/catalog-builder/src/types.ts
@@ -3,6 +3,11 @@ export type AuthType = "none" | "api-key" | "oauth" | "bearer" | "unknown";
 export type Confidence = "high" | "medium" | "low";
 export type VerificationStatus = "unknown" | "self_reported" | "partial" | "verified" | "failing";
 
+export interface CatalogSourceMetadata {
+  lastUpdatedAt?: string | null;
+  pullRequest?: number | null;
+}
+
 export interface CatalogEntry {
   id: string;
   name: string;
@@ -13,6 +18,7 @@ export interface CatalogEntry {
     docsPath: string | null;
     featuredInReadme: boolean;
     pullRequest?: number | null;
+    lastUpdatedAt?: string | null;
   };
   links: {
     primary: string;

--- a/packages/catalog-builder/test/buildCatalog.test.ts
+++ b/packages/catalog-builder/test/buildCatalog.test.ts
@@ -298,6 +298,33 @@ describe("buildCatalogFromMarkdown", () => {
     });
   });
 
+  it("attaches source update metadata from the entry location", () => {
+    const readme = [
+      "## 🔎 Search",
+      "- [Tracked MCP](https://github.com/owner/tracked-mcp): Search tool.",
+    ].join("\n");
+    const docs = new Map([
+      [
+        "docs/search.md",
+        [
+          "## 🔎 Search",
+          "- [Tracked MCP](https://github.com/owner/tracked-mcp): Search tool.",
+        ].join("\n"),
+      ],
+    ]);
+
+    const result = buildCatalogFromMarkdown(readme, docs, new Map(), new Map([
+      [
+        "docs/search.md:2",
+        {
+          lastUpdatedAt: "2026-06-18T12:34:56.000Z",
+        },
+      ],
+    ]));
+
+    expect(result.entries[0]?.source.lastUpdatedAt).toBe("2026-06-18T12:34:56.000Z");
+  });
+
   it("builds entries that validate against the catalog schema", () => {
     const readme = [
       "## Experimental",

--- a/packages/catalog-builder/test/sourceMetadata.test.ts
+++ b/packages/catalog-builder/test/sourceMetadata.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { parseGitBlamePorcelain } from "../src/sourceMetadata.js";
+
+describe("parseGitBlamePorcelain", () => {
+  it("maps blamed source lines to ISO update timestamps", () => {
+    const blameOutput = [
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 1 1 2",
+      "author Example",
+      "author-mail <example@example.com>",
+      "author-time 1781786096",
+      "committer Example",
+      "committer-mail <example@example.com>",
+      "committer-time 1781786096",
+      "summary Add tracked entries (#42)",
+      "\t## Search",
+      "\t- [Tracked MCP](https://github.com/owner/tracked-mcp): Search tool.",
+    ].join("\n");
+
+    expect(parseGitBlamePorcelain("docs/search.md", blameOutput)).toEqual(new Map([
+      ["docs/search.md:1", { lastUpdatedAt: "2026-06-18T12:34:56.000Z", pullRequest: 42 }],
+      ["docs/search.md:2", { lastUpdatedAt: "2026-06-18T12:34:56.000Z", pullRequest: 42 }],
+    ]));
+  });
+});

--- a/packages/registry-api/src/search.ts
+++ b/packages/registry-api/src/search.ts
@@ -20,6 +20,8 @@ export interface ServerSummary {
   primaryUrl: string;
   profilePath: string;
   webProfilePath: string;
+  sourcePullRequest: number | null;
+  lastUpdatedAt: string | null;
 }
 
 export interface CategorySummary {
@@ -47,6 +49,8 @@ export const summarizeServer = (entry: CatalogEntry): ServerSummary => ({
   primaryUrl: entry.links.primary,
   profilePath: `/v1/servers/${entry.id}`,
   webProfilePath: webProfileUrl(entry.id),
+  sourcePullRequest: entry.source.pullRequest ?? null,
+  lastUpdatedAt: entry.source.lastUpdatedAt ?? null,
 });
 
 export const listCategories = (catalog: CatalogEntry[]): CategorySummary[] => {
@@ -99,6 +103,22 @@ export const findServer = (
   catalog: CatalogEntry[],
   serverId: string
 ): CatalogEntry | null => catalog.find((entry) => entry.id === serverId) ?? null;
+
+export const listRecentServers = (
+  catalog: CatalogEntry[],
+  rawLimit: number | undefined
+): ServerSummary[] =>
+  sortWithOriginalOrder(catalog, sortByUpdatedAtThenPullRequest)
+    .slice(0, normalizeLimit(rawLimit))
+    .map(summarizeServer);
+
+export const listUpdatedServers = (
+  catalog: CatalogEntry[],
+  rawLimit: number | undefined
+): ServerSummary[] =>
+  sortWithOriginalOrder(catalog, sortByUpdatedAtThenPullRequest)
+    .slice(0, normalizeLimit(rawLimit))
+    .map(summarizeServer);
 
 export const normalizeLimit = (rawLimit: number | undefined): number => {
   if (!rawLimit || Number.isNaN(rawLimit) || rawLimit < 1) {
@@ -170,6 +190,44 @@ const sortScoredEntries = (left: ScoredEntry, right: ScoredEntry): number =>
 
 const sortEntries = (left: CatalogEntry, right: CatalogEntry): number =>
   left.category.localeCompare(right.category) || left.name.localeCompare(right.name);
+
+const sortWithOriginalOrder = (
+  catalog: CatalogEntry[],
+  compare: (left: CatalogEntry, right: CatalogEntry) => number
+): CatalogEntry[] =>
+  catalog
+    .map((entry, index) => ({ entry, index }))
+    .sort((left, right) => compare(left.entry, right.entry) || left.index - right.index)
+    .map(({ entry }) => entry);
+
+const sortByUpdatedAtThenPullRequest = (left: CatalogEntry, right: CatalogEntry): number =>
+  compareNullableNumberDesc(timestampRank(left.source.lastUpdatedAt), timestampRank(right.source.lastUpdatedAt))
+  || compareNullableNumberDesc(left.source.pullRequest ?? null, right.source.pullRequest ?? null);
+
+const compareNullableNumberDesc = (left: number | null, right: number | null): number => {
+  if (left === null && right === null) {
+    return 0;
+  }
+
+  if (left === null) {
+    return 1;
+  }
+
+  if (right === null) {
+    return -1;
+  }
+
+  return right - left;
+};
+
+const timestampRank = (value: string | null | undefined): number | null => {
+  if (!value) {
+    return null;
+  }
+
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? null : timestamp;
+};
 
 const tokenize = (query: string): string[] =>
   normalizeText(query)

--- a/packages/registry-api/src/server.ts
+++ b/packages/registry-api/src/server.ts
@@ -9,6 +9,8 @@ import {
 import {
   findServer,
   listCategories,
+  listRecentServers,
+  listUpdatedServers,
   normalizeLimit,
   searchCatalog,
 } from "./search.js";
@@ -122,6 +124,16 @@ const handleRequest = async (
       return;
     }
 
+    if (segments[1] === "servers" && segments[2] === "recent" && segments.length === 3) {
+      handleServerCollection(url, response, state.catalog, "recent");
+      return;
+    }
+
+    if (segments[1] === "servers" && segments[2] === "updated" && segments.length === 3) {
+      handleServerCollection(url, response, state.catalog, "updated");
+      return;
+    }
+
     if (segments[1] === "servers" && segments.length === 3) {
       const entry = findServer(state.catalog, segments[2]);
 
@@ -160,6 +172,8 @@ const discoveryPayload = (state: RegistryApiState) => ({
     health: "/health",
     categories: "/v1/categories",
     searchServers: "/v1/servers?query=postgres&limit=5",
+    recentServers: "/v1/servers/recent?limit=12",
+    updatedServers: "/v1/servers/updated?limit=12",
     getServer: "/v1/servers/{id}",
     serverProfile: webProfileTemplate(),
     apiHtmlProfile: "/servers/{id}",
@@ -168,6 +182,26 @@ const discoveryPayload = (state: RegistryApiState) => ({
   },
   docs: "https://github.com/TensorBlock/awesome-mcp-servers/blob/main/docs/index-api.md",
 });
+
+const handleServerCollection = (
+  url: URL,
+  response: ServerResponse,
+  catalog: CatalogEntry[],
+  collection: "recent" | "updated"
+): void => {
+  const rawLimit = url.searchParams.get("limit");
+  const limit = normalizeLimit(rawLimit ? Number(rawLimit) : undefined);
+  const servers = collection === "recent"
+    ? listRecentServers(catalog, limit)
+    : listUpdatedServers(catalog, limit);
+
+  sendJson(response, 200, {
+    collection,
+    count: servers.length,
+    limit,
+    servers,
+  });
+};
 
 const handleSearch = (
   url: URL,

--- a/packages/registry-api/test/search.test.ts
+++ b/packages/registry-api/test/search.test.ts
@@ -3,6 +3,8 @@ import type { CatalogEntry } from "../../catalog-builder/src/types.js";
 import {
   findServer,
   listCategories,
+  listRecentServers,
+  listUpdatedServers,
   normalizeLimit,
   searchCatalog,
   summarizeServer,
@@ -59,7 +61,21 @@ const baseEntry: CatalogEntry = {
   },
 };
 
-const entry = (overrides: Partial<CatalogEntry>): CatalogEntry => ({
+type EntryOverrides = Partial<Omit<
+  CatalogEntry,
+  "source" | "links" | "install" | "auth" | "tools" | "health" | "verification" | "community"
+>> & {
+  source?: Partial<CatalogEntry["source"]>;
+  links?: Partial<CatalogEntry["links"]>;
+  install?: Partial<CatalogEntry["install"]>;
+  auth?: Partial<CatalogEntry["auth"]>;
+  tools?: Partial<CatalogEntry["tools"]>;
+  health?: Partial<CatalogEntry["health"]>;
+  verification?: Partial<CatalogEntry["verification"]>;
+  community?: Partial<CatalogEntry["community"]>;
+};
+
+const entry = (overrides: EntryOverrides): CatalogEntry => ({
   ...baseEntry,
   ...overrides,
   source: {
@@ -185,5 +201,78 @@ describe("catalog helpers", () => {
     expect(normalizeLimit(0)).toBe(25);
     expect(normalizeLimit(101)).toBe(100);
     expect(normalizeLimit(7.8)).toBe(7);
+  });
+
+  it("lists recent servers by update timestamp before pull request fallback", () => {
+    const timelineCatalog = [
+      entry({
+        id: "older-pr",
+        name: "Older PR",
+        source: {
+          pullRequest: 14,
+          lastUpdatedAt: "2026-06-18T10:00:00.000Z",
+        },
+      }),
+      entry({
+        id: "newer-pr",
+        name: "Newer PR",
+        source: {
+          pullRequest: 42,
+          lastUpdatedAt: "2026-06-01T10:00:00.000Z",
+        },
+      }),
+      entry({
+        id: "timestamp-only",
+        name: "Timestamp Only",
+        source: {
+          lastUpdatedAt: "2026-06-20T10:00:00.000Z",
+        },
+      }),
+    ];
+
+    expect(listRecentServers(timelineCatalog, 3).map((server) => server.id)).toEqual([
+      "timestamp-only",
+      "older-pr",
+      "newer-pr",
+    ]);
+    expect(listRecentServers(timelineCatalog, 1)[0]).toMatchObject({
+      id: "timestamp-only",
+      sourcePullRequest: null,
+      lastUpdatedAt: "2026-06-20T10:00:00.000Z",
+    });
+  });
+
+  it("lists updated servers by last updated timestamp", () => {
+    const timelineCatalog = [
+      entry({
+        id: "older",
+        name: "Older",
+        source: {
+          lastUpdatedAt: "2026-06-01T10:00:00.000Z",
+        },
+      }),
+      entry({
+        id: "newer",
+        name: "Newer",
+        source: {
+          lastUpdatedAt: "2026-06-20T10:00:00.000Z",
+        },
+      }),
+      entry({
+        id: "unknown-time",
+        name: "Unknown Time",
+      }),
+    ];
+
+    expect(listUpdatedServers(timelineCatalog, 3).map((server) => server.id)).toEqual([
+      "newer",
+      "older",
+      "unknown-time",
+    ]);
+    expect(listUpdatedServers(timelineCatalog, 1)[0]).toMatchObject({
+      id: "newer",
+      lastUpdatedAt: "2026-06-20T10:00:00.000Z",
+      sourcePullRequest: null,
+    });
   });
 });

--- a/packages/registry-api/test/server.test.ts
+++ b/packages/registry-api/test/server.test.ts
@@ -57,6 +57,24 @@ const catalog: CatalogEntry[] = [
   },
 ];
 
+type CatalogEntryOverrides = Partial<Omit<CatalogEntry, "source" | "links">> & {
+  source?: Partial<CatalogEntry["source"]>;
+  links?: Partial<CatalogEntry["links"]>;
+};
+
+const catalogEntry = (overrides: CatalogEntryOverrides): CatalogEntry => ({
+  ...catalog[0],
+  ...overrides,
+  source: {
+    ...catalog[0].source,
+    ...overrides.source,
+  },
+  links: {
+    ...catalog[0].links,
+    ...overrides.links,
+  },
+});
+
 const servers: Array<ReturnType<typeof createRegistryApiServer>> = [];
 
 afterEach(async () => {
@@ -87,6 +105,8 @@ describe("registry API server", () => {
     expect(body.name).toBe("TensorBlock MCP Index API");
     expect(body.catalogEntries).toBe(1);
     expect(body.endpoints.searchServers).toBe("/v1/servers?query=postgres&limit=5");
+    expect(body.endpoints.recentServers).toBe("/v1/servers/recent?limit=12");
+    expect(body.endpoints.updatedServers).toBe("/v1/servers/updated?limit=12");
     expect(body.endpoints.serverProfile).toBe("https://tensorblock.co/mcp/servers/{id}");
     expect(body.endpoints.apiHtmlProfile).toBe("/servers/{id}");
     expect(body.endpoints.badge).toBe("/v1/servers/{id}/badge.svg");
@@ -129,6 +149,84 @@ describe("registry API server", () => {
     expect(body).toContain("Postgres MCP is indexed on TensorBlock MCP Index");
   });
 
+  it("returns recently added server summaries", async () => {
+    const baseUrl = await startServer([
+      catalogEntry({
+        id: "older-pr",
+        name: "Older PR",
+        source: {
+          pullRequest: 10,
+          lastUpdatedAt: "2026-06-18T10:00:00.000Z",
+        },
+      }),
+      catalogEntry({
+        id: "newer-pr",
+        name: "Newer PR",
+        source: {
+          pullRequest: 42,
+          lastUpdatedAt: "2026-06-01T10:00:00.000Z",
+        },
+      }),
+      catalogEntry({
+        id: "timestamp-only",
+        name: "Timestamp Only",
+        source: {
+          lastUpdatedAt: "2026-06-20T10:00:00.000Z",
+        },
+      }),
+    ]);
+    const response = await fetch(`${baseUrl}/v1/servers/recent?limit=2`);
+    const body = await response.json() as {
+      count: number;
+      limit: number;
+      servers: Array<{ id: string; sourcePullRequest: number | null; lastUpdatedAt: string | null }>;
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.count).toBe(2);
+    expect(body.limit).toBe(2);
+    expect(body.servers.map((server) => server.id)).toEqual(["timestamp-only", "older-pr"]);
+    expect(body.servers[0]).toMatchObject({
+      sourcePullRequest: null,
+      lastUpdatedAt: "2026-06-20T10:00:00.000Z",
+    });
+  });
+
+  it("returns recently updated server summaries", async () => {
+    const baseUrl = await startServer([
+      catalogEntry({
+        id: "older",
+        name: "Older",
+        source: {
+          lastUpdatedAt: "2026-06-01T10:00:00.000Z",
+        },
+      }),
+      catalogEntry({
+        id: "newer",
+        name: "Newer",
+        source: {
+          lastUpdatedAt: "2026-06-20T10:00:00.000Z",
+        },
+      }),
+    ]);
+    const response = await fetch(`${baseUrl}/v1/servers/updated?limit=1`);
+    const body = await response.json() as {
+      count: number;
+      limit: number;
+      servers: Array<{ id: string; lastUpdatedAt: string | null }>;
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.count).toBe(1);
+    expect(body.limit).toBe(1);
+    expect(body.servers).toEqual([
+      expect.objectContaining({
+        id: "newer",
+        lastUpdatedAt: "2026-06-20T10:00:00.000Z",
+      }),
+    ]);
+  });
+
   it("returns JSON errors for missing profile pages", async () => {
     const baseUrl = await startServer();
     const response = await fetch(`${baseUrl}/servers/missing`);
@@ -140,9 +238,9 @@ describe("registry API server", () => {
   });
 });
 
-const startServer = async (): Promise<string> => {
+const startServer = async (entries = catalog): Promise<string> => {
   const server = createRegistryApiServer({
-    catalog,
+    catalog: entries,
     loadedAt: "2026-06-06T00:00:00.000Z",
   });
   servers.push(server);

--- a/schemas/server.schema.json
+++ b/schemas/server.schema.json
@@ -44,7 +44,13 @@
           ]
         },
         "featuredInReadme": { "type": "boolean" },
-        "pullRequest": { "type": ["integer", "null"], "minimum": 1 }
+        "pullRequest": { "type": ["integer", "null"], "minimum": 1 },
+        "lastUpdatedAt": {
+          "anyOf": [
+            { "type": "string", "format": "date-time", "minLength": 1 },
+            { "type": "null" }
+          ]
+        }
       },
       "additionalProperties": false
     },


### PR DESCRIPTION
## Summary
- derive catalog source timestamps and PR numbers from git blame during catalog builds
- expose /v1/servers/recent and /v1/servers/updated collection endpoints with discovery/docs/README coverage
- ensure deploy and health-check workflows fetch full git history so generated timestamps are accurate

## Tests
- npm test
- npm run typecheck
- npm run build