### PR TITLE
Prefer explicit add-server categories

### DIFF
--- a/.github/scripts/create-add-server-pr.mjs
+++ b/.github/scripts/create-add-server-pr.mjs
@@ -407,7 +407,15 @@ function extractMcpEndpointText(value) {
 }
 
 function normalizeCategory(value, context = "") {
-  const lookupText = [value, context].filter(Boolean).join("\n");
+  return categoryFromText(value) ?? categoryFromText(context) ?? value;
+}
+
+function categoryFromText(value = "") {
+  const lookupText = String(value).trim();
+  if (!lookupText) {
+    return null;
+  }
+
   const docsPath = lookupText.match(/docs\/[a-z0-9-]+\.md/i)?.[0];
   if (docsPath && DOCS_PATH_TO_CATEGORY[docsPath]) {
     return DOCS_PATH_TO_CATEGORY[docsPath];
@@ -455,7 +463,7 @@ function normalizeCategory(value, context = "") {
     }
   }
 
-  return value;
+  return null;
 }
 
 export function buildIssueComment({ issue, submission, pullRequest, duplicate, errors }) {

--- a/.github/scripts/create-add-server-pr.test.mjs
+++ b/.github/scripts/create-add-server-pr.test.mjs
@@ -146,6 +146,32 @@ const suggestedCategoryIssueBody = [
   "no auth",
 ].join("\n");
 
+const explicitSearchCategoryIssueBody = [
+  "### Server name",
+  "",
+  "AIServices",
+  "",
+  "### Project URL",
+  "",
+  "https://github.com/vbkotecha/aiservices-api",
+  "",
+  "### Best category",
+  "",
+  "Search",
+  "",
+  "### What can an agent do with this server?",
+  "",
+  "AIServices gives agents a remote MCP endpoint plus paid x402 APIs for AI-powered web search, crypto/DeFi market data, on-chain analytics, URL metadata, marketing intelligence, and policy-driven dispute resolution.",
+  "",
+  "### Install or connection instructions",
+  "",
+  "Remote MCP endpoint: https://api.aiservices.to/mcp",
+  "",
+  "### Known supported clients",
+  "",
+  "MCP-compatible clients and agent frameworks that support remote MCP servers.",
+].join("\n");
+
 const freeformServerUrlIssueBody = [
   "Server URL: https://github.com/wangletiand/400860-radar",
   "",
@@ -268,6 +294,13 @@ test("maps category to docs path", () => {
 test("uses suggested category from the issue description when category is unsure", () => {
   assert.equal(parseAddServerIssue(suggestedCategoryIssueBody).category, "Finance & Crypto");
   assert.deepEqual(validateSubmission(parseAddServerIssue(suggestedCategoryIssueBody)), []);
+});
+
+test("keeps explicit submitted category ahead of contextual category words", () => {
+  const submission = parseAddServerIssue(explicitSearchCategoryIssueBody);
+
+  assert.equal(submission.category, "Search");
+  assert.equal(docPathForCategory(submission.category), "docs/search.md");
 });
 
 test("parses free-form add-server fields with server URL and category aliases", () => {


### PR DESCRIPTION
## Summary
- make add-server category normalization prefer the submitted category field before scanning issue context
- keep docs-path hints and category alias fallback behavior for unsure or free-form submissions
- add a regression test for AIServices, where explicit Search was previously overridden by context mentioning agent frameworks

## Tests
- node --test .github/scripts/create-add-server-pr.test.mjs
- node --test .github/scripts/*.test.mjs
- npm test
- npm run typecheck
- npm run build
- git diff --check