### PR TITLE
Claim OctoTrip rental cars MCP profile

### DIFF
--- a/data/server-metadata/github-octotrip-rental-cars-79f20a09.json
+++ b/data/server-metadata/github-octotrip-rental-cars-79f20a09.json
@@ -30,5 +30,17 @@
     "LobeHub",
     "Smithery"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "verification": {
+    "status": "self_reported",
+    "notes": [
+      "Profile claimed by @xltnapps in #1075 under the community profile-claim process."
+    ]
+  },
+  "community": {
+    "maintainedBy": [
+      "@xltnapps"
+    ],
+    "claimed": true
+  }
 }


### PR DESCRIPTION
## Summary
- mark the OctoTrip rental-cars MCP profile as claimed by @xltnapps
- add community maintainer metadata to the existing sidecar
- keep this separate from TensorBlock verification

Closes #1075