### PR TITLE
Investigate broken MCP entry report #811

### DIFF
--- a/docs/broken-entry-reports/811-github-danielmark001-evm-mcp-server.md
+++ b/docs/broken-entry-reports/811-github-danielmark001-evm-mcp-server.md
@@ -1,0 +1,39 @@
+# Broken entry report: https://github.com/Danielmark001/evm_mcp_server
+
+Status: needs verification
+Source issue: https://github.com/TensorBlock/awesome-mcp-servers/issues/811
+
+## Entry Reference
+
+https://github.com/Danielmark001/evm_mcp_server
+
+## Normalized Server Id
+
+Not available
+
+## Reported Issue Types
+
+- Dead link
+
+## Details
+
+GitHub API returned 404 for https://github.com/Danielmark001/evm_mcp_server.
+
+Indexed server id: github-danielmark001-evm-mcp-server-0c7821b5
+Name: Danielmark001/evm_mcp_server
+Category: Finance & Crypto
+Source docs: docs/finance--crypto.md
+
+A maintainer should verify whether the project moved, became private, or should be removed from the catalog.
+
+## Source Or Proof
+
+https://github.com/Danielmark001/evm_mcp_server
+
+## Maintainer checklist
+
+- Verify the report against the indexed profile, source project, and generated API profile.
+- Check whether the fix belongs in a category markdown entry, metadata sidecar, or removal PR.
+- Search the repo for duplicate project URLs before changing category docs.
+- For safety or security concerns, verify with source links before exposing the profile as healthy.
+- Close the source issue after the fix, removal, or no-action decision is merged.


### PR DESCRIPTION
## Summary
- capture broken-entry report for `https://github.com/Danielmark001/evm_mcp_server`
- add structured investigation spec at `docs/broken-entry-reports/811-github-danielmark001-evm-mcp-server.md`
- keep the report reviewable before editing catalog docs or metadata sidecars

## Reported issue types
- Dead link

## Details

```text
GitHub API returned 404 for https://github.com/Danielmark001/evm_mcp_server.

Indexed server id: github-danielmark001-evm-mcp-server-0c7821b5
Name: Danielmark001/evm_mcp_server
Category: Finance & Crypto
Source docs: docs/finance--crypto.md

A maintainer should verify whether the project moved, became private, or should be removed from the catalog.
```

## Source or proof
https://github.com/Danielmark001/evm_mcp_server

## Generated report

`docs/broken-entry-reports/811-github-danielmark001-evm-mcp-server.md`

https://github.com/TensorBlock/awesome-mcp-servers/issues/811

Closes #811