### PR TITLE
Add GoldBean MCP server

### DIFF
--- a/docs/ai--llm-integration.md
+++ b/docs/ai--llm-integration.md
@@ -2,6 +2,7 @@
 
 Servers integrating with other AI models, AI platforms, RAG tools, prompt management, or agent frameworks.
 
+- [GoldBean](https://github.com/wuzenghai616-lang/goldbean): MCP gateway exposing 51 tools across 67 Baidu AI routes for OCR, translation, speech, ERNIE LLM, vision, NLP, protein structure, and video generation. Install: `npx goldbean-mcp`; remote SSE at `https://goldbean-api.xyz/sse`. No API key for the free tier; paid calls use x402 USDC, PayPal, or Alipay. MIT.
 - [Which-Model/whichmodel-mcp](https://github.com/Which-Model/whichmodel-mcp): Model routing advisor for autonomous agents with 4 tools for model recommendations, pricing lookup, comparisons, and model listing across 100+ LLMs. Remote endpoint: https://whichmodel.dev/mcp. No API key required. MIT.
 - [zenlee123/routerbase-mcp](https://github.com/zenlee123/routerbase-mcp): RouterBase model discovery, pricing lookup, and OpenAI-compatible chat completions through [routerbase](https://routerbase.com). Stdio via `npx -y routerbase-mcp`; requires `ROUTERBASE_API_KEY`. MIT.
 - [AgentPact MCP Server](https://github.com/adamkrawczyk/agentpact-mcp-server): AI agent marketplace MCP server with 42 tools for autonomous agent-to-agent commerce, including work discovery, negotiation, fulfillment, and USDC payments. Remote endpoint: https://mcp.agentpact.xyz/mcp.


### PR DESCRIPTION
## Summary\n\n- add the verified GoldBean MCP server to the AI & LLM Integration category\n- document its current 51-tool / 67-route coverage, local install, hosted SSE transport, payment options, and license\n\n## Verification\n\n- confirmed the source README now consistently documents 51 MCP tools across 67 Baidu AI routes\n- confirmed the published npm package, MIT license, and hosted SSE endpoint\n- \n\nCloses #1153