### PR TITLE
Run merged PR follow-up with target permissions

### DIFF
--- a/.github/workflows/merged-pr-follow-up.yml
+++ b/.github/workflows/merged-pr-follow-up.yml
@@ -1,7 +1,7 @@
 name: MCP Merged PR Follow-up
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
 


### PR DESCRIPTION
## Summary
- switch the merged PR follow-up workflow to pull_request_target so merged fork PRs can receive the TensorBlock profile/star follow-up comment
- keep the job limited to closed merged PRs and base-repo workflow code

## Tests
- node --test .github/scripts/comment-merged-pr.test.mjs
- npm test
- git diff --check