### PR TITLE
Investigate broken MCP entry report #795

### DIFF
--- a/docs/broken-entry-reports/795-github-asirulnik-mcp-server-filesystem-01.md
+++ b/docs/broken-entry-reports/795-github-asirulnik-mcp-server-filesystem-01.md
@@ -1,0 +1,39 @@
+# Broken entry report: https://github.com/asirulnik/mcp_server_filesystem_01
+
+Status: needs verification
+Source issue: https://github.com/TensorBlock/awesome-mcp-servers/issues/795
+
+## Entry Reference
+
+https://github.com/asirulnik/mcp_server_filesystem_01
+
+## Normalized Server Id
+
+Not available
+
+## Reported Issue Types
+
+- Dead link
+
+## Details
+
+GitHub API returned 404 for https://github.com/asirulnik/mcp_server_filesystem_01.
+
+Indexed server id: github-asirulnik-mcp-server-filesystem-01-d53cf227
+Name: asirulnik/mcp_server_filesystem_01
+Category: Filesystems
+Source docs: docs/filesystems.md
+
+A maintainer should verify whether the project moved, became private, or should be removed from the catalog.
+
+## Source Or Proof
+
+https://github.com/asirulnik/mcp_server_filesystem_01
+
+## Maintainer checklist
+
+- Verify the report against the indexed profile, source project, and generated API profile.
+- Check whether the fix belongs in a category markdown entry, metadata sidecar, or removal PR.
+- Search the repo for duplicate project URLs before changing category docs.
+- For safety or security concerns, verify with source links before exposing the profile as healthy.
+- Close the source issue after the fix, removal, or no-action decision is merged.


### PR DESCRIPTION
## Summary
- capture broken-entry report for `https://github.com/asirulnik/mcp_server_filesystem_01`
- add structured investigation spec at `docs/broken-entry-reports/795-github-asirulnik-mcp-server-filesystem-01.md`
- keep the report reviewable before editing catalog docs or metadata sidecars

## Reported issue types
- Dead link

## Details

```text
GitHub API returned 404 for https://github.com/asirulnik/mcp_server_filesystem_01.

Indexed server id: github-asirulnik-mcp-server-filesystem-01-d53cf227
Name: asirulnik/mcp_server_filesystem_01
Category: Filesystems
Source docs: docs/filesystems.md

A maintainer should verify whether the project moved, became private, or should be removed from the catalog.
```

## Source or proof
https://github.com/asirulnik/mcp_server_filesystem_01

## Generated report

`docs/broken-entry-reports/795-github-asirulnik-mcp-server-filesystem-01.md`

https://github.com/TensorBlock/awesome-mcp-servers/issues/795

Closes #795