### PR TITLE
Use GitHub App token for MCP automation

### DIFF
--- a/.github/actions/create-automation-token/action.yml
+++ b/.github/actions/create-automation-token/action.yml
@@ -1,0 +1,48 @@
+name: Create MCP automation token
+description: Resolve the token used by MCP automation workflows.
+
+inputs:
+  app-client-id:
+    description: GitHub App client ID.
+    required: false
+    default: ""
+  app-private-key:
+    description: GitHub App private key.
+    required: false
+    default: ""
+  fallback-token:
+    description: Token to use when the GitHub App is not configured.
+    required: false
+    default: ""
+
+outputs:
+  token:
+    description: Resolved automation token.
+    value: ${{ steps.select-token.outputs.token }}
+
+runs:
+  using: composite
+  steps:
+    - name: Create GitHub App installation token
+      id: app-token
+      if: ${{ inputs.app-client-id != '' }}
+      uses: actions/create-github-app-token@v3
+      with:
+        client-id: ${{ inputs.app-client-id }}
+        private-key: ${{ inputs.app-private-key }}
+        permission-contents: write
+        permission-issues: write
+        permission-pull-requests: write
+
+    - name: Select automation token
+      id: select-token
+      shell: bash
+      env:
+        APP_TOKEN: ${{ steps.app-token.outputs.token }}
+        FALLBACK_TOKEN: ${{ inputs.fallback-token }}
+      run: |
+        if [ -n "$APP_TOKEN" ]; then
+          echo "token=$APP_TOKEN" >> "$GITHUB_OUTPUT"
+        else
+          echo "token=$FALLBACK_TOKEN" >> "$GITHUB_OUTPUT"
+        fi

--- a/.github/workflows/add-server-issue-pr.yml
+++ b/.github/workflows/add-server-issue-pr.yml
@@ -33,7 +33,15 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Resolve automation token
+        id: automation-token
+        uses: ./.github/actions/create-automation-token
+        with:
+          app-client-id: ${{ vars.MCP_AUTOMATION_APP_CLIENT_ID }}
+          app-private-key: ${{ secrets.MCP_AUTOMATION_APP_PRIVATE_KEY }}
+          fallback-token: ${{ secrets.MCP_AUTOMATION_TOKEN || github.token }}
+
       - name: Create or update draft PR
         run: node .github/scripts/create-add-server-pr.mjs
         env:
-          GITHUB_TOKEN: ${{ secrets.MCP_AUTOMATION_TOKEN || github.token }}
+          GITHUB_TOKEN: ${{ steps.automation-token.outputs.token }}

--- a/.github/workflows/broken-entry-report-pr.yml
+++ b/.github/workflows/broken-entry-report-pr.yml
@@ -33,7 +33,15 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Resolve automation token
+        id: automation-token
+        uses: ./.github/actions/create-automation-token
+        with:
+          app-client-id: ${{ vars.MCP_AUTOMATION_APP_CLIENT_ID }}
+          app-private-key: ${{ secrets.MCP_AUTOMATION_APP_PRIVATE_KEY }}
+          fallback-token: ${{ secrets.MCP_AUTOMATION_TOKEN || github.token }}
+
       - name: Create or update draft broken-entry report PR
         run: node .github/scripts/create-broken-entry-report-pr.mjs
         env:
-          GITHUB_TOKEN: ${{ secrets.MCP_AUTOMATION_TOKEN || github.token }}
+          GITHUB_TOKEN: ${{ steps.automation-token.outputs.token }}

--- a/.github/workflows/catalog-health-check.yml
+++ b/.github/workflows/catalog-health-check.yml
@@ -39,23 +39,30 @@ jobs:
     name: Check catalog health
     runs-on: ubuntu-latest
     env:
-      GITHUB_TOKEN: ${{ secrets.MCP_AUTOMATION_TOKEN }}
       HEALTH_CHECK_MAX_GITHUB_REPOS: ${{ github.event.inputs.max_github_repos || '250' }}
       HEALTH_CHECK_MAX_ISSUES: ${{ github.event.inputs.max_issues || '5' }}
       HEALTH_CHECK_OFFSET: ${{ github.event.inputs.offset || '' }}
       HEALTH_CHECK_DRY_RUN: ${{ github.event.inputs.dry_run == 'true' && '1' || '0' }}
 
     steps:
-      - name: Check automation token
-        if: env.GITHUB_TOKEN == '' && env.HEALTH_CHECK_DRY_RUN != '1'
-        run: |
-          echo "MCP_AUTOMATION_TOKEN is required so generated issues can trigger downstream triage and report PR workflows."
-          exit 1
-
       - name: Check out repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Resolve automation token
+        id: automation-token
+        uses: ./.github/actions/create-automation-token
+        with:
+          app-client-id: ${{ vars.MCP_AUTOMATION_APP_CLIENT_ID }}
+          app-private-key: ${{ secrets.MCP_AUTOMATION_APP_PRIVATE_KEY }}
+          fallback-token: ${{ secrets.MCP_AUTOMATION_TOKEN }}
+
+      - name: Check automation token
+        if: steps.automation-token.outputs.token == '' && env.HEALTH_CHECK_DRY_RUN != '1'
+        run: |
+          echo "Configure MCP_AUTOMATION_APP_CLIENT_ID and MCP_AUTOMATION_APP_PRIVATE_KEY, or keep MCP_AUTOMATION_TOKEN, so generated issues can trigger downstream triage and report PR workflows."
+          exit 1
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -71,3 +78,5 @@ jobs:
 
       - name: Run catalog health check
         run: npm run catalog:health
+        env:
+          GITHUB_TOKEN: ${{ steps.automation-token.outputs.token }}

--- a/.github/workflows/claim-profile-pr.yml
+++ b/.github/workflows/claim-profile-pr.yml
@@ -40,7 +40,15 @@ jobs:
       - name: Generate latest catalog
         run: npm run catalog:build
 
+      - name: Resolve automation token
+        id: automation-token
+        uses: ./.github/actions/create-automation-token
+        with:
+          app-client-id: ${{ vars.MCP_AUTOMATION_APP_CLIENT_ID }}
+          app-private-key: ${{ secrets.MCP_AUTOMATION_APP_PRIVATE_KEY }}
+          fallback-token: ${{ secrets.MCP_AUTOMATION_TOKEN || github.token }}
+
       - name: Create or update draft claim PR
         run: node .github/scripts/create-claim-profile-pr.mjs
         env:
-          GITHUB_TOKEN: ${{ secrets.MCP_AUTOMATION_TOKEN || github.token }}
+          GITHUB_TOKEN: ${{ steps.automation-token.outputs.token }}

--- a/.github/workflows/client-config-request-pr.yml
+++ b/.github/workflows/client-config-request-pr.yml
@@ -33,7 +33,15 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Resolve automation token
+        id: automation-token
+        uses: ./.github/actions/create-automation-token
+        with:
+          app-client-id: ${{ vars.MCP_AUTOMATION_APP_CLIENT_ID }}
+          app-private-key: ${{ secrets.MCP_AUTOMATION_APP_PRIVATE_KEY }}
+          fallback-token: ${{ secrets.MCP_AUTOMATION_TOKEN || github.token }}
+
       - name: Create or update draft client-config request PR
         run: node .github/scripts/create-client-config-request-pr.mjs
         env:
-          GITHUB_TOKEN: ${{ secrets.MCP_AUTOMATION_TOKEN || github.token }}
+          GITHUB_TOKEN: ${{ steps.automation-token.outputs.token }}

--- a/.github/workflows/improve-metadata-pr.yml
+++ b/.github/workflows/improve-metadata-pr.yml
@@ -40,7 +40,15 @@ jobs:
       - name: Generate latest catalog
         run: npm run catalog:build
 
+      - name: Resolve automation token
+        id: automation-token
+        uses: ./.github/actions/create-automation-token
+        with:
+          app-client-id: ${{ vars.MCP_AUTOMATION_APP_CLIENT_ID }}
+          app-private-key: ${{ secrets.MCP_AUTOMATION_APP_PRIVATE_KEY }}
+          fallback-token: ${{ secrets.MCP_AUTOMATION_TOKEN || github.token }}
+
       - name: Create or update draft metadata PR
         run: node .github/scripts/create-improve-metadata-pr.mjs
         env:
-          GITHUB_TOKEN: ${{ secrets.MCP_AUTOMATION_TOKEN || github.token }}
+          GITHUB_TOKEN: ${{ steps.automation-token.outputs.token }}

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -28,8 +28,15 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Resolve automation token
+        id: automation-token
+        uses: ./.github/actions/create-automation-token
+        with:
+          app-client-id: ${{ vars.MCP_AUTOMATION_APP_CLIENT_ID }}
+          app-private-key: ${{ secrets.MCP_AUTOMATION_APP_PRIVATE_KEY }}
+          fallback-token: ${{ github.token }}
+
       - name: Route issue and reply
         run: node .github/scripts/triage-issue.mjs
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+          GITHUB_TOKEN: ${{ steps.automation-token.outputs.token }}

--- a/.github/workflows/merged-pr-follow-up.yml
+++ b/.github/workflows/merged-pr-follow-up.yml
@@ -24,7 +24,15 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Resolve automation token
+        id: automation-token
+        uses: ./.github/actions/create-automation-token
+        with:
+          app-client-id: ${{ vars.MCP_AUTOMATION_APP_CLIENT_ID }}
+          app-private-key: ${{ secrets.MCP_AUTOMATION_APP_PRIVATE_KEY }}
+          fallback-token: ${{ secrets.MCP_AUTOMATION_TOKEN || github.token }}
+
       - name: Comment on merged catalog PR
         run: node .github/scripts/comment-merged-pr.mjs
         env:
-          GITHUB_TOKEN: ${{ secrets.MCP_AUTOMATION_TOKEN || github.token }}
+          GITHUB_TOKEN: ${{ steps.automation-token.outputs.token }}

--- a/.github/workflows/refresh-add-server-intake.yml
+++ b/.github/workflows/refresh-add-server-intake.yml
@@ -45,10 +45,18 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Resolve automation token
+        id: automation-token
+        uses: ./.github/actions/create-automation-token
+        with:
+          app-client-id: ${{ vars.MCP_AUTOMATION_APP_CLIENT_ID }}
+          app-private-key: ${{ secrets.MCP_AUTOMATION_APP_PRIVATE_KEY }}
+          fallback-token: ${{ secrets.MCP_AUTOMATION_TOKEN || github.token }}
+
       - name: Refresh intake labels
         run: node .github/scripts/refresh-add-server-intake.mjs
         env:
-          GITHUB_TOKEN: ${{ secrets.MCP_AUTOMATION_TOKEN || github.token }}
+          GITHUB_TOKEN: ${{ steps.automation-token.outputs.token }}
           INPUT_DRY_RUN: ${{ inputs.dry_run }}
           INPUT_ISSUE_NUMBER: ${{ inputs.issue_number }}
           INPUT_LIMIT: ${{ inputs.limit }}


### PR DESCRIPTION
## Summary
- add a local `create-automation-token` action that resolves an MCP automation token
- make MCP automation workflows prefer a GitHub App installation token
- keep the existing `MCP_AUTOMATION_TOKEN` fallback so rollout can be staged safely

## Why
Automation-created issues and PRs currently show the personal account that owns `MCP_AUTOMATION_TOKEN`. A GitHub App token makes new automation activity show as the app bot instead of a maintainer's personal account.

## Setup after merge
Create and install a GitHub App for `TensorBlock/awesome-mcp-servers`, then configure:

- Repository variable: `MCP_AUTOMATION_APP_CLIENT_ID`
- Repository secret: `MCP_AUTOMATION_APP_PRIVATE_KEY`

Required repository permissions for the app:

- Contents: Read and write
- Issues: Read and write
- Pull requests: Read and write
- Metadata: Read

Keep `MCP_AUTOMATION_TOKEN` until the first GitHub App-backed run succeeds, then it can be removed.

## Validation
- parsed all workflow/action YAML files locally
- `npm test`
- `npm run typecheck`
