### PR TITLE
Add Samyama Graph

### DIFF
--- a/docs/databases.md
+++ b/docs/databases.md
@@ -297,3 +297,4 @@ Servers providing interfaces to various database types like SQL, NoSQL, Vector D
 
 - [stucchi/db-mcp-server](https://github.com/stucchi/db-mcp-server): Database MCP server for MySQL, PostgreSQL, and MongoDB with SSH tunneling support. Run queries, explore schemas, and manage data across multiple database types.
 - [haymon-ai/dbmcp](https://github.com/haymon-ai/dbmcp): Connect AI assistants to MySQL, MariaDB, PostgreSQL, and SQLite databases through an MCP server with schema discovery, query execution, read-only mode, and optional PII redaction.
+- [Samyama Graph](https://github.com/samyama-ai/samyama-graph): Auto-generates MCP servers from a graph schema, letting an agent run openCypher traversals and HNSW vector search against the same store. Install: `pip install samyama[mcp]`.


### PR DESCRIPTION
Adds [samyama-ai/samyama-graph](https://github.com/samyama-ai/samyama-graph), an Apache-2.0 graph-vector database written in Rust: property-graph traversal with ~90% openCypher coverage and HNSW vector search in a single engine.

- Repo: https://github.com/samyama-ai/samyama-graph — 78 stars, actively developed, v1.7.0 released 2026-07-21
- License: Apache-2.0
- Docs: https://graph.samyama.cloud/book/
- openCypher coverage is deliberately described as *~90%*; the known gaps are documented in [docs/CYPHER_COMPATIBILITY.md](https://github.com/samyama-ai/samyama-graph/blob/main/docs/CYPHER_COMPATIBILITY.md).

Entry placed in **Databases**, following the surrounding formatting. Disclosure: I work with the team behind this project. Happy to adjust the wording or placement.
