### PR TITLE
Improve add-server issue intake parsing

### DIFF
--- a/.github/scripts/create-add-server-pr.mjs
+++ b/.github/scripts/create-add-server-pr.mjs
@@ -73,16 +73,61 @@ const DOCS_PATH_TO_CATEGORY = Object.fromEntries(
   Object.entries(CATEGORY_TO_DOCS_PATH).map(([category, docsPath]) => [docsPath, category]),
 );
 
-export function parseAddServerIssue(body) {
+const ISSUE_FORM_FIELD_LABELS = [
+  "Server name",
+  "Project URL",
+  "Best category",
+  "What can an agent do with this server?",
+  "Install or connection instructions",
+  "Transport",
+  "Auth requirements",
+  "Known supported clients",
+  "License",
+].map(canonicalLabel);
+
+export function parseAddServerIssue(body, issue = {}) {
+  const suggestedEntry = parseSuggestedMarkdownEntry(body);
+  const projectUrl = normalizeUrlField(
+    firstIssueField(body, "Project URL", "Server URL", "Repository", "Repo", "Homepage", "Website") ||
+      suggestedEntry.projectUrl,
+  );
+  const serverName = normalizeField(
+    firstIssueField(body, "Server name", "Name") ||
+      suggestedEntry.serverName ||
+      serverNameFromTitle(issue.title ?? "", projectUrl) ||
+      serverNameFromUrl(projectUrl),
+  );
+  const category = normalizeCategory(
+    normalizeField(firstIssueField(body, "Best category", "Category", "Suggested category") || suggestedEntry.category),
+    [issue.title, body].filter(Boolean).join("\n"),
+  );
+  const description = normalizeField(
+    firstIssueField(body, "What can an agent do with this server?", "Description", "What it is") ||
+      suggestedEntry.description,
+  );
+  const install = normalizeField(
+    firstIssueField(
+      body,
+      "Install or connection instructions",
+      "Install",
+      "Installation",
+      "Connection instructions",
+      "Remote MCP endpoint",
+      "MCP endpoint",
+      "Endpoint",
+      "Hosted endpoint",
+    ) || suggestedEntry.endpoint,
+  );
+
   return {
-    serverName: normalizeField(extractIssueField(body, "Server name")),
-    projectUrl: normalizeField(extractIssueField(body, "Project URL")),
-    category: normalizeCategory(normalizeField(extractIssueField(body, "Best category")), body),
-    description: normalizeField(extractIssueField(body, "What can an agent do with this server?")),
-    install: normalizeField(extractIssueField(body, "Install or connection instructions")),
-    transport: normalizeField(extractIssueField(body, "Transport")),
-    auth: normalizeField(extractIssueField(body, "Auth requirements", "Auth")),
-    clients: normalizeField(extractIssueField(body, "Known supported clients", "Clients")),
+    serverName,
+    projectUrl,
+    category,
+    description,
+    install,
+    transport: normalizeField(extractIssueField(body, "Transport", "Transport protocol")),
+    auth: normalizeField(extractIssueField(body, "Auth requirements", "Authentication requirements", "Auth", "Authentication")),
+    clients: normalizeField(extractIssueField(body, "Known supported clients", "Clients", "Supported clients")),
     license: normalizeField(extractIssueField(body, "License")),
   };
 }
@@ -243,6 +288,17 @@ export function buildMetadataSidecar({ issue, submission }) {
   };
 }
 
+function firstIssueField(body, ...labels) {
+  for (const label of labels) {
+    const value = extractIssueField(body, label);
+    if (value) {
+      return value;
+    }
+  }
+
+  return "";
+}
+
 function extractIssueField(body, ...labels) {
   for (const label of labels) {
     const markdownField = extractField(body, label);
@@ -254,6 +310,11 @@ function extractIssueField(body, ...labels) {
     if (boldField) {
       return boldField;
     }
+
+    const plainField = extractPlainField(body, label);
+    if (plainField) {
+      return plainField;
+    }
   }
 
   return "";
@@ -261,7 +322,7 @@ function extractIssueField(body, ...labels) {
 
 function extractBoldField(body, label) {
   const pattern = new RegExp(
-    `(?:^|\\n)\\s*\\*\\*${escapeRegex(label)}\\*\\*\\s*:?\\s*([^\\n]*)\\n?([\\s\\S]*?)(?=\\n\\s*(?:\\*\\*[^\\n*]+\\*\\*\\s*:?|###\\s+)|$)`,
+    `(?:^|\\n)\\s*\\*\\*${escapeRegex(label)}\\s*:?\\*\\*\\s*:?\\s*([^\\n]*)\\n?([\\s\\S]*?)(?=\\n\\s*(?:\\*\\*[^\\n*]+\\s*:?\\*\\*\\s*:?|#{2,3}\\s+)|$)`,
     "i",
   );
   const match = body.match(pattern);
@@ -276,6 +337,75 @@ function extractBoldField(body, label) {
     .trim();
 }
 
+function extractPlainField(body, label) {
+  const pattern = new RegExp(
+    `(^|\\n)\\s*${escapeRegex(label)}\\s*:\\s*([^\\n]*)\\n?([\\s\\S]*?)(?=\\n\\s*(?:#{2,3}\\s+|\\*\\*[^\\n*]+\\s*:?\\*\\*\\s*:?|[A-Za-z][A-Za-z0-9 /&()._-]{1,80}:\\s*)|$)`,
+    "gi",
+  );
+
+  for (const match of body.matchAll(pattern)) {
+    const fieldStart = match.index + match[1].length;
+    if (isInsideDifferentIssueFormField(body, fieldStart, label)) {
+      continue;
+    }
+
+    return [match[2], match[3]]
+      .map((value) => value.trim())
+      .filter(Boolean)
+      .join("\n")
+      .trim();
+  }
+
+  return "";
+}
+
+function isInsideDifferentIssueFormField(body, index, label) {
+  const headings = Array.from(body.slice(0, index).matchAll(/(?:^|\n)#{2,3}\s+([^\n]+)\s*\n/g));
+  const heading = headings.at(-1)?.[1];
+  if (!heading) {
+    return false;
+  }
+
+  const headingLabel = canonicalLabel(heading);
+  return ISSUE_FORM_FIELD_LABELS.includes(headingLabel) && headingLabel !== canonicalLabel(label);
+}
+
+function parseSuggestedMarkdownEntry(body) {
+  const candidates = [];
+  const fencedBlocks = Array.from(body.matchAll(/```(?:md|markdown)?\s*\n([\s\S]*?)```/gi)).map((match) => match[1]);
+  candidates.push(...fencedBlocks, body);
+
+  for (const candidate of candidates) {
+    const match = candidate.match(/^\s*[-*]\s+\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)\s*:\s*([\s\S]*?)(?=\n\s*[-*]\s+\[[^\]]+\]\(https?:\/\/|$)/m);
+    if (!match) {
+      continue;
+    }
+
+    const description = normalizeSuggestedDescription(match[3]);
+
+    return {
+      serverName: match[1].trim(),
+      projectUrl: stripUrlPunctuation(match[2]),
+      description,
+      endpoint: extractMcpEndpointText(description),
+    };
+  }
+
+  return {};
+}
+
+function normalizeSuggestedDescription(value) {
+  return value
+    .replace(/```/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function extractMcpEndpointText(value) {
+  const match = value.match(/\b(?:remote\s+)?mcp endpoint\s*:\s*(`https?:\/\/[^`]+`|https?:\/\/[^\s,.)]+)/i);
+  return match ? match[1].replace(/[.;]+$/g, "").trim() : "";
+}
+
 function normalizeCategory(value, context = "") {
   const lookupText = [value, context].filter(Boolean).join("\n");
   const docsPath = lookupText.match(/docs\/[a-z0-9-]+\.md/i)?.[0];
@@ -287,6 +417,41 @@ function normalizeCategory(value, context = "") {
   for (const category of Object.keys(CATEGORY_TO_DOCS_PATH)) {
     if (normalizedValue.includes(category.toLowerCase())) {
       return category;
+    }
+  }
+
+  const aliasRules = [
+    {
+      category: "Finance & Crypto",
+      patterns: [
+        /\bfinance\b/i,
+        /\bfinancial\b/i,
+        /\bdefi\b/i,
+        /\bcrypto\b/i,
+        /\bkyb\b/i,
+        /\bofac\b/i,
+        /\bsanctions?\b/i,
+        /\bvat\b/i,
+        /\bbank(?:ing)?\b/i,
+      ],
+    },
+    {
+      category: "Travel & Transportation",
+      patterns: [/\btravel\b/i, /\btransportation\b/i, /\bflight\b/i, /\bhotel\b/i, /\bbooking\b/i],
+    },
+    {
+      category: "Build & Deployment Tools",
+      patterns: [/\bdeploy(?:ment)?\b/i, /\bbuild\b/i, /\bdocker\b/i, /\bcontainer\b/i],
+    },
+    {
+      category: "Security",
+      patterns: [/\bsecurity\b/i, /\bvulnerabilit(?:y|ies)\b/i, /\bscanner\b/i, /\bcompliance\b/i],
+    },
+  ];
+
+  for (const rule of aliasRules) {
+    if (rule.patterns.some((pattern) => pattern.test(lookupText))) {
+      return rule.category;
     }
   }
 
@@ -350,8 +515,8 @@ export function buildIssueComment({ issue, submission, pullRequest, duplicate, e
   ].join("\n");
 }
 
-function normalizeField(value) {
-  const normalized = value
+function normalizeField(value = "") {
+  const normalized = String(value)
     .replace(/<!--[\s\S]*?-->/g, "")
     .trim();
 
@@ -360,6 +525,56 @@ function normalizeField(value) {
   }
 
   return normalized;
+}
+
+function normalizeUrlField(value) {
+  const normalized = normalizeField(value)
+    .replace(/^`+|`+$/g, "")
+    .replace(/^<|>$/g, "")
+    .trim();
+  const url = normalized.match(/https?:\/\/[^\s`<>)]+/i)?.[0] ?? normalized;
+  return stripUrlPunctuation(url);
+}
+
+function serverNameFromTitle(title, projectUrl) {
+  const cleaned = title
+    .replace(/^add\s+(?:mcp\s+)?server\s*:\s*/i, "")
+    .replace(/^add\s+/i, "")
+    .replace(/\s+(?:to|for|under)\s+.+$/i, "")
+    .replace(/\s+mcp\s+server$/i, "")
+    .trim();
+
+  if (!cleaned || cleaned.toLowerCase() === title.toLowerCase()) {
+    return serverNameFromUrl(projectUrl);
+  }
+
+  return cleaned;
+}
+
+function serverNameFromUrl(projectUrl) {
+  if (!projectUrl) {
+    return "";
+  }
+
+  try {
+    const parsed = new URL(projectUrl);
+    const segments = parsed.pathname
+      .split("/")
+      .filter(Boolean)
+      .map((segment) => decodeURIComponent(segment).replace(/\.git$/i, ""));
+
+    if (parsed.hostname.toLowerCase().replace(/^www\./, "") === "github.com" && segments.length >= 2) {
+      return `${segments[0]}/${segments[1]}`;
+    }
+
+    return segments.at(-1) || parsed.hostname.replace(/^www\./i, "");
+  } catch {
+    return "";
+  }
+}
+
+function canonicalLabel(value) {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
 }
 
 function compactText(value, maxLength = 240) {
@@ -594,7 +809,7 @@ async function main() {
     return;
   }
 
-  const submission = parseAddServerIssue(issue.body ?? "");
+  const submission = parseAddServerIssue(issue.body ?? "", issue);
   const [owner, repo] = repository.split("/");
   const request = createGitHubRequest({ token, owner, repo });
   const errors = validateSubmission(submission);

--- a/.github/scripts/create-add-server-pr.test.mjs
+++ b/.github/scripts/create-add-server-pr.test.mjs
@@ -146,6 +146,51 @@ const suggestedCategoryIssueBody = [
   "no auth",
 ].join("\n");
 
+const freeformServerUrlIssueBody = [
+  "Server URL: https://github.com/wangletiand/400860-radar",
+  "",
+  "Category: Finance / Data APIs",
+  "",
+  "Description: Real-time DeFi yield pools and TVL data from DeFiLlama, LLM API pricing comparison across 8 providers, and web scraping via Scrapling. Pay-per-call via x402 protocol on Base mainnet.",
+  "",
+  "Transport: streamable-http (https://api.400860.xyz/v1/mcp/call)",
+  "",
+  "Tools:",
+  "- get_defi_yields: Top DeFi yield pools filtered by chain/APY/stablecoin",
+  "- get_defi_tvl: Protocol TVL with 24h/7d change deltas",
+  "- get_ai_pricing: LLM API pricing comparison across providers",
+  "",
+  "License: MIT",
+].join("\n");
+
+const boldColonIssueBody = [
+  "**Server name:** ENTIA",
+  "",
+  "**Repository:** https://github.com/ENTIA-IA/entia-mcp-server",
+  "",
+  "**Remote MCP endpoint:** `https://mcp.entia.systems/mcp` (streamable-http)",
+  "",
+  "**Official MCP registry:** `io.github.entia-systems-core/entity-verification` (v4.0.0, active).",
+  "",
+  "**Description:** Verified business-identity intelligence for AI agents & MCP clients — company verification, VAT, BORME, GLEIF, ownership and risk signals across 34 countries.",
+  "",
+  "**Category:** Finance / Business Data / Verification (KYB).",
+  "",
+  "**Language:** Python. **Type:** Cloud / hosted remote. **Official:** yes.",
+].join("\n");
+
+const suggestedEntryIssueBody = [
+  "## Submission: VeraData — LATAM Compliance MCP Server",
+  "",
+  "Requesting addition to the **Finance & Crypto** section.",
+  "",
+  "### Suggested entry",
+  "",
+  "```",
+  "- [VeraData](https://api.veradata.dev): LATAM compliance MCP server — sanctions screening against OFAC+UN+EU+UK with audit trail, KYB bundles for CO/MX/BR/CL/PE, and central bank rates. Tools: `sanctions_screen`, `kyb_complete`, `get_rates`. MCP endpoint: `https://api.veradata.dev/mcp`.",
+  "```",
+].join("\n");
+
 test("parses add-server issue form fields", () => {
   assert.deepEqual(parseAddServerIssue(issueBody), {
     serverName: "owner/example-mcp",
@@ -216,6 +261,48 @@ test("maps category to docs path", () => {
 test("uses suggested category from the issue description when category is unsure", () => {
   assert.equal(parseAddServerIssue(suggestedCategoryIssueBody).category, "Finance & Crypto");
   assert.deepEqual(validateSubmission(parseAddServerIssue(suggestedCategoryIssueBody)), []);
+});
+
+test("parses free-form add-server fields with server URL and category aliases", () => {
+  assert.deepEqual(parseAddServerIssue(freeformServerUrlIssueBody), {
+    serverName: "wangletiand/400860-radar",
+    projectUrl: "https://github.com/wangletiand/400860-radar",
+    category: "Finance & Crypto",
+    description: "Real-time DeFi yield pools and TVL data from DeFiLlama, LLM API pricing comparison across 8 providers, and web scraping via Scrapling. Pay-per-call via x402 protocol on Base mainnet.",
+    install: "",
+    transport: "streamable-http (https://api.400860.xyz/v1/mcp/call)",
+    auth: "",
+    clients: "",
+    license: "MIT",
+  });
+});
+
+test("parses bold labels with colon inside emphasis and remote endpoint metadata", () => {
+  assert.deepEqual(parseAddServerIssue(boldColonIssueBody), {
+    serverName: "ENTIA",
+    projectUrl: "https://github.com/ENTIA-IA/entia-mcp-server",
+    category: "Finance & Crypto",
+    description: "Verified business-identity intelligence for AI agents & MCP clients — company verification, VAT, BORME, GLEIF, ownership and risk signals across 34 countries.",
+    install: "`https://mcp.entia.systems/mcp` (streamable-http)",
+    transport: "",
+    auth: "",
+    clients: "",
+    license: "",
+  });
+});
+
+test("parses server submissions from a suggested markdown entry", () => {
+  assert.deepEqual(parseAddServerIssue(suggestedEntryIssueBody), {
+    serverName: "VeraData",
+    projectUrl: "https://api.veradata.dev",
+    category: "Finance & Crypto",
+    description: "LATAM compliance MCP server — sanctions screening against OFAC+UN+EU+UK with audit trail, KYB bundles for CO/MX/BR/CL/PE, and central bank rates. Tools: `sanctions_screen`, `kyb_complete`, `get_rates`. MCP endpoint: `https://api.veradata.dev/mcp`.",
+    install: "`https://api.veradata.dev/mcp`",
+    transport: "",
+    auth: "",
+    clients: "",
+    license: "",
+  });
 });
 
 test("builds catalog markdown entry", () => {

--- a/.github/scripts/refresh-add-server-intake.mjs
+++ b/.github/scripts/refresh-add-server-intake.mjs
@@ -14,7 +14,7 @@ const COMMENT_MARKER = "<!-- tensorblock-mcp-add-server-pr:v1 -->";
 const SERVER_SUBMISSION_LABEL = "server-submission";
 
 export function classifyAddServerIssue({ issue, docsDir = "docs", comments = [], pullRequests = [] }) {
-  const submission = parseAddServerIssue(issue.body ?? "");
+  const submission = parseAddServerIssue(issue.body ?? "", issue);
   const errors = validateSubmission(submission);
   const duplicate = errors.length > 0 ? null : findDuplicateByUrl(submission.projectUrl, docsDir);
   const pullRequest = errors.length > 0 || duplicate ? null : findGeneratedPullRequest(issue.number, comments, pullRequests);

--- a/.github/scripts/triage-issue.mjs
+++ b/.github/scripts/triage-issue.mjs
@@ -35,7 +35,8 @@ const ROUTES = [
   {
     id: "server-submission",
     label: "server-submission",
-    titlePrefix: "Add MCP server:",
+    titlePrefixes: ["Add MCP server:", "Add server:"],
+    matches: looksLikeFreeformServerSubmission,
     name: "server submission",
   },
   {
@@ -70,9 +71,26 @@ export function routeIssue(issue) {
 
   return (
     ROUTES.find((route) => labels.has(route.label)) ??
-    ROUTES.find((route) => title.startsWith(route.titlePrefix)) ??
+    ROUTES.find((route) => routeTitlePrefixes(route).some((prefix) => title.startsWith(prefix))) ??
+    ROUTES.find((route) => route.matches?.(issue)) ??
     null
   );
+}
+
+function routeTitlePrefixes(route) {
+  return route.titlePrefixes ?? (route.titlePrefix ? [route.titlePrefix] : []);
+}
+
+function looksLikeFreeformServerSubmission(issue) {
+  const title = issue.title ?? "";
+  const body = issue.body ?? "";
+
+  if (!/^Add\b/i.test(title)) {
+    return false;
+  }
+
+  return /(?:Project URL|Server URL|Repository|Repo|Homepage|Website|Remote MCP endpoint|MCP endpoint)\s*:/i.test(body) ||
+    /^\s*[-*]\s+\[[^\]]+\]\(https?:\/\/[^)]+\)\s*:/m.test(body);
 }
 
 export function labelsForIssue(issue, action = "opened") {

--- a/.github/scripts/triage-issue.test.mjs
+++ b/.github/scripts/triage-issue.test.mjs
@@ -91,6 +91,35 @@ test("routes issues by title prefix when labels are missing", () => {
   assert.equal(routeIssue(issue)?.id, "claim-profile");
 });
 
+test("routes free-form add-server issue titles", () => {
+  assert.equal(
+    routeIssue({
+      title: "Add server: ENTIA",
+      labels: [],
+      body: "**Repository:** https://github.com/ENTIA-IA/entia-mcp-server",
+    })?.id,
+    "server-submission",
+  );
+
+  assert.equal(
+    routeIssue({
+      title: "Add 400860 Radar to Finance & DeFi",
+      labels: [],
+      body: "Server URL: https://github.com/wangletiand/400860-radar",
+    })?.id,
+    "server-submission",
+  );
+
+  assert.equal(
+    routeIssue({
+      title: "Add VeraData LATAM Compliance MCP Server",
+      labels: [],
+      body: "- [VeraData](https://api.veradata.dev): LATAM compliance MCP server.",
+    })?.id,
+    "server-submission",
+  );
+});
+
 test("adds triage and metadata labels on opened issues", () => {
   assert.deepEqual(labelsForIssue(metadataIssue, "opened"), [
     "community-intake",

--- a/.github/workflows/add-server-issue-pr.yml
+++ b/.github/workflows/add-server-issue-pr.yml
@@ -19,7 +19,20 @@ concurrency:
 jobs:
   draft-pr:
     name: Draft docs PR from server submission
-    if: contains(github.event.issue.labels.*.name, 'server-submission') || startsWith(github.event.issue.title, 'Add MCP server:')
+    if: >-
+      contains(github.event.issue.labels.*.name, 'server-submission') ||
+      startsWith(github.event.issue.title, 'Add MCP server:') ||
+      startsWith(github.event.issue.title, 'Add server:') ||
+      (
+        startsWith(github.event.issue.title, 'Add ') &&
+        (
+          contains(github.event.issue.body, 'Project URL') ||
+          contains(github.event.issue.body, 'Server URL') ||
+          contains(github.event.issue.body, 'Repository') ||
+          contains(github.event.issue.body, 'MCP endpoint') ||
+          contains(github.event.issue.body, 'Suggested entry')
+        )
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository


### PR DESCRIPTION
## Summary
- parse free-form server submissions with Server URL, Repository, Category, Description, and endpoint labels
- support suggested markdown entries and title/URL server-name fallback
- route Add server / free-form Add issue titles into server-submission automation

## Tests
- node --test .github/scripts/*.test.mjs
- npm test
- npm run typecheck
- npm run build