### PR TITLE
Add Docker MCP Server to Build & Deployment Tools

### DIFF
--- a/docs/build--deployment-tools.md
+++ b/docs/build--deployment-tools.md
@@ -90,4 +90,5 @@ Servers interacting with build systems, containerization, CI/CD, or deployment p
 - [trevorwilkerson/Windows-MCP-Server-Installation-Verification-Guide](https://github.com/trevorwilkerson/Windows-MCP-Server-Installation-Verification-Guide): A detailed guide for verifying and troubleshooting MCP server installations on Windows, highlighting key differences from MacOS setups.
 - [Bigsy/maven-mcp-server](https://github.com/Bigsy/maven-mcp-server): Facilitates LLMs in verifying and retrieving Maven dependency versions from the Maven Central Repository.
 - [QuantGeekDev/docker-mcp](https://github.com/QuantGeekDev/docker-mcp): Facilitates Docker container and stack management through Claude AI with a Model Context Protocol server.
+- [friendlygeorge/docker-mcp-server](https://github.com/friendlygeorge/docker-mcp-server): A comprehensive Docker MCP server with 50+ tools for container lifecycle management, compose stack operations, image management, network/volume administration, and Docker system monitoring.
 


### PR DESCRIPTION
## Add friendlygeorge/docker-mcp-server

Adds Nova's Docker MCP server to the Build & Deployment Tools category.

**Server:** [friendlygeorge/docker-mcp-server](https://github.com/friendlygeorge/docker-mcp-server)
**npm:**  (860+ weekly downloads)
**Tools:** 50+ (container lifecycle, compose stacks, images, networks, volumes, system monitoring)
**Transport:** stdio | **License:** MIT | **Auth:** none

### Why it fits
- Comprehensive Docker management via natural language — covers the full container lifecycle
- 860+ weekly npm installs indicating real-world usage
- TypeScript, actively maintained (v0.4.3), MIT licensed
- Complements existing entries (QuantGeekDev/docker-mcp) with broader tool coverage

### Install
```bash
npx @supernova123/docker-mcp-server
```

### Checklist
- [x] Searched repo for duplicates — QuantGeekDev/docker-mcp exists but covers basic container/stack ops; this server adds 50+ tools including network, volume, image, and system monitoring
- [x] Correct category (Build & Deployment Tools)
- [x] Server is open source and actively maintained