### PR TITLE
add remoteopenclaw-mcp to developer productivity and utilities

### DIFF
--- a/docs/developer-productivity--utilities.md
+++ b/docs/developer-productivity--utilities.md
@@ -2,6 +2,7 @@
 
 Servers enhancing developer workflows, integrating with IDEs, accessing documentation, API exploration, code generation helpers, or general dev utilities.
 
+- [aidevelopers2/remoteopenclaw-mcp](https://github.com/aidevelopers2/remoteopenclaw-mcp): MCP server and CLI that searches 13,870+ MCP servers, 4,384+ skills, and plugins from the terminal or an AI agent. Install: `npx -y remoteopenclaw`. Stdio transport, no API key.
 - [friendlygeorge/cron-scheduler-mcp-server](https://github.com/friendlygeorge/cron-scheduler-mcp-server): Cron job scheduling MCP server for AI agents with 7 tools to create, list, delete, run, monitor, pause, and resume jobs. SQLite persistence, retry logic, webhook triggers, systemd integration, and observability metrics. Install: `npx @supernova123/cron-scheduler-mcp-server`. Stdio transport, no auth. MIT.
 - [BARRYPMARSHALL/free33](https://github.com/BARRYPMARSHALL/free33): A2A microservices platform with MCP-compatible services for code review, security scanning, WASM compilation, structured parsing, log analysis, dependency audit, config validation, PR descriptions, complexity analysis, and schema inference.
 - [Dedicated Mac Mini AI Bot Setup MCP](https://github.com/eibrahim/dedicated-mac-mini-ai-bot-setup-mcp): Read-only hosted MCP endpoint for evaluating dedicated Mac mini AI operator setup services, pricing, queue status, proof links, buyer routes, and setup guardrails. Streamable HTTP endpoint: https://www.emadibrahim.com/mcp.


### PR DESCRIPTION
adds remoteopenclaw-mcp to the developer productivity and utilities category.

it is an MCP server and CLI that searches 13,870+ MCP servers, 4,384+ skills, and plugins from the terminal or an AI agent. stdio transport, no API key needed, MIT licensed, TypeScript.

install: `npx -y remoteopenclaw` or `claude mcp add remoteopenclaw -- npx -y remoteopenclaw`

🤖 Generated with [Claude Code](https://claude.com/claude-code)