### PR TITLE
Clean up dead catalog entries

### DIFF
--- a/docs/finance--crypto.md
+++ b/docs/finance--crypto.md
@@ -131,7 +131,6 @@ Servers dealing with financial data, stock markets, cryptocurrency exchanges/dat
 - [rjn32s/mcp-blockchain](https://github.com/rjn32s/mcp-blockchain): A robust blockchain server leveraging MCP for Ethereum address validation, gas fee estimation, wallet balance checking, and smart contract ownership verification.
 - [KalharPandya/upstocks-mcp](https://github.com/KalharPandya/upstocks-mcp): Facilitates AI-driven trading and market data access on the Upstox platform through a standardized interface.
 - [adairrr/cosmwasm-mcp](https://github.com/adairrr/cosmwasm-mcp): Facilitates AI-driven management and interaction with CosmWasm smart contracts using a Rust-based MCP server.
-- [iAMSagar44/batch-job-mcp](https://github.com/iAMSagar44/batch-job-mcp): Facilitates batch processing of financial transactions using AI categorization and Spring Batch integration.
 - [Adity-star/mcp-yfinance-server](https://github.com/Adity-star/mcp-yfinance-server): A real-time stock data server leveraging the YFinance API, designed for seamless integration with MCP to empower AI agents with advanced stock analysis and management capabilities.
 - [Adity-star/mcp-crypto-server](https://github.com/Adity-star/mcp-crypto-server): A cryptocurrency price lookup service using the ALPACA API, designed for seamless integration with AI agents via MCP.
 - [qingfengzxr/eth-mcp-server](https://github.com/qingfengzxr/eth-mcp-server): Provides Ethereum blockchain capabilities to AI assistants through the MCP framework, enabling real-time access to ETH balances, prices, and transaction details.
@@ -140,11 +139,9 @@ Servers dealing with financial data, stock markets, cryptocurrency exchanges/dat
 - [quanghuynguyen1902/jupiter-mcp-server](https://github.com/quanghuynguyen1902/jupiter-mcp-server): Facilitates Claude AI's interaction with Jupiter's swap API on Solana for seamless token swaps.
 - [sencloud/futures_mcp](https://github.com/sencloud/futures_mcp): A platform for futures trading strategy analysis, integrating real-time market data, technical analysis, news insights, and AI-driven analysis.
 - [djsamseng/bloomberg-mcp](https://github.com/djsamseng/bloomberg-mcp): Provides financial data from Bloomberg's blpapi via a MCP server.
-- [a6b8/solTracker-mcp](https://github.com/a6b8/solTracker-mcp): SolTracker MCP Server offers seamless access to Solana's token, wallet, and trading data, integrating effortlessly with LLM agents.
 - [aaronjmars/web3-research-mcp](https://github.com/aaronjmars/web3-research-mcp): Conducts in-depth cryptocurrency research by aggregating data from multiple sources and generating structured reports.
 - [Bulletninja/mcp-ynab](https://github.com/Bulletninja/mcp-ynab): Connects Cursor to YNAB for seamless financial data management via MCP tools.
 - [ArchimedesCrypto/fusion360-mcp-server](https://github.com/ArchimedesCrypto/fusion360-mcp-server): Facilitates natural language-driven design operations in Autodesk Fusion 360 by mapping prompts to API calls through an MCP server.
-- [a6b8/moralis-mcp](https://github.com/a6b8/moralis-mcp): Facilitates seamless blockchain data querying across multiple networks via Moralis Web3 API endpoints, leveraging a Model Context Protocol server.
 - [Rayato159/your-money-left-the-chat](https://github.com/Rayato159/your-money-left-the-chat): A Rust-native financial tracker that uses MCP to log and analyze spending habits through natural language conversations, all stored locally with SQLite.
 - [mnckapilan/starling_mcp](https://github.com/mnckapilan/starling_mcp): Facilitates AI model interactions with Starling Bank API endpoints for account management, transactions, and more.
 - [TradingBalthazar/hyperliquid-mcp-server-v6](https://github.com/TradingBalthazar/hyperliquid-mcp-server-v6): Facilitates trading and strategy management on the Hyperliquid exchange through a Model Context Protocol server.
@@ -188,7 +185,6 @@ Servers dealing with financial data, stock markets, cryptocurrency exchanges/dat
 - [kriuchkov/ton-mcp](https://github.com/kriuchkov/ton-mcp): Facilitates interaction with the TON Blockchain through MCP, enabling operations like transactions and balance checks.
 - [karacurt/blockscout-mcp-server](https://github.com/karacurt/blockscout-mcp-server): Facilitates AI model interactions with Blockscout API endpoints for blockchain data retrieval and analysis.
 - [Hott-J/coingecko-mcp-server](https://github.com/Hott-J/coingecko-mcp-server): Facilitates cryptocurrency data retrieval from CoinGecko via an MCP server interface.
-- [Danielmark001/evm_mcp_server](https://github.com/Danielmark001/evm_mcp_server): A blockchain service provider enabling AI agents to interact with multiple EVM-compatible networks through a unified interface.
 - [kukapay/crypto-portfolio-mcp](https://github.com/kukapay/crypto-portfolio-mcp): Facilitates real-time cryptocurrency portfolio management and optimization through AI agent interactions.
 - [smhnkmr/realtime-crypto-mcp-server](https://github.com/smhnkmr/realtime-crypto-mcp-server): Provides real-time cryptocurrency data integration for MCP servers using the CoinCap API.
 - [karacurt/evm-rpc-mcp-server](https://github.com/karacurt/evm-rpc-mcp-server): Facilitates AI model interactions with Ethereum and EVM-compatible blockchains via a standardized MCP interface.
@@ -261,7 +257,7 @@ Servers dealing with financial data, stock markets, cryptocurrency exchanges/dat
 - [shinzo-labs/coinmarketcap-mcp](https://github.com/shinzo-labs/coinmarketcap-mcp): Provides a standardized interface for accessing comprehensive cryptocurrency market data and blockchain metrics via the CoinMarketCap API.
 - [recallnet/trading-simulator-mcp](https://github.com/recallnet/trading-simulator-mcp): Facilitates AI-driven trading operations by interfacing with the Trading Simulator API for balance checks, price retrievals, and trade executions.
 - [FrankGenGo/solana-web3js-mcp-server](https://github.com/FrankGenGo/solana-web3js-mcp-server): Facilitates AI-driven Solana smart contract development and deployment through a standardized MCP interface.
-- [lifinance/lifi-mcp](https://github.com/lifinance/lifi-mcp): Official LI.FI MCP server (Go) — 25 read-only tools for cross-chain swap routing, bridge/DEX aggregation, transaction status, and Earn API yield vaults across 58 chains. Hosted at https://mcp.li.quest/mcp; listed on https://smithery.ai/servers/li-fi/lifi-mcp.
+- [LI.FI MCP](https://smithery.ai/servers/li-fi/lifi-mcp): Official LI.FI MCP server for cross-chain swap routing, bridge/DEX aggregation, transaction status, and Earn API yield vaults. Hosted streamable HTTP endpoint: `https://mcp.li.quest/mcp`.
 - [mittal-parth/kosh-sdk](https://github.com/mittal-parth/kosh-sdk): Kosh offers a secure, no-code interface to interact with remote MCP servers within Trusted Execution Environments, enhancing privacy and security for AI-driven tasks.
 - [Outblock/flow-mcp-server](https://github.com/Outblock/flow-mcp-server): Facilitates direct RPC communication with the Flow blockchain, enabling AI agent integration and interaction with Flow contracts.
 - [kukapay/token-minter-mcp](https://github.com/kukapay/token-minter-mcp): Facilitates AI-driven ERC-20 token minting and management across 21 blockchains.

--- a/docs/frameworks.md
+++ b/docs/frameworks.md
@@ -13,7 +13,6 @@ Toolkits, SDKs, starter templates, or code frameworks designed to help developer
 - [larryhudson/figma-mcp-server](https://github.com/larryhudson/figma-mcp-server): A template for building MCP servers with TypeScript, designed to facilitate integration with AI assistants and external tools.
 - [php-mcp/laravel](https://github.com/php-mcp/laravel): Seamlessly integrates the PHP MCP Server package into Laravel, enabling applications to expose MCP tools, resources, and prompts with ease.
 - [php-mcp/server](https://github.com/php-mcp/server): A PHP library facilitating the creation of MCP-compliant servers, enabling seamless integration of PHP applications with AI tools and external systems.
-- [ArisaTaki/MCP-study](https://github.com/ArisaTaki/MCP-study): A TypeScript-based MCP server offering basic arithmetic operations and dynamic resource management.
 - [kenken64/mcp-server-java](https://github.com/kenken64/mcp-server-java): A Java-based MCP server designed for seamless integration with Claude Desktop applications.
 - [RemoteMCP/Remote-MCP](https://github.com/RemoteMCP/Remote-MCP): Facilitates seamless remote communication and centralized management of model contexts through a type-safe MCP protocol.
 - [isuyashpatel/yox-modelcontextprotocol](https://github.com/isuyashpatel/yox-modelcontextprotocol): Facilitates the setup and configuration of MCP servers using Node.js for streamlined integration.
@@ -46,7 +45,6 @@ Toolkits, SDKs, starter templates, or code frameworks designed to help developer
 - [TomCools/mcp-4-tf-quickstarts](https://github.com/TomCools/mcp-4-tf-quickstarts): Facilitates modifications to Timefold Quickstarts using a Quarkus-based MCP server.
 - [302ai/302_custom_mcp](https://github.com/302ai/302_custom_mcp): A customizable MCP service enabling tool selection and flexible configuration for diverse needs.
 - [johnhenry/mcp-server-template](https://github.com/johnhenry/mcp-server-template): A template for creating new MCP servers with sandboxed JavaScript execution and debugging capabilities.
-- [3eer/mcp-server](https://github.com/3eer/mcp-server): A minimal TypeScript MCP server using fastMCP that provides a simple 'hello' response.
 - [Streamline-TS/mcp-runner](https://github.com/Streamline-TS/mcp-runner): A Rust library for managing and interacting with Model Context Protocol servers, offering JSON-RPC communication and tool management.
 - [dawsonlp/BaseMcpServer](https://github.com/dawsonlp/BaseMcpServer): A minimal Docker-based foundation for building MCP servers using the MCP Python SDK, supporting both HTTP+SSE and stdio protocols.
 - [flyingcloud-code/mcp](https://github.com/flyingcloud-code/mcp): A simple demo showcasing an MCP server and client implementation using an openrouter model, featuring tools for date, weather, and web content retrieval.
@@ -106,9 +104,6 @@ Toolkits, SDKs, starter templates, or code frameworks designed to help developer
 - [tenntenn/deepgo](https://github.com/tenntenn/deepgo): Facilitates deeper exploration of the Go ecosystem by providing tools to retrieve Go proposal meeting minutes, release notes, and the latest Go version.
 - [takunagai/mcp-server-boilerplate](https://github.com/takunagai/mcp-server-boilerplate): A foundational implementation for quickly building custom MCP servers with practical tools and extensions.
 - [tidewave-ai/mcp_proxy_elixir](https://github.com/tidewave-ai/mcp_proxy_elixir): Facilitates the connection of STDIO-based MCP clients to HTTP (SSE) based MCP servers using a proxy escript.
-- [amp-labs/sdk-node-write](https://github.com/amp-labs/sdk-node-write): Ampersand's SDK provides a declarative platform for SaaS builders to integrate product functionalities, with methods exposed as tools for AI applications.
-- [amp-labs/sdk-node-platform](https://github.com/amp-labs/sdk-node-platform): A declarative platform SDK for SaaS builders, enabling seamless product integrations with MCP server capabilities for AI applications.
-- [angxuejian/langgraph-start](https://github.com/angxuejian/langgraph-start): LangGraph Start offers a simple MCP server setup for AI applications, featuring chatbot, function calling, and RAG capabilities.
 - [warpdev/mcp-hub-mcp](https://github.com/warpdev/mcp-hub-mcp): A hub server that connects and manages multiple MCP servers, facilitating tool execution and management beyond Cursor's limitations.
 - [hyukkyulee-scllab/MCP_test](https://github.com/hyukkyulee-scllab/MCP_test): A Python-based MCP server using fastmcp to generate personalized greeting messages.
 - [llcdj/Figma-Context-MCP-main](https://github.com/llcdj/Figma-Context-MCP-main): Enable AI-powered coding tools to access and utilize Figma design data efficiently for accurate one-shot design implementations.


### PR DESCRIPTION
## Summary
- remove catalog entries whose GitHub repositories now return 404 and have no reachable replacement found
- update the LI.FI entry from its dead GitHub repo URL to the live Smithery listing while keeping the hosted MCP endpoint
- cover the current generated catalog-health reports for the affected entries

## Validation
- `npm test`
- `npm run typecheck`

Closes #809
Closes #810
Closes #811
Closes #812
Closes #813
Closes #825
Closes #826
Closes #827
Closes #828
Closes #829
