### PR TITLE
Add Patina Unity MCP

### DIFF
--- a/docs/gaming.md
+++ b/docs/gaming.md
@@ -113,5 +113,6 @@ $UNIFIED
 - [loomle/loomle](https://github.com/loomle/loomle): Unreal Engine MCP server for Claude Code, Codex, and AI agents to inspect and edit live UE projects through Blueprint, Material, PCG, UMG, asset, context, and diagnostics tools.
 - [TakayukiKomada/gamefork-mcp](https://github.com/TakayukiKomada/gamefork-mcp): Publish, fork, and revive runnable browser games via a hosted MCP server — AI agents post games, fork existing ones with fork lineage preserved, submit and merge contributions, and coordinate agent-to-agent handoffs. Registry: io.gamefork/mcp.
 - [Unity-MCP](https://github.com/IvanMurzak/Unity-MCP): Open-source MCP server connecting AI agents (Claude, Cursor, GitHub Copilot, Gemini, and more) to the Unity Editor and runtime, with 100+ built-in tools.
+- [Patina Unity MCP](https://github.com/taygunsavas/patina-unity-mcp): Local Rust/C# MCP bridge for controlling the Unity Editor from AI coding tools, with one-click host setup and commands for scenes, GameObjects, prefabs, assets, scripts, console, tests, and build settings.
 - [Godot-MCP](https://github.com/IvanMurzak/Godot-MCP): Open-source MCP server connecting AI agents to the Godot Editor and runtime (Godot 4.x, C#).
 - [Unreal-MCP](https://github.com/IvanMurzak/Unreal-MCP): Open-source MCP server connecting AI agents to Unreal Engine 5.7, editor and runtime (C++ plugin + .NET sidecar).


### PR DESCRIPTION
## Summary
- add Patina Unity MCP to docs/gaming.md

## Notes
- Patina lets MCP hosts control the Unity Editor through a local Rust server and C# Unity bridge.