### PR TITLE
Improve MCP badge lookup fallback

### DIFF
--- a/packages/registry-api/src/badge.ts
+++ b/packages/registry-api/src/badge.ts
@@ -33,6 +33,27 @@ export const renderBadgeSvg = (entry: CatalogEntry): string => {
 </svg>`;
 };
 
+export const renderMissingServerBadgeSvg = (serverId: string): string => {
+  const title = `${serverId} was not resolved in TensorBlock MCP Index`;
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="246" height="34" viewBox="0 0 246 34" role="img" aria-label="${escapeAttribute(title)}">
+  <title>${escapeXml(title)}</title>
+  <defs>
+    <clipPath id="r">
+      <rect width="246" height="34" rx="6"/>
+    </clipPath>
+  </defs>
+  <g clip-path="url(#r)">
+    <rect width="246" height="34" fill="#f8f7f3"/>
+    <rect width="136" height="34" fill="#4b5563"/>
+    <rect x="135.5" y="0.5" width="110" height="33" fill="#f8f7f3" stroke="#e6e3db"/>
+    <path d="M14 8h16l8 4-8 4H14l8-4-8-4Zm0 9h16l8 4-8 4H14l8-4-8-4Zm0 9h16l8 4-8 4H14l8-4-8-4Z" fill="none" stroke="#f8f7f3" stroke-width="1.25" stroke-linejoin="round"/>
+    <text x="48" y="21.5" fill="#f8f7f3" font-family="Inter, Arial, sans-serif" font-size="12" font-weight="650">TensorBlock</text>
+    <text x="150" y="21.5" fill="#0c0a09" font-family="Inter, Arial, sans-serif" font-size="12" font-weight="650">MCP Profile</text>
+  </g>
+</svg>`;
+};
+
 const apiBaseUrl = (): string =>
   (process.env.MCP_INDEX_API_BASE_URL ?? DEFAULT_API_BASE_URL).replace(/\/+$/, "");
 

--- a/packages/registry-api/src/search.ts
+++ b/packages/registry-api/src/search.ts
@@ -102,7 +102,23 @@ export const searchCatalog = (
 export const findServer = (
   catalog: CatalogEntry[],
   serverId: string
-): CatalogEntry | null => catalog.find((entry) => entry.id === serverId) ?? null;
+): CatalogEntry | null => {
+  const requestedKey = normalizeLookupKey(serverId);
+
+  if (!requestedKey) {
+    return null;
+  }
+
+  const exactMatch = catalog.find((entry) => normalizeLookupKey(entry.id) === requestedKey);
+
+  if (exactMatch) {
+    return exactMatch;
+  }
+
+  const aliasMatches = catalog.filter((entry) => serverLookupKeys(entry).has(requestedKey));
+
+  return aliasMatches.length === 1 ? aliasMatches[0] : null;
+};
 
 export const listRecentServers = (
   catalog: CatalogEntry[],
@@ -235,3 +251,70 @@ const tokenize = (query: string): string[] =>
     .filter((term) => term.length > 0);
 
 const normalizeText = (value: string): string => value.toLowerCase();
+
+const HASH_SUFFIX_PATTERN = /-[a-f0-9]{8}$/;
+
+const serverLookupKeys = (entry: CatalogEntry): Set<string> => {
+  const keys = new Set<string>();
+  addLookupKey(keys, entry.id);
+  addLookupKey(keys, entry.id.replace(HASH_SUFFIX_PATTERN, ""));
+  addNameLookupKeys(keys, entry.name);
+  addUrlLookupKeys(keys, entry.links.primary);
+  addUrlLookupKeys(keys, entry.links.repo);
+
+  return keys;
+};
+
+const addNameLookupKeys = (keys: Set<string>, name: string): void => {
+  addLookupKey(keys, name);
+
+  const parts = name.split("/").filter(Boolean);
+  if (parts.length >= 2) {
+    addLookupKey(keys, parts.slice(-2).join("-"));
+    addLookupKey(keys, parts.at(-1) ?? "");
+  }
+};
+
+const addUrlLookupKeys = (keys: Set<string>, rawUrl: string | null | undefined): void => {
+  if (!rawUrl) {
+    return;
+  }
+
+  try {
+    const parsed = new URL(rawUrl);
+    const host = parsed.hostname.replace(/^www\./, "").toLowerCase();
+    const pathParts = parsed.pathname.split("/").filter(Boolean);
+
+    if (host === "github.com" && pathParts.length >= 2) {
+      const owner = pathParts[0];
+      const repo = pathParts[1];
+
+      addLookupKey(keys, `github-${owner}-${repo}`);
+      addLookupKey(keys, `${owner}-${repo}`);
+      addLookupKey(keys, repo);
+      return;
+    }
+
+    addLookupKey(keys, [host, ...pathParts].join("-"));
+    addLookupKey(keys, pathParts.at(-1) ?? "");
+  } catch {
+    addLookupKey(keys, rawUrl);
+  }
+};
+
+const addLookupKey = (keys: Set<string>, value: string): void => {
+  const key = normalizeLookupKey(value);
+
+  if (key) {
+    keys.add(key);
+  }
+};
+
+const normalizeLookupKey = (value: string): string =>
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/[_\s]+/g, "-")
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-|-$/g, "");

--- a/packages/registry-api/src/server.ts
+++ b/packages/registry-api/src/server.ts
@@ -16,7 +16,7 @@ import {
 } from "./search.js";
 import { renderServerProfilePage } from "./profilePage.js";
 import { webProfileTemplate } from "./webProfile.js";
-import { renderBadgeSvg } from "./badge.js";
+import { renderBadgeSvg, renderMissingServerBadgeSvg } from "./badge.js";
 
 const CLIENT_ALIASES: Record<string, ClientName> = {
   "claude": "claude",
@@ -94,14 +94,7 @@ const handleRequest = async (
     }
 
     if (segments[0] === "servers" && segments[2] === "badge.svg" && segments.length === 3) {
-      const entry = findServer(state.catalog, segments[1]);
-
-      if (!entry) {
-        sendError(response, 404, `Server not found: ${segments[1]}`);
-        return;
-      }
-
-      sendSvg(response, 200, renderBadgeSvg(entry));
+      handleBadge(response, state.catalog, segments[1]);
       return;
     }
 
@@ -275,7 +268,7 @@ const handleBadge = (
   const entry = findServer(catalog, serverId);
 
   if (!entry) {
-    sendError(response, 404, `Server not found: ${serverId}`);
+    sendSvg(response, 200, renderMissingServerBadgeSvg(serverId));
     return;
   }
 

--- a/packages/registry-api/test/badge.test.ts
+++ b/packages/registry-api/test/badge.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { CatalogEntry } from "../../catalog-builder/src/types.js";
-import { badgeImageUrl, badgeMarkdown, renderBadgeSvg } from "../src/badge.js";
+import { badgeImageUrl, badgeMarkdown, renderBadgeSvg, renderMissingServerBadgeSvg } from "../src/badge.js";
 
 const entry: CatalogEntry = {
   id: "unsafe-demo",
@@ -68,5 +68,14 @@ describe("badge helpers", () => {
     expect(badgeMarkdown(entry, "https://example.com/profile")).toBe(
       "[![Indexed on TensorBlock MCP Index](https://mcp-index.tensorblock.co/v1/servers/unsafe-demo/badge.svg)](https://example.com/profile)"
     );
+  });
+
+  it("renders a non-broken fallback badge for unresolved server ids", () => {
+    const svg = renderMissingServerBadgeSvg("unsafe <missing>");
+
+    expect(svg).toContain("TensorBlock");
+    expect(svg).toContain("MCP Profile");
+    expect(svg).toContain("unsafe &lt;missing&gt; was not resolved in TensorBlock MCP Index");
+    expect(svg).not.toContain("unsafe <missing>");
   });
 });

--- a/packages/registry-api/test/search.test.ts
+++ b/packages/registry-api/test/search.test.ts
@@ -196,6 +196,54 @@ describe("catalog helpers", () => {
     expect(findServer(catalog, "missing")).toBeNull();
   });
 
+  it("finds a unique hashed GitHub server by stable alias keys", () => {
+    const hashedCatalog = [
+      entry({
+        id: "github-owner-alpha-server-1234abcd",
+        name: "owner/alpha-server",
+        links: {
+          primary: "https://github.com/owner/alpha-server",
+          repo: "https://github.com/owner/alpha-server",
+        },
+      }),
+      entry({
+        id: "github-owner-beta-server-5678abcd",
+        name: "owner/beta-server",
+        links: {
+          primary: "https://github.com/owner/beta-server",
+          repo: "https://github.com/owner/beta-server",
+        },
+      }),
+    ];
+
+    expect(findServer(hashedCatalog, "github-owner-alpha-server")?.id).toBe("github-owner-alpha-server-1234abcd");
+    expect(findServer(hashedCatalog, "owner-alpha-server")?.id).toBe("github-owner-alpha-server-1234abcd");
+    expect(findServer(hashedCatalog, "alpha-server")?.id).toBe("github-owner-alpha-server-1234abcd");
+  });
+
+  it("does not resolve ambiguous short aliases", () => {
+    const ambiguousCatalog = [
+      entry({
+        id: "github-first-postgres-mcp-1234abcd",
+        name: "first/postgres-mcp",
+        links: {
+          primary: "https://github.com/first/postgres-mcp",
+          repo: "https://github.com/first/postgres-mcp",
+        },
+      }),
+      entry({
+        id: "github-second-postgres-mcp-5678abcd",
+        name: "second/postgres-mcp",
+        links: {
+          primary: "https://github.com/second/postgres-mcp",
+          repo: "https://github.com/second/postgres-mcp",
+        },
+      }),
+    ];
+
+    expect(findServer(ambiguousCatalog, "postgres-mcp")).toBeNull();
+  });
+
   it("normalizes limits", () => {
     expect(normalizeLimit(undefined)).toBe(25);
     expect(normalizeLimit(0)).toBe(25);

--- a/packages/registry-api/test/server.test.ts
+++ b/packages/registry-api/test/server.test.ts
@@ -149,6 +149,51 @@ describe("registry API server", () => {
     expect(body).toContain("Postgres MCP is indexed on TensorBlock MCP Index");
   });
 
+  it("serves a branded SVG badge through a unique repo slug alias", async () => {
+    const baseUrl = await startServer([
+      catalogEntry({
+        id: "github-crystaldba-postgres-mcp-22e80ea8",
+        name: "crystaldba/postgres-mcp",
+        links: {
+          primary: "https://github.com/crystaldba/postgres-mcp",
+          repo: "https://github.com/crystaldba/postgres-mcp",
+        },
+      }),
+    ]);
+    const response = await fetch(`${baseUrl}/v1/servers/postgres-mcp/badge.svg`);
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("image/svg+xml");
+    expect(body).toContain("crystaldba/postgres-mcp is indexed on TensorBlock MCP Index");
+  });
+
+  it("serves a fallback SVG badge for an unresolved server id", async () => {
+    const baseUrl = await startServer();
+    const response = await fetch(`${baseUrl}/v1/servers/missing-server/badge.svg`);
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("image/svg+xml");
+    expect(body).toContain("<svg");
+    expect(body).toContain("TensorBlock");
+    expect(body).toContain("MCP Profile");
+    expect(body).toContain("missing-server was not resolved in TensorBlock MCP Index");
+  });
+
+  it("keeps unresolved install config requests as JSON 404 errors", async () => {
+    const baseUrl = await startServer();
+    const response = await fetch(`${baseUrl}/v1/servers/missing-server/install-config`);
+    const body = await response.json() as { error: { message: string; statusCode: number } };
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expect(body.error).toEqual({
+      message: "Server not found: missing-server",
+      statusCode: 404,
+    });
+  });
+
   it("returns recently added server summaries", async () => {
     const baseUrl = await startServer([
       catalogEntry({


### PR DESCRIPTION
## Summary
- Resolve server lookups through stable unique aliases, including hashless GitHub ids and repo slugs.
- Return a non-broken SVG fallback for unresolved badge URLs instead of JSON 404s.
- Keep non-badge missing server APIs as JSON 404s and cover the behavior with regression tests.

## Test Plan
- npm run typecheck
- npm test
- PORT=3911 CATALOG_PATH=data/catalog.json npm run registry:api:dev
- curl -i http://127.0.0.1:3911/v1/servers/postgres-mcp/badge.svg
- curl -i http://127.0.0.1:3911/v1/servers/missing-server/install-config