### PR TITLE
Add AccountsOS MCP server to Finance & Crypto

### DIFF
--- a/docs/finance--crypto.md
+++ b/docs/finance--crypto.md
@@ -1,5 +1,6 @@
 ## 💰 Finance & Crypto
 
+- [AccountsOS](https://www.npmjs.com/package/@thriveventurelabs/accountsos-mcp) - AI accountant for UK and global founders. Query your company's real books (balances, transactions, VAT, deadlines, invoices) from Claude or any MCP client. Install: `npx -y @thriveventurelabs/accountsos-mcp`. Homepage: https://accounts-os.com
 - [Timwal78/SqueezeOS](https://github.com/Timwal78/SqueezeOS) - Institutional market intelligence MCP server with 33 tools. Schwab/Polygon/Alpaca APIs, x402 payment gating via XRPL/RLUSD and Base/USDC, short-squeeze detection, FTD cycle analysis. Free tier + paid signal tiers. Remote: `https://squeezeos-api.onrender.com/mcp`
 - [Timwal78/ghost-layer](https://github.com/Timwal78/ghost-layer) - Dual-chain XRPL/Base toll gateway for autonomous AI agents. URIToken on-chain licensing, 54-block execution matrix, Agent Passport loyalty tiers, x402 protocol. MCP: `https://ghost-layer.onrender.com/mcp`. Zero custody.
 


### PR DESCRIPTION
Adds AccountsOS to docs/finance--crypto.md. AI accountant for UK and global founders; the MCP server lets Claude (or any MCP client) query real accounting data (balances, transactions, VAT, deadlines, invoices, documents). npm: @thriveventurelabs/accountsos-mcp (https://www.npmjs.com/package/@thriveventurelabs/accountsos-mcp). Homepage: https://accounts-os.com. Transport: stdio (TypeScript), connects to the AccountsOS cloud API via API key.