### PR TITLE
Add latam-data-mcp to Finance & Crypto

### DIFF
--- a/docs/finance--crypto.md
+++ b/docs/finance--crypto.md
@@ -1,5 +1,6 @@
 ## 💰 Finance & Crypto
 
+- [svkbogislav/latam-data-mcp](https://github.com/svkbogislav/latam-data-mcp) - Latin America data & compliance MCP server: tax-ID validation for 15 countries, bank-account (MX CLABE, AR CBU/CVU), Brazil PIX-key and phone-number validation, company lookups (Brazil, Costa Rica), FX & central-bank rates, currency conversion, and holiday/business-day math. 20 tools, free no-key APIs. Install: `uvx latam-data-mcp`.
 - [AccountsOS](https://www.npmjs.com/package/@thriveventurelabs/accountsos-mcp) - AI accountant for UK and global founders. Query your company's real books (balances, transactions, VAT, deadlines, invoices) from Claude or any MCP client. Install: `npx -y @thriveventurelabs/accountsos-mcp`. Homepage: https://accounts-os.com
 - [Timwal78/SqueezeOS](https://github.com/Timwal78/SqueezeOS) - Institutional market intelligence MCP server with 33 tools. Schwab/Polygon/Alpaca APIs, x402 payment gating via XRPL/RLUSD and Base/USDC, short-squeeze detection, FTD cycle analysis. Free tier + paid signal tiers. Remote: `https://squeezeos-api.onrender.com/mcp`
 - [Timwal78/ghost-layer](https://github.com/Timwal78/ghost-layer) - Dual-chain XRPL/Base toll gateway for autonomous AI agents. URIToken on-chain licensing, 54-block execution matrix, Agent Passport loyalty tiers, x402 protocol. MCP: `https://ghost-layer.onrender.com/mcp`. Zero custody.


### PR DESCRIPTION
Adds latam-data-mcp — an open-source (MIT) MCP server for reliable Latin America data: tax-ID validation for 15 countries (real check digits), bank-account validation (Mexico CLABE, Argentina CBU/CVU), Brazil PIX-key & phone-number validation, company lookups (Brazil, Costa Rica), FX & central-bank rates, currency conversion, and holiday/business-day math. 20 tools, Python, on PyPI and the official MCP registry. All sources are free/no-key or pure local algorithms. Install: `uvx latam-data-mcp`.