### PR TITLE
metadata: add sidecar for sipyourdrink-ltd/bernstein

### DIFF
--- a/data/server-metadata/github-sipyourdrink-ltd-bernstein-82d9a3e2.json
+++ b/data/server-metadata/github-sipyourdrink-ltd-bernstein-82d9a3e2.json
@@ -42,23 +42,19 @@
     "other MCP clients with stdio or streamable HTTP support"
   ],
   "tools": {
-    "count": 17,
+    "count": 13,
     "names": [
+      "bernstein_health",
+      "bernstein_run",
+      "bernstein_status",
+      "bernstein_tasks",
+      "bernstein_task_handle",
       "bernstein_approve",
       "bernstein_claim",
-      "bernstein_context",
       "bernstein_cost",
       "bernstein_create_subtask",
-      "bernstein_health",
       "bernstein_post_artifact",
-      "bernstein_run",
-      "bernstein_scenario",
-      "bernstein_scenario_status",
-      "bernstein_scenarios",
-      "bernstein_status",
       "bernstein_stop",
-      "bernstein_task_handle",
-      "bernstein_tasks",
       "bernstein_update",
       "load_skill"
     ],
@@ -68,9 +64,9 @@
   "verification": {
     "status": "self_reported",
     "notes": [
-      "Tool names and count read from the shipped tool schemas in src/bernstein/mcp/tool_schemas/ at version 3.9.0.",
+      "Tool count is the number advertised at the default tier. The server has a tier setting that trades tool count against context budget: core advertises 5, the default standard advertises the 13 listed here, and all advertises 18. The repository ships 17 tool schema files, which is a different figure and is not the advertised count.",
       "Transports read from the stdio entry point and the streamable HTTP transport module.",
-      "Adapter count read from the adapter registry, which holds more than 40 entries; the indexed profile description said 37."
+      "Adapter count read from the adapter registry, which holds more than 40 entries. The indexed profile description said 37."
     ]
   },
   "community": {

--- a/data/server-metadata/github-sipyourdrink-ltd-bernstein-82d9a3e2.json
+++ b/data/server-metadata/github-sipyourdrink-ltd-bernstein-82d9a3e2.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "../../schemas/server-metadata.schema.json",
+  "id": "github-sipyourdrink-ltd-bernstein-82d9a3e2",
+  "source": {
+    "issue": 1390,
+    "projectUrl": "https://github.com/sipyourdrink-ltd/bernstein"
+  },
+  "description": "Orchestrator for CLI coding agents, exposed over MCP. Runs Claude Code, Codex, Gemini CLI, Aider, OpenHands and 40 or more other agent CLIs in isolated git worktrees under a deterministic scheduler, with deterministic replay, lineage records, and an opt-in HMAC-chained audit log that verifies offline. Apache 2.0.",
+  "category": "AI & LLM Integration",
+  "links": {
+    "docs": "https://bernstein.readthedocs.io"
+  },
+  "install": {
+    "commands": [
+      "uvx --from bernstein bernstein mcp",
+      "pip install bernstein && bernstein mcp",
+      "bernstein mcp --transport http --port 8765"
+    ],
+    "env": [],
+    "confidence": "high"
+  },
+  "transport": [
+    "stdio",
+    "sse",
+    "streamable-http"
+  ],
+  "auth": {
+    "type": "none",
+    "notes": [
+      "The stdio transport requires no authentication.",
+      "The HTTP transport accepts a static bearer token supplied through BERNSTEIN_MCP_TOKEN or BERNSTEIN_AUTH_TOKEN; when neither is set it binds loopback only.",
+      "OAuth 2 protected-resource discovery metadata is served, but anonymous and static-bearer remain the advertised flows."
+    ]
+  },
+  "clients": [
+    "Claude Code",
+    "Claude Desktop",
+    "Cursor",
+    "Cline",
+    "Continue",
+    "Zed",
+    "other MCP clients with stdio or streamable HTTP support"
+  ],
+  "tools": {
+    "count": 17,
+    "names": [
+      "bernstein_approve",
+      "bernstein_claim",
+      "bernstein_context",
+      "bernstein_cost",
+      "bernstein_create_subtask",
+      "bernstein_health",
+      "bernstein_post_artifact",
+      "bernstein_run",
+      "bernstein_scenario",
+      "bernstein_scenario_status",
+      "bernstein_scenarios",
+      "bernstein_status",
+      "bernstein_stop",
+      "bernstein_task_handle",
+      "bernstein_tasks",
+      "bernstein_update",
+      "load_skill"
+    ],
+    "source": "self_reported"
+  },
+  "license": "Apache-2.0",
+  "verification": {
+    "status": "self_reported",
+    "notes": [
+      "Tool names and count read from the shipped tool schemas in src/bernstein/mcp/tool_schemas/ at version 3.9.0.",
+      "Transports read from the stdio entry point and the streamable HTTP transport module.",
+      "Adapter count read from the adapter registry, which holds more than 40 entries; the indexed profile description said 37."
+    ]
+  },
+  "community": {
+    "maintainedBy": [
+      "@chernistry"
+    ],
+    "verifiedBy": [],
+    "claimed": true
+  }
+}


### PR DESCRIPTION
Adds `data/server-metadata/github-sipyourdrink-ltd-bernstein-82d9a3e2.json`.

The indexed profile for this server currently records `transport: ["unknown"]`, `auth: "unknown"`, `toolCount: null`, `installConfidence: "low"` and no homepage or docs link, and its description states 37 agent CLIs where the project adapter registry holds more than 40.

This sidecar supplies values read from the project source at version 3.9.0:

| Field | Value | Read from |
|---|---|---|
| transport | stdio, sse, streamable-http | the stdio entry point and the streamable HTTP transport module |
| auth | none, with an optional static bearer on the HTTP transport | the transport auth path |
| tools | 17, named | the shipped tool schemas |
| install | `uvx --from bernstein bernstein mcp` | the console entry point |
| license | Apache-2.0 | LICENSE and package metadata |
| docs | https://bernstein.readthedocs.io | live |

Validated against `schemas/server-metadata.schema.json`: required keys, id pattern, no unknown properties in any object, and every enum-constrained field.

Filed because the metadata improvement issue in #1390 could not be processed automatically. Refs #1390