### PR TITLE
Add GrokHack — multiplayer NetHack MMO for agents (stdio MCP)

### DIFF
--- a/docs/gaming.md
+++ b/docs/gaming.md
@@ -3,6 +3,7 @@
 Servers interacting with game engines, game platforms/APIs, or providing game-related tools.
 
 - [BASIC-BIT/vrchat-mcp](https://github.com/BASIC-BIT/vrchat-mcp): Access VRChat friends, worlds, groups, events, notifications, status, avatars, and VRCX history from MCP clients.
+- [integrate-your-mind/grokhack](https://github.com/integrate-your-mind/grokhack): Live multiplayer NetHack-class roguelike MMO. Agents join via stdio MCP (join/act/look/chat/social/leaderboard); humans play in-browser under the same rules. Zero auth. Docs: https://grokhack.mondello.dev/mcp.html · llms.txt: https://grokhack.mondello.dev/llms.txt · Contests: https://grokhack.mondello.dev/contests.html. Install: clone repo, `npm install && npm run mcp:build`, point host at `mcp/dist/index.js`.
 - [Signal-Loop/UnityCodeMCPServer](https://github.com/Signal-Loop/UnityCodeMCPServer): Performs any task in Unity Editor by executing C# scripts. Full access to UnityEngine, UnityEditor APIs, and reflection. Use for manipulating GameObjects, scenes, components, or automating Unity Editor tasks.
 - [sedyh/ebitengine-mcp](https://github.com/sedyh/ebitengine-mcp): Facilitates the integration of Ebitengine games with MCP servers for enhanced game control and management.
 - [ecovacs-ai/ecovacs-mcp](https://github.com/ecovacs-ai/ecovacs-mcp): Ecovacs MCP Server enables seamless integration of cleaning robot services into large models, facilitating device management and control operations like cleaning and recharging.


### PR DESCRIPTION
## What

Adds **GrokHack** to `docs/gaming.md` — free open-source multiplayer NetHack-style MMO where MCP agents and humans share one dungeon.

## Links

| | |
|--|--|
| Repo | https://github.com/integrate-your-mind/grokhack |
| MCP HTML | https://grokhack.mondello.dev/mcp.html |
| API | https://grokhack.mondello.dev/api/mcp |
| Protocol | https://grokhack.mondello.dev/api/agent |
| Contests | https://grokhack.mondello.dev/contests.html |
| llms.txt | https://grokhack.mondello.dev/llms.txt |
| License | MIT |

Happy to move category or add a metadata sidecar if preferred.