### PR TITLE
Remove dead Knowledge Management entries

### DIFF
--- a/docs/knowledge-management--memory.md
+++ b/docs/knowledge-management--memory.md
@@ -30,7 +30,6 @@ Servers connecting to personal knowledge bases, flashcard apps, building/queryin
 - [brian3814/notion_fastmcp](https://github.com/brian3814/notion_fastmcp): Facilitates task management in Notion through an MCP server integration with Cursor IDE.
 - [KerolIA98/mcp-sample](https://github.com/KerolIA98/mcp-sample): A template MCP server integrated with Mem0, enabling AI agents to manage long-term memory through semantic search and storage.
 - [mkusaka/mcp-server-memory](https://github.com/mkusaka/mcp-server-memory): A persistent memory server utilizing a local knowledge graph to enable Claude to retain user information across interactions.
-- [Arc-Computer/arc-mcp-server](https://github.com/Arc-Computer/arc-mcp-server): Arc Memory MCP Server bridges Arc Memory TKG with MCP clients, enabling AI-assisted development through structured, temporal knowledge graph access.
 - [jordankamto/code-explorer-mcp](https://github.com/jordankamto/code-explorer-mcp): A TypeScript-based server that manages and summarizes text notes using the Model Context Protocol.
 - [meetdhanani17/xgmem](https://github.com/meetdhanani17/xgmem): A TypeScript-based MCP server for managing project-specific and cross-project knowledge graph memory for LLM agents and tools.
 - [jodli/git-github.com-jodli-factorio-modding-api](https://github.com/jodli/git-github.com-jodli-factorio-modding-api): A TypeScript-based server enabling access to Factorio Modding API documentation through Model Context Protocol queries.
@@ -66,7 +65,6 @@ Servers connecting to personal knowledge bases, flashcard apps, building/queryin
 - [HaruHunab1320/docmost-mcp](https://github.com/HaruHunab1320/docmost-mcp): Docmost integrates AI assistants with collaborative documentation through the Model Context Protocol, enabling seamless AI-assisted workflows.
 - [gpreddy172/MCP-Server-for-Documentation](https://github.com/gpreddy172/MCP-Server-for-Documentation): Facilitates searching for the latest documentation across various libraries using a standardized protocol.
 - [SilenceBoy/ai2flomo](https://github.com/SilenceBoy/ai2flomo): Facilitates seamless note-taking and management between AI assistants and Flomo, leveraging FastMCP for efficient synchronization and historical record retrieval.
-- [944750720/chemican-mcp](https://github.com/944750720/chemican-mcp): Facilitates seamless integration with the Notion API, enabling automated content management and interaction through MCP protocol.
 - [AdilFayyaz/Slack-Search](https://github.com/AdilFayyaz/Slack-Search): A local MCP server that enhances Slack search capabilities by integrating with Claude Desktop for intelligent, private querying of Slack export logs.
 - [jfim/obsidian-tasks-mcp](https://github.com/jfim/obsidian-tasks-mcp): Facilitates AI-assisted task management by extracting and querying tasks from Obsidian markdown files using the MCP protocol.
 - [andrewginns/mcp-mind-palace](https://github.com/andrewginns/mcp-mind-palace): A Python-based MCP server offering a persistent, searchable knowledge base for LLMs using Markdown files and ChromaDB for semantic search.
@@ -81,7 +79,6 @@ Servers connecting to personal knowledge bases, flashcard apps, building/queryin
 - [zw459123678/tuniao-server](https://github.com/zw459123678/tuniao-server): Access and explore TuNiao UI components through a Model Context Protocol server with AI model integration.
 - [Joeycz/whistle-docs-server](https://github.com/Joeycz/whistle-docs-server): Facilitates search and access to Whistle documentation through a TypeScript-based MCP server.
 - [StitchAI/stitch-ai-mcp](https://github.com/StitchAI/stitch-ai-mcp): A decentralized knowledge hub for AI, enabling efficient memory management through a Model Context Protocol server.
-- [andrefelipe18/tall-mcp](https://github.com/andrefelipe18/tall-mcp): A TypeScript-based server enabling AI assistants to access local documentation for Filament, Laravel, and Livewire, enhancing offline reference capabilities.
 - [kibela/kibela-mcp-server](https://github.com/kibela/kibela-mcp-server): Facilitates seamless interaction with Kibela through a local MCP server, enabling note and folder management, AI-assisted writing, and more.
 - [noahgorstein/mcp-server-stardog](https://github.com/noahgorstein/mcp-server-stardog): Facilitates interaction and automation with Stardog Knowledge Graphs through a Model Context Protocol server.
 - [springdo/mcp-cookbook](https://github.com/springdo/mcp-cookbook): Access the Gousto cookbook API to browse and search recipes with this MCP server.
@@ -160,7 +157,6 @@ Servers connecting to personal knowledge bases, flashcard apps, building/queryin
 - [BangyiZhang/xmind-generator-mcp](https://github.com/BangyiZhang/xmind-generator-mcp): Facilitates the creation of structured Xmind mind maps through LLMs using the MCP protocol.
 - [fnf-deepHeading/mcp-api-server-wrapper](https://github.com/fnf-deepHeading/mcp-api-server-wrapper): A template for wrapping external APIs into MCP servers using AI, featuring automatic API integration and Docker support.
 - [apw124/logseq-mcp](https://github.com/apw124/logseq-mcp): Facilitates AI agents' interaction with Logseq graphs through a set of MCP tools, enabling seamless data manipulation and retrieval.
-- [AgentTorch/mcp-server](https://github.com/AgentTorch/mcp-server): AgentTorch MCP server facilitates local and Claude Desktop integration for running simulations via Docker.
 - [rsym/how-person](https://github.com/rsym/how-person): A TypeScript-based MCP server implementing a simple notes system with tools for note creation and summarization.
 - [rarandeyo/INIAD-MOOCs-MCP](https://github.com/rarandeyo/INIAD-MOOCs-MCP): Automates login, assignment submission, and file uploads for INIAD MOOCs using Playwright MCP.
 - [moritalous/mermaid-doc-mcp-server](https://github.com/moritalous/mermaid-doc-mcp-server): Facilitates the generation and retrieval of Mermaid diagram documentation through an MCP server interface.
@@ -174,7 +170,6 @@ Servers connecting to personal knowledge bases, flashcard apps, building/queryin
 - [vyahhi/hyperskill-mcp-server](https://github.com/vyahhi/hyperskill-mcp-server): Facilitates searching and accessing educational content on Hyperskill through an MCP server.
 - [7nohe/qiita-mcp](https://github.com/7nohe/qiita-mcp): Facilitates interaction with Qiita's API for retrieving user and article information using the Model Context Protocol.
 - [r-huijts/strava-mcp](https://github.com/r-huijts/strava-mcp): Connects to Strava API, enabling LLMs to access and manage Strava data and activities.
-- [cer12u/wikimcp](https://github.com/cer12u/wikimcp): Facilitates interaction between Claude Desktop and Wiki.js by enabling page listing, reading, creation, and updating.
 - [PhiloSolares/roam-mcp](https://github.com/PhiloSolares/roam-mcp): Connects AI assistants like Claude to Roam Research for seamless data interaction and management.
 - [jaw9c/awesome-remote-mcp-servers](https://github.com/jaw9c/awesome-remote-mcp-servers): A curated list of high-quality remote MCP servers for developers seeking reliable and production-ready services for AI applications.
 - [mbcrawfo/KnowledgeBaseServer](https://github.com/mbcrawfo/KnowledgeBaseServer): Facilitates LLMs in storing and retrieving conversational memories using SQLite's full-text search capabilities.
@@ -187,7 +182,6 @@ Servers connecting to personal knowledge bases, flashcard apps, building/queryin
 - [Qwinty/anytype-mcp](https://github.com/Qwinty/anytype-mcp): Facilitates interaction with Anytype data through an MCP server, enabling AI assistants and other clients to manage spaces, objects, and templates.
 - [BaoxingZhang/mcp-server-notion-prompt](https://github.com/BaoxingZhang/mcp-server-notion-prompt): Access and manage prompts stored in Notion databases using the Model Context Protocol (MCP) standard.
 - [phkus/tinderbox-mcp](https://github.com/phkus/tinderbox-mcp): Facilitates AI-driven interactions with Tinderbox, enabling natural language control and integration with other services through AppleScript.
-- [BangyiZhang/xmind-generator-mcp-server](https://github.com/BangyiZhang/xmind-generator-mcp-server): Facilitates the creation of Xmind mind maps through a standardized API, supporting both stdio and HTTP server modes for seamless integration with AI assistants and applications.
 - [hassaku63/mcp-start-go](https://github.com/hassaku63/mcp-start-go): A Go-based example of an MCP server implementation, demonstrating cross-platform capabilities with StdioTransport.
 - [JordanDalton/AnthropicMcpClient](https://github.com/JordanDalton/AnthropicMcpClient): A CLI tool for interacting with Anthropic MCP servers, enabling tool execution across multiple server connections.
 - [jesegher/EduMCPServer](https://github.com/jesegher/EduMCPServer): Facilitates AI-driven management of Microsoft Education classes, assignments, and rubrics through integration with Microsoft Graph API.
@@ -208,7 +202,6 @@ Servers connecting to personal knowledge bases, flashcard apps, building/queryin
 - [shiquda/mediawiki-mcp-server](https://github.com/shiquda/mediawiki-mcp-server): Facilitates seamless interaction with MediaWiki-based sites, enabling LLMs to search and retrieve content from platforms like Wikipedia and Fandom.
 - [Tae4an/mcp-prompt-manager](https://github.com/Tae4an/mcp-prompt-manager): Facilitates efficient management of local prompt files for AI models like Claude, enabling prompt creation, retrieval, modification, and deletion.
 - [uoky5217/Mcp-Server-Study](https://github.com/uoky5217/Mcp-Server-Study): A learning project implementing an MCP server with stdio and SSE transport methods for basic arithmetic operations.
-- [andrewmccarthywustl/model-context-protocol-obsidian](https://github.com/andrewmccarthywustl/model-context-protocol-obsidian): Facilitates seamless integration of personal notes and projects with LLMs using MCP, enhancing context-aware interactions.
 - [kwanLeeFrmVi/mcp-server-memory](https://github.com/kwanLeeFrmVi/mcp-server-memory): Facilitates AI models' persistent memory through a knowledge graph, enabling information retention and recall across interactions.
 - [yenslife/nckuhub-mcp](https://github.com/yenslife/nckuhub-mcp): Leverage the NCKUHub API to provide a robust MCP service for seamless integration and development.
 - [kaygee/rev-mcp](https://github.com/kaygee/rev-mcp): Fetches transcripts from Rev.com using their API, integrating seamlessly with MCP clients like Claude for Desktop.
@@ -333,7 +326,6 @@ Servers connecting to personal knowledge bases, flashcard apps, building/queryin
 - [ndchikin/reference-mcp](https://github.com/ndchikin/reference-mcp): Facilitates seamless integration of BibTeX-formatted citation retrieval from CiteAs and Google Scholar into applications.
 - [Jon-Vii/canvas-student-mcp](https://github.com/Jon-Vii/canvas-student-mcp): Facilitates interaction between Canvas LMS and LLM clients using the MCP standard, enabling course content retrieval and assignment management.
 - [arabold/docs-mcp-server](https://github.com/arabold/docs-mcp-server): Facilitates efficient scraping, indexing, and searching of third-party library documentation using semantic splitting and vector embeddings.
-- [edcity-mlearning/teaapp-mcp-api](https://github.com/edcity-mlearning/teaapp-mcp-api): A TypeScript-based MCP server implementing a simple notes system with resources, tools, and prompts for note management and summarization.
 - [tejpalvirk/contextmanager](https://github.com/tejpalvirk/contextmanager): Enhances AI models with persistent context across work sessions using domain-specific knowledge graphs managed by a central Context Manager.
 - [elliottlawson/kagi-mcp-server](https://github.com/elliottlawson/kagi-mcp-server): A Node.js server enabling AI assistants to perform web searches using the Kagi API, supporting parallel queries and formatted results.
 - [ronaldtebrake/slite-mcp](https://github.com/ronaldtebrake/slite-mcp): Facilitates AI interaction with Slite notes through a Model Context Protocol server, enabling note management and search functionalities.
@@ -396,7 +388,6 @@ Servers connecting to personal knowledge bases, flashcard apps, building/queryin
 - [jsonresume/mcp](https://github.com/jsonresume/mcp): Enhance your JSON Resume with AI by analyzing your coding projects and updating your resume automatically.
 - [joleyline/mcp-memory-libsql](https://github.com/joleyline/mcp-memory-libsql): High-performance persistent memory system utilizing libSQL for vector search and semantic knowledge storage, ideal for AI agents and knowledge graph applications.
 - [wxxedu/ankify](https://github.com/wxxedu/ankify): Repository classified as category 19
-- [craycrayfish/cowriter](https://github.com/craycrayfish/cowriter): Facilitates collaborative writing through an MCP server integrated with LLM chat and Telegram messaging.
 - [SAhmadUmass/notion-mcp-server](https://github.com/SAhmadUmass/notion-mcp-server): Facilitates seamless interaction between Claude and Notion workspaces, enabling advanced page and database management.
 - [Cam10001110101/mcp-server-obsidian-jsoncanvas](https://github.com/Cam10001110101/mcp-server-obsidian-jsoncanvas): Facilitates the creation, manipulation, and validation of infinite canvas data structures using JSON Canvas files.
 - [Tom-Semple/mcp-apple-notes-fixed](https://github.com/Tom-Semple/mcp-apple-notes-fixed): Facilitates semantic search and retrieval over Apple Notes for AI assistants like Claude, leveraging on-device embeddings and vector storage.
@@ -434,7 +425,6 @@ Servers connecting to personal knowledge bases, flashcard apps, building/queryin
 - [sujianqingfeng/mcp-apifox](https://github.com/sujianqingfeng/mcp-apifox): Facilitates seamless integration between Apifox API documentation and AI assistants using the Model Context Protocol.
 - [succil3/clanki](https://github.com/succil3/clanki): Facilitates AI assistants' interaction with Anki flashcard decks through MCP, supporting deck management and card creation.
 - [d-klotz/perplexity-mcp-ts](https://github.com/d-klotz/perplexity-mcp-ts): Integrate Perplexity AI with Cline, Windsurf, and Cursor using configurable MCP servers.
-- [CarlosCommits/SimpleDocs](https://github.com/CarlosCommits/SimpleDocs): A documentation web scraper and search engine utilizing MCP for intelligent content extraction and semantic search across multiple sources.
 - [orbit-logistics/notion-mcp-server](https://github.com/orbit-logistics/notion-mcp-server): Enables seamless interaction between LLMs and Notion by mirroring the Notion API SDK as MCP tools.
 - [valyu-network/valyu-mcp](https://github.com/valyu-network/valyu-mcp): Enables AI models to access high-quality context from Valyu's API, offering comprehensive search capabilities over Wikipedia, arXiv, and web search.
 - [davidvc/code-knowledge-mcptool](https://github.com/davidvc/code-knowledge-mcptool): A tool for managing and querying codebase knowledge using vector embeddings, integrated with RooCode and Cline via MCP.
@@ -508,7 +498,6 @@ Servers connecting to personal knowledge bases, flashcard apps, building/queryin
 - [th3w1zard1/cedarscript-mcp](https://github.com/th3w1zard1/cedarscript-mcp): Integrates CEDARScript grammar for advanced code manipulation and pattern-based transformations.
 - [StevenStavrakis/obsidian-mcp](https://github.com/StevenStavrakis/obsidian-mcp): Facilitates AI-driven management of Obsidian vaults, enabling note reading, creation, editing, and tag management.
 - [emzimmer/server-moz-readability](https://github.com/emzimmer/server-moz-readability): Transforms webpage content into clean, LLM-optimized Markdown using Mozilla's Readability algorithm, removing ads and non-essential elements while preserving core content.
-- [heltonteixeira/ragdocs](https://github.com/heltonteixeira/ragdocs): Facilitates RAG-based document search and management using Qdrant and embeddings for semantic similarity.
 - [GuoAccount/notepad-server](https://github.com/GuoAccount/notepad-server): A TypeScript-based notes server implementing the MCP protocol, offering note management and integration with Claude Desktop.
 - [skydeckai/mcp-rememberizer-vectordb](https://github.com/skydeckai/mcp-rememberizer-vectordb): Facilitates LLM interactions with Rememberizer Vector Store for semantic document search and management.
 - [2b3pro/roam-research-mcp](https://github.com/2b3pro/roam-research-mcp): Facilitates AI interaction with Roam Research graphs through a standardized interface, enabling comprehensive API access and advanced data retrieval.
@@ -530,7 +519,6 @@ Servers connecting to personal knowledge bases, flashcard apps, building/queryin
 - [qpd-v/mcp-ragdocs](https://github.com/qpd-v/mcp-ragdocs): Facilitates semantic search and retrieval of documentation using a vector database, enabling natural language queries for added documentation from URLs or local files.
 - [lloydchang/PierrunoYT-openrouter-docs-server](https://github.com/lloydchang/PierrunoYT-openrouter-docs-server): A TypeScript-based MCP server implementing a simple notes system with resources, tools, and prompts for note management and summarization.
 - [domdomegg/airtable-mcp-server](https://github.com/domdomegg/airtable-mcp-server): Facilitates AI-driven interactions with Airtable databases by providing read and write access through a Model Context Protocol server.
-- [gabornyergesX/mcp-notion-server](https://github.com/gabornyergesX/mcp-notion-server): Facilitates seamless interaction between Claude and Notion through a TypeScript-based MCP server, enabling efficient management and analysis of Notion content.
 - [viewyonder/claudemcp](https://github.com/viewyonder/claudemcp): Explore and learn Claude MCP through Python code and documentation, focusing on building a CLI host app with conversational interfaces.
 - [narphorium/mcp-memex](https://github.com/narphorium/mcp-memex): Memex enhances web content analysis and integration into a knowledge base using the Model Context Protocol.
 - [scorzeth/anki-mcp-server](https://github.com/scorzeth/anki-mcp-server): Facilitates seamless interaction with Anki for card review and creation through a locally connected MCP server.
@@ -563,7 +551,6 @@ Servers connecting to personal knowledge bases, flashcard apps, building/queryin
 - [get-engram/engram](https://github.com/get-engram/engram): Hosted memory service for AI agents that stores complete, verbatim conversation transcripts and makes them searchable via semantic search. Built on Cloudflare Workers + D1 + Vectorize. Free tier at mcp.getengram.app.
 - [Fisher521/burn-mcp-server](https://github.com/Fisher521/burn-mcp-server): Burn 451 MCP server with 26 tools for saving, searching, and triaging a personal read-later queue with a 24h burn timer (Flame → Spark → Vault → Ash pipeline). Works with Claude, Cursor, and Windsurf via stdio. Requires a free Burn account token. MIT licensed, available on npm.
 
-- [Evanyuan-builder/memory-core](https://github.com/Evanyuan-builder/memory-core): Unified memory layer for AI agents and teams. Provides semantic search, temporal fact tracking (Graphiti/FalkorDB), and shared memory via REST API, Python SDK, and MCP server. Supports local Ollama — no cloud API key required.
 - [GuyMannDude/mnemo-cortex](https://github.com/GuyMannDude/mnemo-cortex): Persistent cross-agent semantic memory for AI agents (v2.0). Privacy-first share switch (separate/always/never + per-session toggle). Multi-agent with isolated writes and privacy-controlled reads. Local-first SQLite + FTS5, zero-cost compaction via local Ollama. Three integration paths: Claude Code, Claude Desktop, and OpenClaw MCP.
 - [Bpolat0/atlasmemory](https://github.com/Bpolat0/atlasmemory): Evidence-backed AI memory for codebases. Tree-sitter indexing (11 languages), proof system with line:hash anchors, token-budgeted context packs, drift detection, cross-session learning. 28 MCP tools, VS Code extension, zero config.
 - [LeandroPG19/cuba-memorys](https://github.com/LeandroPG19/cuba-memorys): Persistent memory for AI agents with 13 Cuban-named MCP tools. Knowledge graph with Hebbian learning, exponential decay, hybrid search (RRF + pgvector), anti-hallucination grounding, error memory, and REM sleep consolidation. Rust, PostgreSQL.


### PR DESCRIPTION
## Summary
- remove 13 Knowledge Management & Memory catalog entries whose GitHub project URLs now return 404
- convert the corresponding broken-entry reports into an actual docs cleanup instead of merging report-only draft PRs

## Verified 404 entries
- #858: `https://github.com/944750720/chemican-mcp`
- #860: `https://github.com/andrefelipe18/tall-mcp`
- #861: `https://github.com/Arc-Computer/arc-mcp-server`
- #874: `https://github.com/AgentTorch/mcp-server`
- #875: `https://github.com/andrewmccarthywustl/model-context-protocol-obsidian`
- #876: `https://github.com/BangyiZhang/xmind-generator-mcp-server`
- #877: `https://github.com/cer12u/wikimcp`
- #878: `https://github.com/edcity-mlearning/teaapp-mcp-api`
- #893: `https://github.com/CarlosCommits/SimpleDocs`
- #894: `https://github.com/craycrayfish/cowriter`
- #895: `https://github.com/Evanyuan-builder/memory-core`
- #896: `https://github.com/gabornyergesX/mcp-notion-server`
- #897: `https://github.com/heltonteixeira/ragdocs`

## Verification
- Ran `curl -L` against each GitHub URL; all returned HTTP 404
- Confirmed each URL existed in `docs/knowledge-management--memory.md` on latest `origin/main`
- Confirmed the cleanup diff only deletes those 13 entries from `docs/knowledge-management--memory.md`

Related broken-entry draft PRs: #865, #864, #866, #882, #883, #881, #879, #880, #901, #898, #899, #902, #900.

Closes #858
Closes #860
Closes #861
Closes #874
Closes #875
Closes #876
Closes #877
Closes #878
Closes #893
Closes #894
Closes #895
Closes #896
Closes #897