### PR TITLE
Add registry deployment fingerprint

### DIFF
--- a/.github/workflows/deploy-registry-api.yml
+++ b/.github/workflows/deploy-registry-api.yml
@@ -56,6 +56,21 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
+      - name: Write build metadata
+        run: |
+          node --input-type=module <<'NODE'
+          import { mkdirSync, writeFileSync } from "node:fs";
+
+          const metadata = {
+            commitSha: process.env.GITHUB_SHA ?? null,
+            builtAt: new Date().toISOString(),
+          };
+
+          mkdirSync("data", { recursive: true });
+          writeFileSync("data/build-info.json", `${JSON.stringify(metadata, null, 2)}\n`, "utf8");
+          console.log(JSON.stringify(metadata));
+          NODE
+
       - name: Build
         run: npm run build
 
@@ -81,22 +96,25 @@ jobs:
           base_url="${REGISTRY_API_BASE_URL%/}"
           health_url="$base_url/health"
           badge_url="$base_url/v1/servers/postgres-mcp/badge.svg"
+          expected_commit_sha="$GITHUB_SHA"
           delay_seconds=10
           max_attempts=36
 
           for attempt in $(seq 1 "$max_attempts"); do
             health_status="$(curl -sS -o /tmp/registry-health.json -w "%{http_code}" "$health_url" || true)"
             badge_status="$(curl -sS -D /tmp/registry-badge.headers -o /tmp/registry-badge.svg -w "%{http_code}" "$badge_url" || true)"
+            health_commit_sha="$(node -e 'const fs = require("node:fs"); const health = JSON.parse(fs.readFileSync("/tmp/registry-health.json", "utf8")); process.stdout.write(health.build?.commitSha ?? "");' 2>/tmp/registry-health-parse.err || true)"
 
             if [ "$health_status" = "200" ] \
               && [ "$badge_status" = "200" ] \
+              && [ "$health_commit_sha" = "$expected_commit_sha" ] \
               && grep -qi '^content-type: image/svg+xml' /tmp/registry-badge.headers \
               && grep -q '<svg' /tmp/registry-badge.svg; then
               echo "Registry API smoke test passed on attempt $attempt."
               exit 0
             fi
 
-            echo "Attempt $attempt/$max_attempts failed: health=$health_status badge=$badge_status"
+            echo "Attempt $attempt/$max_attempts failed: health=$health_status badge=$badge_status commit=$health_commit_sha expected=$expected_commit_sha"
             if [ "$attempt" -lt "$max_attempts" ]; then
               sleep "$delay_seconds"
             fi
@@ -105,6 +123,8 @@ jobs:
           echo "Registry API smoke test failed after $max_attempts attempts."
           echo "Health response:"
           cat /tmp/registry-health.json 2>/dev/null || true
+          echo "Health parse error:"
+          cat /tmp/registry-health-parse.err 2>/dev/null || true
           echo "Badge response headers:"
           cat /tmp/registry-badge.headers 2>/dev/null || true
           echo "Badge response body:"

--- a/docs/index-api.md
+++ b/docs/index-api.md
@@ -31,6 +31,25 @@ Discover available endpoints:
 curl "$MCP_INDEX_API_URL/"
 ```
 
+Check API health and deployment fingerprint:
+
+```bash
+curl "$MCP_INDEX_API_URL/health"
+```
+
+```json
+{
+  "status": "ok",
+  "catalogEntries": 7729,
+  "loadedAt": "2026-07-08T00:00:00.000Z",
+  "build": {
+    "commitSha": "694bc1a8c555e6d6df6dfe2ee1b04b7ae866eee5",
+    "builtAt": "2026-07-08T00:11:55.000Z"
+  },
+  "uptimeSeconds": 60
+}
+```
+
 Search for Postgres servers:
 
 ```bash
@@ -103,6 +122,6 @@ The service reads `data/catalog.json` on startup and keeps it in memory. Every d
 
 ## Automatic Refresh
 
-The deployment workflow runs on every push to `main` that touches the catalog, docs, API package, schema, or Railway config. It rebuilds `data/catalog.json` and `data/profiles/*.json` before deploying, so newly merged server entries are reflected by the live API after the Railway deployment succeeds.
+The deployment workflow runs on every push to `main` that touches the catalog, docs, API package, schema, or Railway config. It rebuilds `data/catalog.json` and `data/profiles/*.json`, writes `data/build-info.json`, and verifies the live `/health` deployment fingerprint before finishing, so newly merged server entries are reflected by the live API after the Railway deployment succeeds.
 
 The workflow requires a GitHub repository secret named `RAILWAY_TOKEN` with deploy access to the Railway project.

--- a/packages/registry-api/src/server.ts
+++ b/packages/registry-api/src/server.ts
@@ -33,12 +33,35 @@ const AUTH_TYPES = new Set<AuthType>(["none", "api-key", "oauth", "bearer", "unk
 interface RegistryApiState {
   catalog: CatalogEntry[];
   loadedAt: string;
+  build: BuildInfo;
+}
+
+export interface BuildInfo {
+  commitSha: string | null;
+  builtAt: string | null;
 }
 
 const startedAt = new Date();
 
 export const loadCatalog = (catalogPath = process.env.CATALOG_PATH ?? "data/catalog.json"): CatalogEntry[] =>
   JSON.parse(readFileSync(resolve(catalogPath), "utf8")) as CatalogEntry[];
+
+export const loadBuildInfo = (buildInfoPath = process.env.BUILD_INFO_PATH ?? "data/build-info.json"): BuildInfo => {
+  try {
+    const raw = JSON.parse(readFileSync(resolve(buildInfoPath), "utf8")) as Partial<BuildInfo>;
+
+    return {
+      commitSha: typeof raw.commitSha === "string" ? raw.commitSha : null,
+      builtAt: typeof raw.builtAt === "string" ? raw.builtAt : null,
+    };
+  } catch (error) {
+    if (isNodeFileNotFoundError(error)) {
+      return emptyBuildInfo();
+    }
+
+    throw error;
+  }
+};
 
 export const createRegistryApiServer = (state: RegistryApiState) =>
   createServer((request, response) => {
@@ -76,6 +99,7 @@ const handleRequest = async (
         status: "ok",
         catalogEntries: state.catalog.length,
         loadedAt: state.loadedAt,
+        build: state.build,
         uptimeSeconds: Math.floor((Date.now() - startedAt.getTime()) / 1000),
       });
       return;
@@ -355,6 +379,7 @@ export const main = (): void => {
   const server = createRegistryApiServer({
     catalog,
     loadedAt: new Date().toISOString(),
+    build: loadBuildInfo(),
   });
 
   server.listen(port, host, () => {
@@ -373,4 +398,17 @@ const isDirectRun = (): boolean => {
 
 if (isDirectRun()) {
   main();
+}
+
+function emptyBuildInfo(): BuildInfo {
+  return {
+    commitSha: null,
+    builtAt: null,
+  };
+}
+
+function isNodeFileNotFoundError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error
+    && "code" in error
+    && (error as NodeJS.ErrnoException).code === "ENOENT";
 }

--- a/packages/registry-api/test/server.test.ts
+++ b/packages/registry-api/test/server.test.ts
@@ -1,8 +1,11 @@
 import { once } from "node:events";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import type { CatalogEntry } from "../../catalog-builder/src/types.js";
-import { createRegistryApiServer } from "../src/server.js";
+import { createRegistryApiServer, loadBuildInfo, type BuildInfo } from "../src/server.js";
 
 const catalog: CatalogEntry[] = [
   {
@@ -119,6 +122,53 @@ describe("registry API server", () => {
 
     expect(response.status).toBe(200);
     expect(body.version).toBe("v1");
+  });
+
+  it("returns build fingerprint metadata from the health endpoint", async () => {
+    const build = {
+      commitSha: "abc123def456",
+      builtAt: "2026-07-08T00:00:00.000Z",
+    };
+    const baseUrl = await startServer(catalog, build);
+    const response = await fetch(`${baseUrl}/health`);
+    const body = await response.json() as {
+      status: string;
+      catalogEntries: number;
+      loadedAt: string;
+      build: BuildInfo;
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.status).toBe("ok");
+    expect(body.catalogEntries).toBe(1);
+    expect(body.loadedAt).toBe("2026-06-06T00:00:00.000Z");
+    expect(body.build).toEqual(build);
+  });
+
+  it("loads build fingerprint metadata from JSON", () => {
+    const directory = mkdtempSync(join(tmpdir(), "registry-api-build-"));
+    const buildInfoPath = join(directory, "build-info.json");
+    const build = {
+      commitSha: "abc123def456",
+      builtAt: "2026-07-08T00:00:00.000Z",
+    };
+
+    try {
+      writeFileSync(buildInfoPath, `${JSON.stringify(build)}\n`, "utf8");
+
+      expect(loadBuildInfo(buildInfoPath)).toEqual(build);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("uses null build fingerprint metadata when the JSON file is missing", () => {
+    const missingPath = join(tmpdir(), "missing-registry-api-build-info.json");
+
+    expect(loadBuildInfo(missingPath)).toEqual({
+      commitSha: null,
+      builtAt: null,
+    });
   });
 
   it("serves a shareable HTML profile page for a server", async () => {
@@ -283,10 +333,17 @@ describe("registry API server", () => {
   });
 });
 
-const startServer = async (entries = catalog): Promise<string> => {
+const startServer = async (
+  entries = catalog,
+  build: BuildInfo = {
+    commitSha: null,
+    builtAt: null,
+  }
+): Promise<string> => {
   const server = createRegistryApiServer({
     catalog: entries,
     loadedAt: "2026-06-06T00:00:00.000Z",
+    build,
   });
   servers.push(server);
   server.listen(0, "127.0.0.1");


### PR DESCRIPTION
## Summary
- Add build fingerprint metadata to the Registry API `/health` response.
- Load deployment metadata from `data/build-info.json`, with null metadata fallback for local development.
- Write build metadata during the Railway deploy workflow and require the live `/health.build.commitSha` to match `GITHUB_SHA` in the smoke check.
- Document the health response and deployment fingerprint behavior.

## Test Plan
- npx vitest run packages/registry-api/test/server.test.ts
- npm test
- npm run typecheck
- npm run build
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-registry-api.yml")'
- git diff --check
- local workflow metadata script check with `GITHUB_SHA=workflow-test-sha`
- local API `/health` check with `BUILD_INFO_PATH=/tmp/registry-build-info-test.json`