### PR TITLE
Add server-ops-mcp to Monitoring & Observability

### DIFF
--- a/docs/monitoring--observability.md
+++ b/docs/monitoring--observability.md
@@ -2,6 +2,7 @@
 
 Servers connecting to monitoring systems, logging platforms, or providing system/application performance metrics.
 
+- [GT-dinuo/server-ops-mcp](https://github.com/GT-dinuo/server-ops-mcp): Server ops via MCP — log troubleshooting, CPU/memory/disk monitoring, code edit, Nginx & certificate management. Local or SSH-remote with two-step confirmation, command whitelist, and secret redaction. Install: `npx -y server-ops-mcp`. Registry id `io.github.GT-dinuo/server-ops-mcp`.
 - [uptimemonitoring/examples](https://github.com/uptimemonitoring/examples): Agent-native uptime monitoring via MCP — create, inspect, and assert monitor health, list incidents, and manage monitors. Remote `streamable-http` at `https://api.uptimemonitoring.com/mcp`, OAuth 2.1 or API key, no install. Free 50-monitor tier. Registry id `com.uptimemonitoring/mcp`. Docs: https://uptimemonitoring.com/docs/mcp/.
 - [triadgit/humanhours-mcp](https://github.com/triadgit/humanhours-mcp): Track agent ROI and enrich companies via MCP: hours and money saved, ROI reports, and per-hour wage data. Remote `streamable-http` at `https://mcp.humanhours.dev/mcp`, OAuth 2.1, no install, no API keys. Registry id `dev.humanhours/humanhours`. Docs: https://humanhours.dev/docs/mcp.
 - [Tethral-Inc/AgentRegistry](https://github.com/Tethral-Inc/AgentRegistry): Agent Composition Records MCP server for logging AI-agent interactions and querying behavioral profiles through friction, coverage, stable-corridor, failure-registry, and trend lenses. 21 tools. Install: `npx -y @tethral/acr-mcp`.


### PR DESCRIPTION
Adds [server-ops-mcp](https://github.com/GT-dinuo/server-ops-mcp) to the Monitoring & Observability category page.

**What it is:** General-purpose server-ops MCP server — log troubleshooting, CPU/memory/disk monitoring, code edit, Nginx & certificate management. Local + SSH-remote modes, with two-step confirmation for writes, command whitelist, and secret redaction.

- npm: https://www.npmjs.com/package/server-ops-mcp (`npx -y server-ops-mcp`)
- Official MCP Registry id: `io.github.GT-dinuo/server-ops-mcp`
- Entry follows the category-page bullet format with install command and registry id