### PR TITLE
Trigger add-server automation on labels

### DIFF
--- a/.github/scripts/create-add-server-pr.test.mjs
+++ b/.github/scripts/create-add-server-pr.test.mjs
@@ -191,6 +191,13 @@ const suggestedEntryIssueBody = [
   "```",
 ].join("\n");
 
+test("runs add-server workflow when server-submission label is added manually", () => {
+  const workflow = fs.readFileSync(".github/workflows/add-server-issue-pr.yml", "utf8");
+
+  assert.match(workflow, /types:\s*\n(?:\s+- .+\n)*\s+- labeled\b/);
+  assert.match(workflow, /contains\(github\.event\.issue\.labels\.\*\.name, 'server-submission'\)/);
+});
+
 test("parses add-server issue form fields", () => {
   assert.deepEqual(parseAddServerIssue(issueBody), {
     serverName: "owner/example-mcp",

--- a/.github/workflows/add-server-issue-pr.yml
+++ b/.github/workflows/add-server-issue-pr.yml
@@ -5,6 +5,7 @@ on:
     types:
       - opened
       - edited
+      - labeled
       - reopened
 
 permissions:


### PR DESCRIPTION
## Summary
- run the add-server draft PR workflow when an issue receives a label
- keep the existing server-submission condition as the gate for manual label backfills
- add a regression test for the labeled workflow trigger

## Tests
- node --test .github/scripts/create-add-server-pr.test.mjs .github/scripts/refresh-add-server-intake.test.mjs .github/scripts/triage-issue.test.mjs
- npm test
- npm run typecheck
- npm run build
- git diff --check