### PR TITLE
Add Casa to Filesystems

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ The README is now a lightweight entry point. Browse the full directory in the ca
 | Data Analysis & Business Intelligence | 244 | [Browse](docs/data-analysis--business-intelligence.md) |
 | Databases | 299 | [Browse](docs/databases.md) |
 | Developer Productivity & Utilities | 414 | [Browse](docs/developer-productivity--utilities.md) |
-| Filesystems | 56 | [Browse](docs/filesystems.md) |
+| Filesystems | 57 | [Browse](docs/filesystems.md) |
 | Finance & Crypto | 445 | [Browse](docs/finance--crypto.md) |
 | Frameworks | 245 | [Browse](docs/frameworks.md) |
 | Gaming | 108 | [Browse](docs/gaming.md) |

--- a/docs/filesystems.md
+++ b/docs/filesystems.md
@@ -58,3 +58,5 @@ Servers focused on interacting with local or remote file systems for reading, wr
 
 
 - [fast-filesystem-mcp](https://github.com/efforthye/fast-filesystem-mcp): Advanced filesystem operations with large file handling capabilities and Claude-optimized features. Provides fast file reading/writing, sequential reading for large files, directory operations, file search, and streaming writes with backup & recovery.
+
+- [tony8713/casa](https://github.com/tony8713/casa): Encrypted, pay-per-call (x402/USDC) permanent storage for AI agents. Content is encrypted client-side (zero-knowledge) and stored permanently; each store costs $0.01 USDC paid automatically over x402 from your own wallet, and the wallet that pays is the wallet that decrypts. Ships an MCP server plus a TypeScript SDK.


### PR DESCRIPTION
Adds **Casa** to the **Filesystems** category (docs/filesystems.md), and bumps the README count.

Casa — encrypted, pay-per-call (x402/USDC) permanent storage for AI agents; MCP server + SDK. Content is encrypted client-side (zero-knowledge), each store is auto-paid $0.01 USDC over x402, and the wallet that pays is the wallet that decrypts.

- Repo: https://github.com/tony8713/casa

🤖 Generated with [Claude Code](https://claude.com/claude-code)