### PR TITLE
Add ActableSite website audit MCP

### DIFF
--- a/docs/browser-automation--web-scraping.md
+++ b/docs/browser-automation--web-scraping.md
@@ -1,6 +1,7 @@
 ## 🌐 Browser Automation & Web Scraping
 
 Servers using tools for browser control, automation, and extracting content from websites.
+- [unitedideas/actablesite-mcp](https://github.com/unitedideas/actablesite-mcp): Read-only website audit MCP server for AI-crawler policy checks and full-report handoff. Supports Streamable HTTP and a dependency-free stdio bridge with no authentication; exposes 3 bounded tools and cannot modify sites. MIT.
 - [Goldentrii/novada-mcp](https://github.com/Goldentrii/novada-mcp): Web data MCP server for search, extraction, crawling, and research using Novada proxy infrastructure. Tools include `novada_search`, `novada_extract`, `novada_crawl`, and `novada_research`. Install: `npx -y novada-mcp`. Env: NOVADA_API_KEY.
 - [rog0x/mcp-web-tools](https://github.com/rog0x/mcp-web-tools): Web MCP tools for scraping, search, and monitoring workflows. Install from the `@rog0x` npm package family. MIT.
 - [rog0x/mcp-seo-tools](https://github.com/rog0x/mcp-seo-tools): SEO MCP tools for metadata, keywords, page speed, and search visibility checks. Install from the `@rog0x` npm package family. MIT.


### PR DESCRIPTION
## What

Adds the official ActableSite MCP implementation to Browser Automation & Web Scraping.

## Verification

- Source: https://github.com/unitedideas/actablesite-mcp
- MIT licensed and actively maintained
- Streamable HTTP plus dependency-free stdio transport
- No authentication
- Exactly 3 bounded, read-only tools
- Cannot modify audited sites
- Source test suite: 8 passing
- Live protocol verification: version 1.1.1 and all 3 documented tools detected

The catalog entry links only to the source repository.