### PR TITLE
Add Steep to Data Analysis & Business Intelligence

### DIFF
--- a/docs/data-analysis--business-intelligence.md
+++ b/docs/data-analysis--business-intelligence.md
@@ -2,6 +2,8 @@
 
 Servers connecting to data warehouses, data query engines, analytics platforms, or specific data APIs.
 
+- [Steep](https://github.com/SteepHq/steep-mcp): Query a governed semantic layer — list and query metrics (with date ranges and breakdowns), targets, entities, modules, reports, and workspace members — and create reports. Streamable HTTP endpoint at `https://mcp.steep.app/mcp` with OAuth (RFC 9728 discovery + dynamic client registration). Listed in the official MCP Registry as `app.steep/mcp`. Apache-2.0.
+
 - [CrashStory MCP](https://crashstory.com/mcp): Colorado crash data and attorney-search MCP server with 15 tools for querying 594K+ crash records by location, date, and severity, plus AI-analyzed review intelligence for 600+ personal injury attorneys. Streamable HTTP endpoint: https://crashstory-mcp-production.up.railway.app/mcp. Public read-only. MIT.
 - [ResultRail](https://github.com/LarryLemonBot/resultrail-mcp-server): Hosted remote MCP server for pay-per-success public-data result packs with source URLs, confidence, timestamps, and receipt hashes. Streamable HTTP endpoint at `https://x402-resource-scanner.vercel.app/resultrail/mcp`; public `initialize` and `tools/list`; protected paid execution may require product authorization or x402 payment flow.
 - [Alessandro114/scala-mcp-server](https://github.com/Alessandro114/scala-mcp-server): Search 250M+ companies across 40+ countries — revenue, employees, credit score (0-100), industry. 6 tools for company search, lookup, report generation, and database stats. Free tier: 50 lookups/month. Install: `npx scala-mcp-server`.


### PR DESCRIPTION
Adds **Steep** under **📊 Data Analysis & Business Intelligence**.

[Steep](https://steep.app) is a governed semantic-layer / BI platform. Its MCP server exposes the same governed metrics that power Steep.

- **Repo:** https://github.com/SteepHq/steep-mcp
- **Endpoint:** `https://mcp.steep.app/mcp` — streamable-HTTP, OAuth (RFC 9728 + dynamic client registration)
- **Official MCP Registry:** `app.steep/mcp`
- **Tools:** query metrics (date ranges + breakdowns), targets, entities, modules, reports, workspace members — and create reports
- **License:** Apache-2.0