### PR TITLE
Fix broken-entry draft PR readiness update

### DIFF
--- a/.github/scripts/create-broken-entry-report-pr.mjs
+++ b/.github/scripts/create-broken-entry-report-pr.mjs
@@ -459,6 +459,7 @@ async function main() {
   const [owner, repo] = repository.split("/");
   const report = parseBrokenEntryIssue(issue.body ?? "");
   const request = createGitHubRequest({ token, owner, repo });
+  const graphqlRequest = createGitHubGraphqlRequest({ token });
   const errors = validateBrokenEntryReport(report);
   const catalog = JSON.parse(fs.readFileSync("data/catalog.json", "utf8"));
 
@@ -509,6 +510,7 @@ async function main() {
       title,
       body,
       draft,
+      graphqlRequest,
     });
   } catch (error) {
     if (!isPullRequestCreationBlocked(error)) {
@@ -590,7 +592,34 @@ function createGitHubRequest({ token, owner, repo }) {
   };
 }
 
-async function createOrUpdatePullRequest(request, { owner, branch, title, body, draft = true }) {
+function createGitHubGraphqlRequest({ token }) {
+  return async function graphqlRequest(query, variables = {}) {
+    const response = await fetch(`${API_BASE}/graphql`, {
+      method: "POST",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      body: JSON.stringify({ query, variables }),
+    });
+
+    const text = await response.text();
+    const data = text ? JSON.parse(text) : null;
+
+    if (!response.ok || data?.errors?.length) {
+      const error = new Error(`GitHub GraphQL request failed: ${response.status}`);
+      error.status = response.status;
+      error.data = data;
+      throw error;
+    }
+
+    return data?.data;
+  };
+}
+
+export async function createOrUpdatePullRequest(request, { owner, branch, title, body, draft = true, graphqlRequest }) {
   const query = new URLSearchParams({
     head: `${owner}:${branch}`,
     state: "open",
@@ -604,10 +633,9 @@ async function createOrUpdatePullRequest(request, { owner, branch, title, body, 
       body: { title, body },
     });
 
-    if (!draft && existingPull.draft) {
-      return request(`/pulls/${existingPull.number}/ready_for_review`, {
-        method: "POST",
-      });
+    if (!draft && existingPull.draft && graphqlRequest) {
+      await markPullRequestReadyForReview(graphqlRequest, existingPull.node_id);
+      return request(`/pulls/${existingPull.number}`);
     }
 
     return updatedPull;
@@ -624,6 +652,20 @@ async function createOrUpdatePullRequest(request, { owner, branch, title, body, 
       maintainer_can_modify: true,
     },
   });
+}
+
+async function markPullRequestReadyForReview(graphqlRequest, pullRequestId) {
+  return graphqlRequest(
+    `mutation MarkPullRequestReadyForReview($pullRequestId: ID!) {
+      markPullRequestReadyForReview(input: { pullRequestId: $pullRequestId }) {
+        pullRequest {
+          id
+          isDraft
+        }
+      }
+    }`,
+    { pullRequestId },
+  );
 }
 
 function isPullRequestCreationBlocked(error) {

--- a/.github/scripts/create-broken-entry-report-pr.test.mjs
+++ b/.github/scripts/create-broken-entry-report-pr.test.mjs
@@ -7,6 +7,7 @@ import {
   buildBrokenEntryReportSpec,
   buildIssueComment,
   buildPrBody,
+  createOrUpdatePullRequest,
   findBrokenEntryTargets,
   parseBrokenEntryIssue,
   removeEntryLineFromMarkdown,
@@ -240,4 +241,68 @@ test("skips direct cleanup when the dead primary URL maps to multiple catalog en
   });
 
   assert.equal(cleanup, null);
+});
+
+test("marks an existing draft cleanup pull request ready through GraphQL", async () => {
+  const calls = [];
+  const graphqlCalls = [];
+  const request = async (pathname, options = {}) => {
+    calls.push({ pathname, options });
+
+    if (pathname.startsWith("/pulls?")) {
+      return [{
+        number: 1027,
+        draft: true,
+        node_id: "PR_kwDOExample",
+      }];
+    }
+
+    if (pathname === "/pulls/1027" && options.method === "PATCH") {
+      return {
+        number: 1027,
+        draft: true,
+        html_url: "https://github.com/TensorBlock/awesome-mcp-servers/pull/1027",
+      };
+    }
+
+    if (pathname === "/pulls/1027") {
+      return {
+        number: 1027,
+        draft: false,
+        html_url: "https://github.com/TensorBlock/awesome-mcp-servers/pull/1027",
+      };
+    }
+
+    throw new Error(`Unexpected request: ${pathname}`);
+  };
+  const graphqlRequest = async (query, variables) => {
+    graphqlCalls.push({ query, variables });
+    return {
+      markPullRequestReadyForReview: {
+        pullRequest: {
+          id: variables.pullRequestId,
+          isDraft: false,
+        },
+      },
+    };
+  };
+
+  const pullRequest = await createOrUpdatePullRequest(request, {
+    owner: "TensorBlock",
+    branch: "mcp/broken-entry-issue-1022",
+    title: "Remove dead MCP entry report #1022",
+    body: "body",
+    draft: false,
+    graphqlRequest,
+  });
+
+  assert.equal(pullRequest.draft, false);
+  assert.equal(graphqlCalls.length, 1);
+  assert.match(graphqlCalls[0].query, /markPullRequestReadyForReview/);
+  assert.deepEqual(graphqlCalls[0].variables, { pullRequestId: "PR_kwDOExample" });
+  assert.deepEqual(calls.map((call) => `${call.options.method ?? "GET"} ${call.pathname}`), [
+    "GET /pulls?head=TensorBlock%3Amcp%2Fbroken-entry-issue-1022&state=open",
+    "PATCH /pulls/1027",
+    "GET /pulls/1027",
+  ]);
 });


### PR DESCRIPTION
## Summary
- mark existing draft broken-entry cleanup PRs ready through the GitHub GraphQL mutation
- re-read the REST PR payload after the ready transition so issue comments still receive the expected fields
- add regression coverage for updating an existing draft cleanup PR

## Test Plan
- [x] node --test .github/scripts/create-broken-entry-report-pr.test.mjs
- [x] npm test
- [x] npm run typecheck
- [x] npm run build
