### PR TITLE
Fix MCP API docs badge sample

### DIFF
--- a/docs/index-api.md
+++ b/docs/index-api.md
@@ -60,13 +60,13 @@ Server summaries include `sourcePullRequest` when known and `lastUpdatedAt` when
 Fetch a full server profile:
 
 ```bash
-curl "$MCP_INDEX_API_URL/v1/servers/postgres-mcp"
+curl "$MCP_INDEX_API_URL/v1/servers/github-crystaldba-postgres-mcp-22e80ea8"
 ```
 
 Open a shareable website profile page:
 
 ```text
-https://tensorblock.co/mcp/servers/postgres-mcp
+https://tensorblock.co/mcp/servers/github-crystaldba-postgres-mcp-22e80ea8
 ```
 
 The API also keeps `GET /servers/{id}` as a lightweight HTML fallback, but the canonical community profile is hosted on the TensorBlock website.
@@ -74,13 +74,13 @@ The API also keeps `GET /servers/{id}` as a lightweight HTML fallback, but the c
 Embed an MCP Index badge in a project README:
 
 ```markdown
-[![Indexed on TensorBlock MCP Index](https://mcp-index.tensorblock.co/v1/servers/postgres-mcp/badge.svg)](https://tensorblock.co/mcp/servers/postgres-mcp)
+[![Indexed on TensorBlock MCP Index](https://mcp-index.tensorblock.co/v1/servers/github-crystaldba-postgres-mcp-22e80ea8/badge.svg)](https://tensorblock.co/mcp/servers/github-crystaldba-postgres-mcp-22e80ea8)
 ```
 
 Generate an install config:
 
 ```bash
-curl "$MCP_INDEX_API_URL/v1/servers/postgres-mcp/install-config?client=claude-desktop"
+curl "$MCP_INDEX_API_URL/v1/servers/github-crystaldba-postgres-mcp-22e80ea8/install-config?client=claude-desktop"
 ```
 
 ## Railway Deployment

--- a/packages/registry-api/test/docsExamples.test.ts
+++ b/packages/registry-api/test/docsExamples.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import type { CatalogEntry } from "../../catalog-builder/src/types.js";
+
+const catalog = JSON.parse(readFileSync("data/catalog.json", "utf8")) as CatalogEntry[];
+const catalogIds = new Set(catalog.map((entry) => entry.id));
+
+const concreteServerIdsFromDocs = (markdown: string): string[] => {
+  const ids = new Set<string>();
+  const patterns = [
+    /\/v1\/servers\/([^/?#\s)"'`<]+)/g,
+    /\/mcp\/servers\/([^/?#\s)"'`<]+)/g,
+  ];
+
+  for (const pattern of patterns) {
+    for (const match of markdown.matchAll(pattern)) {
+      const id = match[1];
+
+      if (!id || id.includes("{") || id === "recent" || id === "updated") {
+        continue;
+      }
+
+      ids.add(id);
+    }
+  }
+
+  return [...ids].sort();
+};
+
+describe("MCP Index API docs examples", () => {
+  it("uses concrete server ids that exist in the generated catalog", () => {
+    const docs = readFileSync("docs/index-api.md", "utf8");
+    const missingIds = concreteServerIdsFromDocs(docs)
+      .filter((id) => !catalogIds.has(id));
+
+    expect(missingIds).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces the `postgres-mcp` docs example with a real generated catalog id.
- Adds a docs consistency test so concrete `/v1/servers/{id}` and `/mcp/servers/{id}` examples must exist in `data/catalog.json`.

## Why
The previous README badge sample requested `/v1/servers/postgres-mcp/badge.svg`, but `postgres-mcp` is not a generated production catalog id. Renderers that load the docs image repeatedly hit the API with 404s.

## Verification
- Red/green TDD: `npx vitest run packages/registry-api/test/docsExamples.test.ts` failed with `[ 'postgres-mcp' ]`, then passed after replacing the sample id.
- `npm test` — 13 files / 66 tests passed
- `npm run typecheck` — passed
- `npm run build` — passed
- Local API check: `/v1/servers/github-crystaldba-postgres-mcp-22e80ea8/badge.svg` returned `200 image/svg+xml`; `/v1/servers/postgres-mcp/badge.svg` still returns the expected 404 for a missing id.