### PR TITLE
Investigate broken MCP entry report #791

### DIFF
--- a/docs/broken-entry-reports/791-github-abhishekloiwal-mcp-file-server.md
+++ b/docs/broken-entry-reports/791-github-abhishekloiwal-mcp-file-server.md
@@ -1,0 +1,39 @@
+# Broken entry report: https://github.com/abhishekloiwal/mcp-file-server
+
+Status: needs verification
+Source issue: https://github.com/TensorBlock/awesome-mcp-servers/issues/791
+
+## Entry Reference
+
+https://github.com/abhishekloiwal/mcp-file-server
+
+## Normalized Server Id
+
+Not available
+
+## Reported Issue Types
+
+- Dead link
+
+## Details
+
+GitHub API returned 404 for https://github.com/abhishekloiwal/mcp-file-server.
+
+Indexed server id: github-abhishekloiwal-mcp-file-server-510bb546
+Name: abhishekloiwal/mcp-file-server
+Category: Filesystems
+Source docs: docs/filesystems.md
+
+A maintainer should verify whether the project moved, became private, or should be removed from the catalog.
+
+## Source Or Proof
+
+https://github.com/abhishekloiwal/mcp-file-server
+
+## Maintainer checklist
+
+- Verify the report against the indexed profile, source project, and generated API profile.
+- Check whether the fix belongs in a category markdown entry, metadata sidecar, or removal PR.
+- Search the repo for duplicate project URLs before changing category docs.
+- For safety or security concerns, verify with source links before exposing the profile as healthy.
+- Close the source issue after the fix, removal, or no-action decision is merged.


### PR DESCRIPTION
## Summary
- capture broken-entry report for `https://github.com/abhishekloiwal/mcp-file-server`
- add structured investigation spec at `docs/broken-entry-reports/791-github-abhishekloiwal-mcp-file-server.md`
- keep the report reviewable before editing catalog docs or metadata sidecars

## Reported issue types
- Dead link

## Details

```text
GitHub API returned 404 for https://github.com/abhishekloiwal/mcp-file-server.

Indexed server id: github-abhishekloiwal-mcp-file-server-510bb546
Name: abhishekloiwal/mcp-file-server
Category: Filesystems
Source docs: docs/filesystems.md

A maintainer should verify whether the project moved, became private, or should be removed from the catalog.
```

## Source or proof
https://github.com/abhishekloiwal/mcp-file-server

## Generated report

`docs/broken-entry-reports/791-github-abhishekloiwal-mcp-file-server.md`

https://github.com/TensorBlock/awesome-mcp-servers/issues/791

Closes #791