### PR TITLE
Add Unity-MCP, Godot-MCP, Unreal-MCP to Gaming

### DIFF
--- a/docs/gaming.md
+++ b/docs/gaming.md
@@ -112,3 +112,6 @@ $UNIFIED
 - [maxsloef/loom-mcp](https://github.com/maxsloef/loom-mcp): A TypeScript-based MCP server that implements a simple loom interface for Claude, enabling parallel generation and selection of model completions.
 
 - [loomle/loomle](https://github.com/loomle/loomle): Unreal Engine MCP server for Claude Code, Codex, and AI agents to inspect and edit live UE projects through Blueprint, Material, PCG, UMG, asset, context, and diagnostics tools.
+- [Unity-MCP](https://github.com/IvanMurzak/Unity-MCP): Open-source MCP server connecting AI agents (Claude, Cursor, GitHub Copilot, Gemini, and more) to the Unity Editor and runtime, with 100+ built-in tools.
+- [Godot-MCP](https://github.com/IvanMurzak/Godot-MCP): Open-source MCP server connecting AI agents to the Godot Editor and runtime (Godot 4.x, C#).
+- [Unreal-MCP](https://github.com/IvanMurzak/Unreal-MCP): Open-source MCP server connecting AI agents to Unreal Engine 5.7, editor and runtime (C++ plugin + .NET sidecar).


### PR DESCRIPTION
Adds Unity-MCP, Godot-MCP, and Unreal-MCP to the Gaming section. These are open-source (Apache-2.0) MCP servers that connect AI coding agents (Claude, Cursor, GitHub Copilot, Gemini, and others) to the Unity, Godot, and Unreal Engine 5.7 editors and runtimes via Anthropic's Model Context Protocol. Maintained at github.com/IvanMurzak/Unity-MCP, github.com/IvanMurzak/Godot-MCP, github.com/IvanMurzak/Unreal-MCP. Happy to adjust formatting/placement to match your conventions — thanks for maintaining this list!