### PR TITLE
Add posthell to Social Media & Content Platforms

### DIFF
--- a/docs/social-media--content-platforms.md
+++ b/docs/social-media--content-platforms.md
@@ -2,6 +2,7 @@
 
 Servers interacting with social networks, content platforms, or feed aggregators.
 
+- [Rohan27s/posthell-mcp](https://github.com/Rohan27s/posthell-mcp): Hosted social media scheduler for AI agents. Remote Streamable HTTP server at https://www.posthell.com/api/mcp (API key): shape notes into posts in the user's voice, queue drafts for human approval, read growth analytics, and (per-key opt-in) publish to 15 networks (X, LinkedIn, Instagram, TikTok, and more). Docs: https://www.posthell.com/mcp
 - [TheColonyCC/colony-mcp-server](https://github.com/TheColonyCC/colony-mcp-server): Remote MCP server for The Colony (thecolony.cc), a social network for AI agents — 15 tools for post/comment/vote/react/DM/notifications, 5 resources including a one-call polling diff, 2 resource templates, 3 structured prompts. Streamable HTTP at `https://thecolony.cc/mcp/`, JWT Bearer auth.
 - [Vovala14/vynly-mcp](https://github.com/Vovala14/vynly-mcp) - Post AI-generated images and short video to Vynly, an AI-only social network with server-side provenance verification (C2PA / SynthID / generator metadata). Free demo token, no signup.
 - [Post for Me](https://github.com/DayMoonDevelopment/post-for-me-typescript/tree/main/packages/mcp-server): Quickly integrate social media platforms directly into your product to power posting, feeds, analytics, and more through a single, simple API. Get started at [postforme.dev](https://www.postforme.dev), then run the MCP server locally or access our [hosted server](https://mcp.postforme.dev).


### PR DESCRIPTION
Adds posthell: a hosted social media scheduler built for AI agents.

- Remote Streamable HTTP MCP server: `https://www.posthell.com/api/mcp` (per-user API key; unauthenticated introspection open)
- Tools: shape_post (notes -> post drafts in the user's voice), create_draft (human-approval queue), list_posts (with engagement metrics), get_growth, publish_post (per-key opt-in)
- 15 networks: X, LinkedIn, Instagram, TikTok, YouTube, Threads, Bluesky, Pinterest, Reddit, Telegram, Discord, Snapchat, Facebook, Google Business, WhatsApp
- Also in the official MCP registry as `io.github.Rohan27s/posthell`; docs: https://www.posthell.com/mcp