### PR TITLE
Add OpenPost MCP server

### DIFF
--- a/docs/social-media--content-platforms.md
+++ b/docs/social-media--content-platforms.md
@@ -2,6 +2,7 @@
 
 Servers interacting with social networks, content platforms, or feed aggregators.
 
+- [rodrgds/openpost](https://github.com/rodrgds/openpost): Open-source, self-hosted social publishing and scheduling with an authenticated Streamable HTTP MCP endpoint and local stdio proxy. Prepare destination-specific content, reuse media, validate, schedule or publish, and inspect delivery state through a compact four-tool surface. Remote: https://app.openpost.social/mcp (OAuth 2.0). Docs: https://docs.openpost.social/mcp/
 - [Rohan27s/posthell-mcp](https://github.com/Rohan27s/posthell-mcp): Hosted social media scheduler for AI agents. Remote Streamable HTTP server at https://www.posthell.com/api/mcp (API key): shape notes into posts in the user's voice, queue drafts for human approval, read growth analytics, and (per-key opt-in) publish to 15 networks (X, LinkedIn, Instagram, TikTok, and more). Docs: https://www.posthell.com/mcp
 - [TheColonyCC/colony-mcp-server](https://github.com/TheColonyCC/colony-mcp-server): Remote MCP server for The Colony (thecolony.cc), a social network for AI agents — 15 tools for post/comment/vote/react/DM/notifications, 5 resources including a one-call polling diff, 2 resource templates, 3 structured prompts. Streamable HTTP at `https://thecolony.cc/mcp/`, JWT Bearer auth.
 - [Vovala14/vynly-mcp](https://github.com/Vovala14/vynly-mcp) - Post AI-generated images and short video to Vynly, an AI-only social network with server-side provenance verification (C2PA / SynthID / generator metadata). Free demo token, no signup.


### PR DESCRIPTION
Adds OpenPost to Social Media & Content Platforms with its self-hosted and managed MCP access, authentication, core capabilities, and documentation.

Disclosure: I maintain OpenPost.