### PR TITLE
Improve profile claim and broken-entry workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/claim-profile.yml
+++ b/.github/ISSUE_TEMPLATE/claim-profile.yml
@@ -7,7 +7,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Use this form if you maintain an indexed MCP server and want the public profile to show maintainer and verification metadata. The Project URL should match the indexed profile source, repository, homepage, docs URL, or existing metadata sidecar project URL.
+        Use this form if you maintain an indexed MCP server and want the public profile to show maintainer claim metadata. Claiming a profile is separate from TensorBlock verification. The Project URL should match the indexed profile source, repository, homepage, docs URL, or existing metadata sidecar project URL.
   - type: input
     id: profile-url
     attributes:
@@ -33,17 +33,17 @@ body:
   - type: textarea
     id: proof
     attributes:
-      label: Maintainer proof
-      description: Explain how we can verify your relationship to the project.
+      label: Optional maintainer proof
+      description: Optional links or notes that support your claim. Claims can be accepted without this, but stronger verification signals may be added later through metadata updates.
       placeholder: |
         I am an owner of the GitHub repo / npm package / organization.
         Verification link:
     validations:
-      required: true
+      required: false
   - type: textarea
     id: metadata
     attributes:
       label: Metadata you want displayed
-      description: Optional maintainer, verification, docs, or support details for the indexed profile.
+      description: Optional maintainer, docs, support, install, auth, or verification details for the indexed profile.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/report-broken-entry.yml
+++ b/.github/ISSUE_TEMPLATE/report-broken-entry.yml
@@ -1,5 +1,5 @@
 name: Report broken entry
-description: Report a duplicate, dead link, bad category, stale metadata, or unsafe entry. Clear reports can generate a draft investigation PR.
+description: Report a duplicate, dead link, bad category, stale metadata, or unsafe entry. Clear dead-link reports can generate cleanup PRs; other reports generate draft investigation PRs.
 title: "Report broken MCP entry: "
 labels:
   - broken-entry

--- a/.github/scripts/comment-merged-pr.mjs
+++ b/.github/scripts/comment-merged-pr.mjs
@@ -79,6 +79,7 @@ export function buildMergedPrComment({ pullRequest, entries }) {
     ...visibleEntries.flatMap(formatEntryFollowUp),
     ...(omittedCount > 0 ? [`_Omitted ${omittedCount} additional entries from this comment._`, ""] : []),
     "Help the MCP community find better servers:",
+    "- TensorBlock contributes free hosting, indexing, install-config generation, and registry API infrastructure for the MCP community.",
     `- Star this repo if the TensorBlock MCP Index is useful: ${REPO_URL}`,
     "- Share the indexed profile with users who need install/config metadata.",
     `- Join the community: ${DISCORD_URL}`,

--- a/.github/scripts/comment-merged-pr.test.mjs
+++ b/.github/scripts/comment-merged-pr.test.mjs
@@ -95,5 +95,6 @@ test("builds a merged PR follow-up with profile, API, badge, and community links
   assert.match(comment, /Share this profile/);
   assert.match(comment, /Add the README badge/);
   assert.match(comment, /Missing install, transport, auth, docs, license, or tool metadata\?/);
+  assert.match(comment, /free hosting, indexing, install-config generation, and registry API infrastructure/);
   assert.match(comment, /Star this repo/);
 });

--- a/.github/scripts/create-broken-entry-report-pr.mjs
+++ b/.github/scripts/create-broken-entry-report-pr.mjs
@@ -10,6 +10,7 @@ const API_BASE = "https://api.github.com";
 const COMMENT_MARKER = "<!-- tensorblock-mcp-broken-entry-report-pr:v1 -->";
 const DEFAULT_BASE_BRANCH = "main";
 const REPORT_DIR = "docs/broken-entry-reports";
+const DEAD_LINK_STATUS_CODES = new Set([404, 410, 451]);
 
 export function parseBrokenEntryIssue(body) {
   const entryReference = normalizeField(extractField(body, "TensorBlock profile URL, server id, or project URL"));
@@ -110,6 +111,127 @@ export function buildBrokenEntryReportSpec({ issue, report }) {
   };
 }
 
+export function findBrokenEntryTargets(catalog, report) {
+  if (report.serverId) {
+    return catalog.filter((entry) => entry.id === report.serverId);
+  }
+
+  const references = unique([
+    firstUrl(report.entryReference) || report.entryReference,
+    firstUrl(report.source),
+  ].filter(Boolean).map(canonicalizeUrl));
+
+  if (references.length === 0) {
+    return [];
+  }
+
+  return catalog.filter((entry) => {
+    const links = [
+      entry.links?.primary,
+      entry.links?.repo,
+      entry.links?.homepage,
+      entry.links?.docs,
+      entry.links?.endpoint,
+    ].filter(Boolean).map(canonicalizeUrl);
+
+    return links.some((link) => references.includes(link));
+  });
+}
+
+export async function buildDeadEntryCleanupCandidate({ catalog, report, fetchImpl = fetch }) {
+  if (report.issueTypes.length !== 1 || report.issueTypes[0] !== "Dead link") {
+    return null;
+  }
+
+  const targets = findBrokenEntryTargets(catalog, report);
+  if (targets.length !== 1) {
+    return null;
+  }
+
+  const entry = targets[0];
+  const sourcePath = entry.source?.docsPath;
+  const checkedUrl = deadLinkCheckUrlForEntry(report, entry);
+
+  if (!sourcePath || !checkedUrl || !isValidHttpUrl(checkedUrl)) {
+    return null;
+  }
+
+  if (catalogPrimaryUrlMatches(catalog, checkedUrl).length !== 1) {
+    return null;
+  }
+
+  const statusCode = await fetchHttpStatus(checkedUrl, fetchImpl);
+  if (!DEAD_LINK_STATUS_CODES.has(statusCode)) {
+    return null;
+  }
+
+  return {
+    entry,
+    path: sourcePath,
+    checkedUrl,
+    statusCode,
+  };
+}
+
+export function removeEntryLineFromMarkdown(markdown, entry) {
+  const urls = unique([
+    entry.links?.primary,
+    entry.links?.repo,
+    entry.links?.homepage,
+    entry.links?.docs,
+    entry.links?.endpoint,
+  ].filter(Boolean));
+  const hadTrailingNewline = markdown.endsWith("\n");
+  const removedLines = [];
+  const keptLines = markdown.split(/\r?\n/).filter((line, index, lines) => {
+    if (index === lines.length - 1 && line === "" && hadTrailingNewline) {
+      return true;
+    }
+
+    const shouldRemove = /^\s*-\s+\[/.test(line) && urls.some((url) => line.includes(url));
+    if (shouldRemove) {
+      removedLines.push(line);
+      return false;
+    }
+
+    return true;
+  });
+
+  let content = keptLines.join("\n");
+  if (hadTrailingNewline && !content.endsWith("\n")) {
+    content += "\n";
+  }
+
+  return {
+    content,
+    removedLines,
+  };
+}
+
+export function buildDeadEntryCleanupPrBody({ issue, report, cleanup, removal }) {
+  return [
+    "## Summary",
+    `- remove verified-dead catalog entry \`${cleanup.entry.name}\` from \`${cleanup.path}\``,
+    `- checked \`${cleanup.checkedUrl}\` and received HTTP ${cleanup.statusCode}`,
+    "- keep the fix scoped to the source category docs; no generated catalog files are committed",
+    "",
+    "## Reported issue types",
+    report.issueTypes.map((issueType) => `- ${issueType}`).join("\n"),
+    "",
+    "## Removed entry",
+    "",
+    "```md",
+    ...removal.removedLines,
+    "```",
+    "",
+    "## Source issue",
+    "",
+    issue.html_url ?? `#${issue.number}`,
+    "",
+    `Closes #${issue.number}`,
+  ].join("\n");
+}
+
 export function buildIssueComment({ issue, report, pullRequest, errors }) {
   if (errors?.length) {
     return [
@@ -133,6 +255,18 @@ export function buildIssueComment({ issue, report, pullRequest, errors }) {
   }
 
   const target = report.serverId || report.entryReference;
+
+  if (pullRequest?.cleanup) {
+    return [
+      COMMENT_MARKER,
+      `Created a cleanup PR for verified-dead entry \`${target}\`: ${pullRequest.html_url}`,
+      "",
+      `The automation rechecked ${pullRequest.checkedUrl} and received HTTP ${pullRequest.statusCode}, then removed the matching docs entry from \`${pullRequest.path}\`.`,
+      "",
+      `Source issue: #${issue.number}`,
+    ].join("\n");
+  }
+
   return [
     COMMENT_MARKER,
     `Created a draft broken-entry report PR for \`${target}\`: ${pullRequest.html_url}`,
@@ -182,6 +316,18 @@ function writeSpec(spec) {
   fs.writeFileSync(spec.path, spec.content);
 }
 
+function writeDeadEntryCleanup(cleanup) {
+  const markdown = fs.readFileSync(cleanup.path, "utf8");
+  const removal = removeEntryLineFromMarkdown(markdown, cleanup.entry);
+
+  if (removal.removedLines.length === 0) {
+    return null;
+  }
+
+  fs.writeFileSync(cleanup.path, removal.content);
+  return removal;
+}
+
 function parseCheckedIssueTypes(value) {
   return value
     .split("\n")
@@ -224,6 +370,76 @@ function isValidHttpUrl(value) {
   }
 }
 
+function deadLinkCheckUrlForEntry(report, entry) {
+  const primaryUrl = entry.links?.primary;
+  if (!primaryUrl || !isValidHttpUrl(primaryUrl)) {
+    return "";
+  }
+
+  const canonicalPrimary = canonicalizeUrl(primaryUrl);
+  const reportedUrls = [
+    firstUrl(report.entryReference),
+    firstUrl(report.source),
+  ].filter(Boolean);
+
+  if (reportedUrls.length === 0) {
+    return primaryUrl;
+  }
+
+  if (reportedUrls.some((url) => canonicalizeUrl(url) === canonicalPrimary)) {
+    return primaryUrl;
+  }
+
+  if (report.serverId && !firstUrl(report.source)) {
+    return primaryUrl;
+  }
+
+  return "";
+}
+
+function catalogPrimaryUrlMatches(catalog, url) {
+  const canonicalUrl = canonicalizeUrl(url);
+  return catalog.filter((entry) => {
+    const primaryUrl = entry.links?.primary;
+    return primaryUrl && canonicalizeUrl(primaryUrl) === canonicalUrl;
+  });
+}
+
+function canonicalizeUrl(value) {
+  try {
+    const parsed = new URL(value.trim());
+    parsed.hash = "";
+    parsed.protocol = parsed.protocol.toLowerCase();
+    parsed.hostname = parsed.hostname.toLowerCase().replace(/^www\./, "");
+
+    if ((parsed.protocol === "https:" && parsed.port === "443") || (parsed.protocol === "http:" && parsed.port === "80")) {
+      parsed.port = "";
+    }
+
+    parsed.pathname = parsed.pathname.replace(/\.git$/i, "").replace(/\/+$/g, "");
+    return parsed.toString().replace(/\/$/g, "");
+  } catch {
+    return value.trim();
+  }
+}
+
+async function fetchHttpStatus(url, fetchImpl) {
+  try {
+    const response = await fetchImpl(url, {
+      method: "GET",
+      redirect: "follow",
+      signal: AbortSignal.timeout(15000),
+    });
+    return response.status;
+  } catch {
+    return 0;
+  }
+}
+
+function unique(values) {
+  return Array.from(new Set(values));
+}
+
 async function main() {
   const token = process.env.GITHUB_TOKEN;
   const eventPath = process.env.GITHUB_EVENT_PATH;
@@ -244,6 +460,7 @@ async function main() {
   const report = parseBrokenEntryIssue(issue.body ?? "");
   const request = createGitHubRequest({ token, owner, repo });
   const errors = validateBrokenEntryReport(report);
+  const catalog = JSON.parse(fs.readFileSync("data/catalog.json", "utf8"));
 
   if (errors.length > 0) {
     await upsertIssueComment(request, issue.number, buildIssueComment({ issue, report, errors }));
@@ -251,21 +468,33 @@ async function main() {
     return;
   }
 
-  const spec = buildBrokenEntryReportSpec({ issue, report });
   const branch = `mcp/broken-entry-issue-${issue.number}`;
-  const title = `Investigate broken MCP entry report #${issue.number}`;
-  const body = buildPrBody({ issue, report, spec });
 
   run("git", ["config", "user.name", "github-actions[bot]"]);
   run("git", ["config", "user.email", "41898282+github-actions[bot]@users.noreply.github.com"]);
   run("git", ["fetch", "origin", DEFAULT_BASE_BRANCH]);
   run("git", ["checkout", "-B", branch, `origin/${DEFAULT_BASE_BRANCH}`]);
 
-  writeSpec(spec);
-  run("git", ["add", spec.path]);
+  const cleanup = await buildDeadEntryCleanupCandidate({ catalog, report });
+  const removal = cleanup ? writeDeadEntryCleanup(cleanup) : null;
+  const spec = removal ? null : buildBrokenEntryReportSpec({ issue, report });
+  const title = removal
+    ? `Remove dead MCP entry report #${issue.number}`
+    : `Investigate broken MCP entry report #${issue.number}`;
+  const body = removal
+    ? buildDeadEntryCleanupPrBody({ issue, report, cleanup, removal })
+    : buildPrBody({ issue, report, spec });
+  const draft = !removal;
+
+  if (removal) {
+    run("git", ["add", cleanup.path]);
+  } else {
+    writeSpec(spec);
+    run("git", ["add", spec.path]);
+  }
 
   if (!hasStagedChanges()) {
-    console.log(`No broken-entry report changes generated for issue #${issue.number}.`);
+    console.log(`No broken-entry changes generated for issue #${issue.number}.`);
     return;
   }
 
@@ -279,6 +508,7 @@ async function main() {
       branch,
       title,
       body,
+      draft,
     });
   } catch (error) {
     if (!isPullRequestCreationBlocked(error)) {
@@ -304,8 +534,20 @@ async function main() {
     return;
   }
 
-  await upsertIssueComment(request, issue.number, buildIssueComment({ issue, report, pullRequest }));
-  console.log(`Created or updated draft PR ${pullRequest.html_url} for issue #${issue.number}.`);
+  await upsertIssueComment(request, issue.number, buildIssueComment({
+    issue,
+    report,
+    pullRequest: removal
+      ? {
+          ...pullRequest,
+          cleanup: true,
+          checkedUrl: cleanup.checkedUrl,
+          statusCode: cleanup.statusCode,
+          path: cleanup.path,
+        }
+      : pullRequest,
+  }));
+  console.log(`Created or updated ${draft ? "draft report" : "cleanup"} PR ${pullRequest.html_url} for issue #${issue.number}.`);
 }
 
 function run(command, args) {
@@ -348,7 +590,7 @@ function createGitHubRequest({ token, owner, repo }) {
   };
 }
 
-async function createOrUpdatePullRequest(request, { owner, branch, title, body }) {
+async function createOrUpdatePullRequest(request, { owner, branch, title, body, draft = true }) {
   const query = new URLSearchParams({
     head: `${owner}:${branch}`,
     state: "open",
@@ -357,10 +599,18 @@ async function createOrUpdatePullRequest(request, { owner, branch, title, body }
   const existingPull = existingPulls[0];
 
   if (existingPull) {
-    return request(`/pulls/${existingPull.number}`, {
+    const updatedPull = await request(`/pulls/${existingPull.number}`, {
       method: "PATCH",
       body: { title, body },
     });
+
+    if (!draft && existingPull.draft) {
+      return request(`/pulls/${existingPull.number}/ready_for_review`, {
+        method: "POST",
+      });
+    }
+
+    return updatedPull;
   }
 
   return request("/pulls", {
@@ -370,7 +620,7 @@ async function createOrUpdatePullRequest(request, { owner, branch, title, body }
       body,
       head: branch,
       base: DEFAULT_BASE_BRANCH,
-      draft: true,
+      draft,
       maintainer_can_modify: true,
     },
   });

--- a/.github/scripts/create-broken-entry-report-pr.test.mjs
+++ b/.github/scripts/create-broken-entry-report-pr.test.mjs
@@ -2,10 +2,14 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  buildDeadEntryCleanupCandidate,
+  buildDeadEntryCleanupPrBody,
   buildBrokenEntryReportSpec,
   buildIssueComment,
   buildPrBody,
+  findBrokenEntryTargets,
   parseBrokenEntryIssue,
+  removeEntryLineFromMarkdown,
   slugFromEntryReference,
   validateBrokenEntryReport,
 } from "./create-broken-entry-report-pr.mjs";
@@ -106,4 +110,134 @@ test("builds actionable comments and PR body", () => {
   assert.match(body, /## Summary/);
   assert.match(body, /docs\/broken-entry-reports\/901-github-owner-demo-mcp-12345678\.md/);
   assert.match(body, /Closes #901/);
+});
+
+test("builds direct cleanup changes for verified dead docs entries", async () => {
+  const report = {
+    ...parseBrokenEntryIssue(issueBody),
+    issueTypes: ["Dead link"],
+    source: "https://github.com/owner/demo-mcp",
+  };
+  const entry = {
+    id: "github-owner-demo-mcp-12345678",
+    name: "owner/demo-mcp",
+    source: {
+      docsPath: "docs/developer-productivity--utilities.md",
+    },
+    links: {
+      primary: "https://github.com/owner/demo-mcp",
+      repo: "https://github.com/owner/demo-mcp",
+      homepage: null,
+      docs: null,
+      endpoint: null,
+    },
+  };
+  const targets = findBrokenEntryTargets([entry], report);
+  const cleanup = await buildDeadEntryCleanupCandidate({
+    catalog: [entry],
+    report,
+    fetchImpl: async () => ({ status: 404 }),
+  });
+  const removal = removeEntryLineFromMarkdown([
+    "## Developer Productivity",
+    "",
+    "- [owner/demo-mcp](https://github.com/owner/demo-mcp): Dead server.",
+    "- [Keep](https://github.com/owner/keep): Healthy server.",
+    "",
+  ].join("\n"), entry);
+  const body = buildDeadEntryCleanupPrBody({
+    issue: { number: 901, html_url: "https://github.com/TensorBlock/awesome-mcp-servers/issues/901" },
+    report,
+    cleanup,
+    removal,
+  });
+  const comment = buildIssueComment({
+    issue: { number: 901 },
+    report,
+    pullRequest: {
+      cleanup: true,
+      html_url: "https://github.com/TensorBlock/awesome-mcp-servers/pull/902",
+      checkedUrl: cleanup.checkedUrl,
+      statusCode: cleanup.statusCode,
+      path: cleanup.path,
+    },
+  });
+
+  assert.equal(targets.length, 1);
+  assert.equal(cleanup.path, "docs/developer-productivity--utilities.md");
+  assert.equal(cleanup.statusCode, 404);
+  assert.deepEqual(removal.removedLines, [
+    "- [owner/demo-mcp](https://github.com/owner/demo-mcp): Dead server.",
+  ]);
+  assert.doesNotMatch(removal.content, /demo-mcp/);
+  assert.match(body, /remove verified-dead catalog entry/);
+  assert.match(body, /HTTP 404/);
+  assert.match(comment, /Created a cleanup PR/);
+});
+
+test("skips direct cleanup for mixed or proof-only dead-link reports", async () => {
+  const entry = {
+    id: "github-owner-demo-mcp-12345678",
+    name: "owner/demo-mcp",
+    source: {
+      docsPath: "docs/developer-productivity--utilities.md",
+    },
+    links: {
+      primary: "https://github.com/owner/demo-mcp",
+      repo: "https://github.com/owner/demo-mcp",
+      homepage: null,
+      docs: null,
+      endpoint: null,
+    },
+  };
+  const mixedReport = {
+    ...parseBrokenEntryIssue(issueBody),
+    issueTypes: ["Dead link", "Wrong category"],
+    source: "https://github.com/owner/demo-mcp",
+  };
+  const proofOnlyReport = {
+    ...parseBrokenEntryIssue(issueBody),
+    issueTypes: ["Dead link"],
+    source: "https://example.com/proof-of-broken-link",
+  };
+  const fetchImpl = async () => {
+    throw new Error("fetch should not be called for skipped cleanup candidates");
+  };
+
+  assert.equal(await buildDeadEntryCleanupCandidate({ catalog: [entry], report: mixedReport, fetchImpl }), null);
+  assert.equal(await buildDeadEntryCleanupCandidate({ catalog: [entry], report: proofOnlyReport, fetchImpl }), null);
+});
+
+test("skips direct cleanup when the dead primary URL maps to multiple catalog entries", async () => {
+  const report = {
+    ...parseBrokenEntryIssue(issueBody),
+    issueTypes: ["Dead link"],
+    source: "https://github.com/owner/demo-mcp",
+  };
+  const firstEntry = {
+    id: "github-owner-demo-mcp-12345678",
+    name: "owner/demo-mcp",
+    source: {
+      docsPath: "docs/developer-productivity--utilities.md",
+    },
+    links: {
+      primary: "https://github.com/owner/demo-mcp",
+      repo: "https://github.com/owner/demo-mcp",
+      homepage: null,
+      docs: null,
+      endpoint: null,
+    },
+  };
+  const duplicateEntry = {
+    ...firstEntry,
+    id: "github-owner-demo-mcp-87654321",
+    name: "owner/demo-mcp duplicate",
+  };
+  const cleanup = await buildDeadEntryCleanupCandidate({
+    catalog: [firstEntry, duplicateEntry],
+    report,
+    fetchImpl: async () => ({ status: 404 }),
+  });
+
+  assert.equal(cleanup, null);
 });

--- a/.github/scripts/create-claim-profile-pr.mjs
+++ b/.github/scripts/create-claim-profile-pr.mjs
@@ -45,10 +45,6 @@ export function validateClaimSubmission(submission, entry, existingMetadata) {
     errors.push("Maintainer handle is required.");
   }
 
-  if (!submission.proof) {
-    errors.push("Maintainer proof is required.");
-  }
-
   if (entry && submission.projectUrl && !projectUrlMatchesEntry(submission.projectUrl, entry, existingMetadata)) {
     errors.push("Project URL must match the indexed profile source URL, repository, homepage, docs URL, or existing sidecar project URL.");
   }
@@ -57,7 +53,10 @@ export function validateClaimSubmission(submission, entry, existingMetadata) {
 }
 
 export function buildClaimMetadataSidecar({ issue, submission, entry, existingMetadata = {} }) {
-  const proofNote = `Claimed by ${submission.maintainer} in #${issue.number}. Proof: ${compactText(submission.proof, 220)}`;
+  const claimNote = `Profile claimed by ${submission.maintainer} in #${issue.number} under the community profile-claim process.`;
+  const proofNote = submission.proof
+    ? `Optional maintainer proof submitted in #${issue.number}: ${compactText(submission.proof, 220)}`
+    : "";
   const requestedMetadataNote = submission.requestedMetadata
     ? `Requested profile metadata in #${issue.number}: ${compactText(submission.requestedMetadata, 220)}`
     : "";
@@ -75,9 +74,10 @@ export function buildClaimMetadataSidecar({ issue, submission, entry, existingMe
     source,
     verification: {
       ...(existingMetadata.verification ?? {}),
-      status: "verified",
+      status: claimVerificationStatus(existingMetadata.verification?.status),
       notes: unique([
         ...(existingMetadata.verification?.notes ?? []),
+        claimNote,
         proofNote,
         requestedMetadataNote,
       ].filter(Boolean)),
@@ -90,7 +90,6 @@ export function buildClaimMetadataSidecar({ issue, submission, entry, existingMe
       ]),
       verifiedBy: unique([
         ...(existingMetadata.community?.verifiedBy ?? []),
-        "TensorBlock",
       ]),
       claimed: true,
     },
@@ -115,7 +114,7 @@ export function buildIssueComment({ issue, submission, pullRequest, errors }) {
       "What needs attention:",
       ...errors.map((error) => `- ${error}`),
       "",
-      "Update this issue with the corrected profile id, matching project URL, maintainer handle, and proof link. The automation will try again when the issue is edited.",
+      "Update this issue with the corrected profile id, matching project URL, and maintainer handle. Optional proof links can still be added as supporting context. The automation will try again when the issue is edited.",
     ].join("\n");
   }
 
@@ -132,7 +131,7 @@ export function buildIssueComment({ issue, submission, pullRequest, errors }) {
     COMMENT_MARKER,
     `Created a draft metadata PR for this profile claim: ${pullRequest.html_url}`,
     "",
-    "A maintainer should verify the proof before merging. Once merged and deployed, the profile will show the claimed maintainer and verification metadata.",
+    "This claim PR records the maintainer handle and marks the profile as claimed. Claiming is separate from TensorBlock verification; stronger verification signals can be added later through a metadata update.",
     "",
     `Claimed profile id: \`${submission.serverId}\``,
   ].join("\n");
@@ -142,19 +141,26 @@ export function buildPrBody({ issue, submission, entry, sidecar }) {
   return [
     "## Summary",
     `- claim TensorBlock MCP profile \`${entry.id}\` for \`${entry.name}\``,
-    `- add maintainer and verification metadata to \`${sidecar.path}\``,
+    `- add maintainer claim metadata to \`${sidecar.path}\``,
     "- mark the profile as claimed once this PR is reviewed and merged",
     "",
-    "## Maintainer verification",
+    "## Profile claim",
     `- Maintainer: ${submission.maintainer}`,
     `- Project URL: ${submission.projectUrl}`,
     `- Indexed primary link: ${entry.links.primary}`,
+    "- Claim status is tracked separately from TensorBlock verification.",
     "",
-    "Proof submitted in the issue:",
-    "",
-    "```text",
-    submission.proof,
-    "```",
+    ...(submission.proof
+      ? [
+          "Optional proof submitted in the issue:",
+          "",
+          "```text",
+          submission.proof,
+          "```",
+        ]
+      : [
+          "No maintainer proof was required for this community profile claim.",
+        ]),
     ...(submission.requestedMetadata
       ? [
           "",
@@ -263,6 +269,14 @@ function compactText(value, maxLength) {
   const lastSpace = slice.lastIndexOf(" ");
   const wordBoundary = lastSpace > maxLength * 0.6 ? slice.slice(0, lastSpace) : slice;
   return `${wordBoundary.trimEnd()}...`;
+}
+
+function claimVerificationStatus(existingStatus) {
+  if (existingStatus && existingStatus !== "unknown") {
+    return existingStatus;
+  }
+
+  return "self_reported";
 }
 
 function unique(values) {

--- a/.github/scripts/create-claim-profile-pr.test.mjs
+++ b/.github/scripts/create-claim-profile-pr.test.mjs
@@ -57,6 +57,7 @@ test("validates profile claim submissions against indexed project URLs", () => {
   const submission = parseClaimProfileIssue(issueBody);
 
   assert.deepEqual(validateClaimSubmission(submission, catalogEntry, {}), []);
+  assert.deepEqual(validateClaimSubmission({ ...submission, proof: "" }, catalogEntry, {}), []);
   assert.deepEqual(
     validateClaimSubmission({
       ...submission,
@@ -101,12 +102,13 @@ test("builds a claimed profile metadata sidecar while preserving existing metada
     commands: ["npx demo-mcp"],
     confidence: "medium",
   });
-  assert.equal(metadata.verification.status, "verified");
-  assert.ok(metadata.verification.notes.some((note) => /Claimed by @owner in #761/.test(note)));
+  assert.equal(metadata.verification.status, "self_reported");
+  assert.ok(metadata.verification.notes.some((note) => /Profile claimed by @owner in #761/.test(note)));
+  assert.ok(metadata.verification.notes.some((note) => /Optional maintainer proof submitted in #761/.test(note)));
   assert.ok(metadata.verification.notes.some((note) => /Requested profile metadata in #761/.test(note)));
   assert.deepEqual(metadata.community, {
     maintainedBy: ["@co-maintainer", "@owner"],
-    verifiedBy: ["TensorBlock"],
+    verifiedBy: [],
     claimed: true,
   });
 });
@@ -125,5 +127,6 @@ test("finds catalog entries and builds actionable comments", () => {
 
   assert.match(comment, /tensorblock-mcp-claim-profile-pr:v1/);
   assert.match(comment, /draft metadata PR/);
+  assert.match(comment, /Claiming is separate from TensorBlock verification/);
   assert.match(comment, /github-owner-demo-mcp-12345678/);
 });

--- a/.github/scripts/triage-issue.mjs
+++ b/.github/scripts/triage-issue.mjs
@@ -146,9 +146,9 @@ export function buildTriageComment(issue) {
       `Thanks for claiming this MCP profile in ${issueNumber}.`,
       "",
       "What happens next:",
-      "- We will verify the maintainer relationship using the repo, package, organization, or docs proof you provided.",
       "- If the profile id and project URL match the index, automation will draft a metadata PR for maintainer review.",
-      "- After that PR is verified, merged, and deployed, the profile can show maintainer and claim metadata in the index.",
+      "- After that PR is merged and deployed, the profile can show the requested maintainer handle as a claimed profile.",
+      "- Claiming is separate from TensorBlock verification; stronger verification signals can be added later through metadata updates.",
       "- If the profile also needs install/auth/docs updates, include them here or open a metadata PR.",
       "",
       describeCapturedFields(body, [
@@ -174,7 +174,8 @@ export function buildTriageComment(issue) {
       "",
       "What happens next:",
       "- We will verify the duplicate, dead link, stale metadata, wrong category, or safety concern.",
-      "- If the entry reference, issue type, and details are clear, automation will draft a broken-entry report spec PR for maintainer review.",
+      "- If this is a clear dead link and the URL still returns a dead status, automation can draft a cleanup PR against the matching `docs/*.md` entry.",
+      "- For duplicates, wrong categories, stale metadata, or safety reports, automation drafts an investigation spec PR for maintainer review.",
       "- If there is a clear correction, a direct PR against the matching `docs/*.md` entry is welcome.",
       "- Safety or security reports are routed with higher priority.",
       "",
@@ -211,11 +212,11 @@ function claimProfileGuidance(body) {
 
   return [
     ...links,
-    "Maintainer verification checklist:",
+    "Profile claim checklist:",
     "- The submitted project URL matches the indexed profile source or official project docs.",
-    "- The maintainer handle is visible on the official project source, package, organization, or docs.",
-    "- The proof link is controlled by the project, not only a personal statement.",
-    "- After verification, profile metadata changes can go through the metadata issue form or a direct PR.",
+    "- The maintainer handle is the GitHub/package/org handle you want displayed on the profile.",
+    "- Optional proof links can be added as supporting context, but claim metadata can be accepted without them.",
+    "- TensorBlock verification is tracked separately from the claimed profile status.",
   ].join("\n");
 }
 

--- a/.github/scripts/triage-issue.test.mjs
+++ b/.github/scripts/triage-issue.test.mjs
@@ -154,15 +154,15 @@ test("builds a deduplicated route-specific comment", () => {
   assert.match(comment, /https:\/\/github.com\/owner\/example/);
 });
 
-test("builds claim profile comments with normalized profile links and verification steps", () => {
+test("builds claim profile comments with normalized profile links and claim steps", () => {
   const comment = buildTriageComment(claimProfileIssue);
 
   assert.match(comment, /tensorblock-mcp-issue-triage:v1:claim-profile/);
   assert.match(comment, /https:\/\/tensorblock\.co\/mcp\/servers\/github-owner-demo-12345678/);
   assert.match(comment, /https:\/\/mcp-index\.tensorblock\.co\/v1\/servers\/github-owner-demo-12345678/);
   assert.match(comment, /badge\.svg/);
-  assert.match(comment, /Maintainer verification checklist:/);
-  assert.match(comment, /official project source/);
+  assert.match(comment, /Profile claim checklist:/);
+  assert.match(comment, /Claiming is separate from TensorBlock verification/);
 });
 
 test("builds client config comments that mention the generated request spec", () => {
@@ -177,7 +177,8 @@ test("builds broken-entry comments that mention the generated report spec", () =
   const comment = buildTriageComment(brokenEntryIssue);
 
   assert.match(comment, /tensorblock-mcp-issue-triage:v1:broken-entry/);
-  assert.match(comment, /automation will draft a broken-entry report spec PR/);
+  assert.match(comment, /automation can draft a cleanup PR/);
+  assert.match(comment, /investigation spec PR/);
   assert.match(comment, /github-owner-demo-mcp-12345678/);
 });
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you maintain an MCP server, the index can give your project a public profile,
 2. Include install, transport, auth, supported clients, docs, license, endpoint, and tool details when you have them.
 3. After merge, the follow-up comment gives you the public profile URL, API profile URL, install-config links, and badge markdown.
 4. Add the TensorBlock MCP Index badge to your project README so users can jump back to the indexed profile.
-5. Claim your profile or send metadata fixes through the [claim profile](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=claim-profile.yml) and [metadata improvement](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=improve-metadata.yml) forms. Valid profile claims and structured metadata updates generate draft metadata PRs; once reviewed, merged, and deployed, the public profile shows the maintainer, install, auth, docs, license, tool, and verification metadata.
+5. Claim your profile or send metadata fixes through the [claim profile](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=claim-profile.yml) and [metadata improvement](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=improve-metadata.yml) forms. Valid profile claims and structured metadata updates generate draft metadata PRs; once reviewed, merged, and deployed, the public profile shows maintainer claim status plus install, auth, docs, license, tool, and verification metadata when available. Claim status is separate from TensorBlock verification.
 
 ## Coverage
 
@@ -55,7 +55,7 @@ Choose the path that matches what you want to do.
 - Share your public MCP profile from [https://www.tensorblock.co/mcp](https://www.tensorblock.co/mcp) so users can inspect metadata, install configs, source links, and badges without reading the raw markdown.
 - Add your server to the best category under [Browse by Category](#browse-by-category), or use the [Add MCP server issue form](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=add-mcp-server.yml).
 - Improve your existing entry with install command, transport, auth requirements, supported clients, docs URL, license, endpoint, and tool details. Use the [metadata issue form](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=improve-metadata.yml) if you do not want to open a PR directly; when the profile id and structured values are clear, automation drafts a metadata sidecar PR for maintainer review.
-- Claim your TensorBlock MCP profile with the [claim profile issue form](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=claim-profile.yml).
+- Claim your TensorBlock MCP profile with the [claim profile issue form](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=claim-profile.yml). Claims show community maintainer ownership metadata and do not imply TensorBlock verification.
 - Add the TensorBlock MCP Index badge to your project README so users can jump from your repo to the indexed profile.
 
 **If you build MCP clients, agents, or developer tools:**
@@ -66,13 +66,13 @@ Choose the path that matches what you want to do.
 
 **If you want to improve the index itself:**
 
-- Fix duplicate, stale, broken, or poorly categorized entries. Use the [broken entry issue form](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=report-broken-entry.yml) when you want maintainers to triage it; clear reports generate a draft investigation PR so cleanup work can be reviewed and tracked.
+- Fix duplicate, stale, broken, or poorly categorized entries. Use the [broken entry issue form](https://github.com/TensorBlock/awesome-mcp-servers/issues/new?template=report-broken-entry.yml) when you want maintainers to triage it. Clear dead-link reports can generate direct cleanup PRs, while duplicate, stale, category, safety, or unclear reports generate draft investigation PRs so cleanup work can be reviewed and tracked.
 - Add missing metadata that makes search and install generation more accurate.
 - Pick a scoped cleanup task from the [community cleanup queue](docs/community-cleanup-queue.md).
 - Propose verification signals, ranking improvements, or better category rules. The catalog health checker also runs on a schedule to flag duplicate primary links, missing GitHub repos, archived repos, and disabled repos as broken-entry reports.
 - Join the [TensorBlock Discord](https://discord.com/invite/Ej5NmeHFf2) to discuss roadmap work before opening a larger PR.
 
-Issue forms are routed automatically. When you submit a server, metadata update, profile claim, client config request, or broken-entry report, the repo adds the right triage labels and posts the next steps so contributors and maintainers can keep the workflow moving. Server submissions with a clear category can generate draft docs PRs, structured metadata updates or profile claims can generate draft metadata PRs, clear client-config requests can generate draft spec PRs, and clear broken-entry reports can generate draft investigation PRs.
+Issue forms are routed automatically. When you submit a server, metadata update, profile claim, client config request, or broken-entry report, the repo adds the right triage labels and posts the next steps so contributors and maintainers can keep the workflow moving. Server submissions with a clear category can generate draft docs PRs, structured metadata updates or profile claims can generate draft metadata PRs, clear client-config requests can generate draft spec PRs, and clear broken-entry reports can generate either direct cleanup PRs or draft investigation PRs depending on the report type.
 
 New server submissions also get intake status labels so the queue is easier to review at scale:
 
@@ -94,7 +94,7 @@ New server entries can be simple, but high-quality metadata makes the profile mu
 
 After a PR lands on `main`, the deploy workflow rebuilds the catalog and profiles. The hosted API and public profile pages refresh after the Railway deployment succeeds.
 
-The scheduled catalog health check uses the generated catalog to open `catalog-health` issues for duplicate links and stale or unreachable GitHub repositories. Those issues feed back into the same broken-entry report workflow, so cleanup work can become reviewable PRs instead of staying as loose maintainer notes.
+The scheduled catalog health check uses the generated catalog to open `catalog-health` issues for duplicate links and stale or unreachable GitHub repositories. Those issues feed back into the same broken-entry report workflow, so verified dead links can become direct cleanup PRs and ambiguous cleanup work can become reviewable investigation PRs instead of staying as loose maintainer notes.
 
 ## TensorBlock MCP Index
 

--- a/docs/broken-entry-reports/README.md
+++ b/docs/broken-entry-reports/README.md
@@ -6,4 +6,6 @@ Each report captures the affected TensorBlock profile, server id, or project URL
 
 Generated report files are starting points, not final catalog data. After a report is verified, the actual fix should land in the relevant `docs/*.md` category page or `data/server-metadata/*.json` sidecar.
 
+Clear dead-link reports may bypass this directory and generate direct cleanup PRs against the matching `docs/*.md` category page. Reports in this directory are for duplicate, stale, category, safety, or unclear cases that need maintainer review before catalog edits.
+
 Reports may come from community-submitted broken-entry issues or from the scheduled catalog health check, which flags duplicate primary links and stale or unreachable GitHub repositories.

--- a/docs/community-cleanup-queue.md
+++ b/docs/community-cleanup-queue.md
@@ -17,7 +17,7 @@ Use it when you want a focused contribution: verify a stale entry, improve metad
 | Ready server PRs | Server submissions with automation-generated PRs ready for maintainer review | [Open ready-for-pr submissions](https://github.com/TensorBlock/awesome-mcp-servers/issues?q=is%3Aissue%20is%3Aopen%20label%3Aserver-submission%20label%3Aready-for-pr) |
 | Duplicate submissions | Server submissions matching an existing project URL | [Open duplicate submissions](https://github.com/TensorBlock/awesome-mcp-servers/issues?q=is%3Aissue%20is%3Aopen%20label%3Aserver-submission%20label%3Aduplicate) |
 | Client config requests | New MCP client or install target formats | [Open client-config issues](https://github.com/TensorBlock/awesome-mcp-servers/issues?q=is%3Aissue%20is%3Aopen%20label%3Aclient-config) |
-| Profile claims | Maintainer verification for indexed profiles | [Open claim-profile issues](https://github.com/TensorBlock/awesome-mcp-servers/issues?q=is%3Aissue%20is%3Aopen%20label%3Aclaim-profile) |
+| Profile claims | Community maintainer claims for indexed profiles | [Open claim-profile issues](https://github.com/TensorBlock/awesome-mcp-servers/issues?q=is%3Aissue%20is%3Aopen%20label%3Aclaim-profile) |
 
 ## How To Pick A Task
 
@@ -28,13 +28,13 @@ Before editing, check:
 - whether the project URL already appears elsewhere in `docs/*.md`,
 - whether the public project README or docs confirm the proposed change,
 - whether the fix belongs in a category markdown file or `data/server-metadata/*.json`,
-- whether the issue already has an automation-generated draft PR.
+- whether the issue already has an automation-generated cleanup PR or draft investigation PR.
 
 For server submissions, use the intake labels to pick the next action:
 
 - `needs-metadata`: ask for the missing URL, category, or description before editing docs.
 - `duplicate`: close or link to the existing entry unless the submitter shows it is a distinct MCP server.
-- `ready-for-pr`: review the generated draft PR instead of hand-editing the issue.
+- `ready-for-pr`: review the generated PR instead of hand-editing the issue.
 - `automation-blocked`: open the PR from the generated branch or fix workflow permissions, then rerun by editing the issue.
 
 Maintainers can backfill these labels with the **MCP Add Server Intake Refresh** workflow. Use `dry_run=true` to inspect the planned changes across open `server-submission` issues, then rerun with `dry_run=false` to apply the labels. Set `issue_number` when you only want to refresh one issue.
@@ -45,7 +45,7 @@ Comment on the issue before doing larger cleanup work so two contributors do not
 
 Most cleanup PRs fall into one of these shapes:
 
-- Edit a category page under `docs/*.md` to remove a duplicate, fix a broken link, or move an entry to a better category.
+- Edit a category page under `docs/*.md` to remove a duplicate, remove a verified dead link, fix a broken URL, or move an entry to a better category.
 - Add or update a `data/server-metadata/{serverId}.json` sidecar for install, auth, transport, docs, license, client, tool, maintainer, or verification metadata.
 - Update a generated investigation spec under `docs/broken-entry-reports/` with the maintainer decision.
 - Add client config support after a request spec under `docs/client-config-requests/` is reviewed.
@@ -87,7 +87,7 @@ Generated files such as `data/catalog.json`, `data/catalog-errors.json`, and `da
 The queue is meant to turn drive-by reports into visible contribution opportunities:
 
 - issue forms add route labels and next-step comments,
-- clear reports can create draft PRs,
+- clear dead-link reports can create direct cleanup PRs, while ambiguous reports can create draft investigation PRs,
 - catalog-health issues surface stale or broken entries proactively,
 - merged server PRs post profile, API, install-config, and badge links,
 - cleanup contributors can point maintainers to verified sources instead of leaving loose notes.

--- a/docs/index-alpha/contribution-guide.md
+++ b/docs/index-alpha/contribution-guide.md
@@ -45,7 +45,7 @@ Tool count: 2
 
 When the profile id matches the index and the values are clear, automation drafts a metadata sidecar PR for maintainer review.
 
-For duplicate, stale, broken, unsafe, or poorly categorized entries, use the broken entry issue form with the TensorBlock profile URL, server id, or project URL. Clear reports can generate a draft investigation PR under `docs/broken-entry-reports/` so maintainers can verify the problem before editing catalog docs or metadata sidecars.
+For duplicate, stale, broken, unsafe, or poorly categorized entries, use the broken entry issue form with the TensorBlock profile URL, server id, or project URL. Clear dead-link reports can generate direct cleanup PRs against the matching `docs/*.md` category page. Duplicate, stale, category, safety, or unclear reports generate draft investigation PRs under `docs/broken-entry-reports/` so maintainers can verify the problem before editing catalog docs or metadata sidecars.
 
 TensorBlock also runs a scheduled catalog health check. It scans the generated catalog for duplicate primary links and rotates through indexed GitHub repositories to detect 404, archived, or disabled projects. New findings open `catalog-health` issues that feed into the same broken-entry report workflow.
 

--- a/packages/registry-api/src/profilePage.ts
+++ b/packages/registry-api/src/profilePage.ts
@@ -12,7 +12,7 @@ export const renderServerProfilePage = (entry: CatalogEntry): string => {
   const readmeBadge = badgeMarkdown(entry, profileUrl);
   const maintainerActions = renderMaintainerActions(entry);
   const maintainerIntro = entry.community.claimed
-    ? "This profile has been claimed by a verified project maintainer. Keep metadata current when install, auth, docs, license, or tool details change."
+    ? "This profile has been claimed by a community maintainer. Claim status is separate from TensorBlock verification; keep metadata current when install, auth, docs, license, or tool details change."
     : "Use this profile as the public install and metadata page for your MCP server. Claim the profile, add the badge to your README, and send metadata fixes when install or auth details change.";
   const installCommands = entry.install.commands.length > 0
     ? entry.install.commands.map((command) => `<code>${escapeHtml(command)}</code>`).join("")

--- a/packages/registry-api/test/profilePage.test.ts
+++ b/packages/registry-api/test/profilePage.test.ts
@@ -95,7 +95,8 @@ describe("renderServerProfilePage", () => {
     });
 
     expect(html).toContain("Claimed profile");
-    expect(html).toContain("verified project maintainer");
+    expect(html).toContain("community maintainer");
+    expect(html).toContain("Claim status is separate from TensorBlock verification");
     expect(html).toContain("<dd>Yes</dd>");
     expect(html).toContain("<code>@owner</code>");
     expect(html).toContain("<code>TensorBlock</code>");


### PR DESCRIPTION
## Summary
- make profile claims self-reported maintainer metadata that is separate from TensorBlock verification
- let pure dead-link broken-entry reports open direct cleanup PRs after rechecking the catalog primary URL, while mixed/duplicate/stale/category/safety reports stay draft investigation PRs
- update README, contribution docs, cleanup queue docs, issue templates, profile-page copy, and merged-PR follow-up messaging

## Test Plan
- [x] node --test .github/scripts/*.test.mjs
- [x] npm test
- [x] npm run typecheck
- [x] npm run build
