### PR TITLE
Add Tavily Hub to Search category — 国内 Tavily 聚合 + Credit 池 + MCP 双协议

### DIFF
--- a/README.md
+++ b/README.md
@@ -2283,6 +2283,8 @@ Servers accessing scientific databases, research platforms, or providing tools f
 Servers providing web search capabilities or interfacing with specialized search APIs/platforms.
 
 - [RamXX/mcp-tavily](https://github.com/RamXX/mcp-tavily): An MCP server for Tavily's search API
+- [sharyuke/tavily-hub](https://github.com/sharyuke/tavily-hub): Tavily 国内聚合 + Credit 池回充 + 自费通道 + 多账号号池 + 自动负载均衡 (MCP streamableHTTP + SSE 双协议, 5 分钟接入 Claude/Cursor/Cherry 等 9 个客户端, 无需海外信用卡)
+
 - [Sunwood-ai-labs/duckduckgo-web-search](https://github.com/Sunwood-ai-labs/duckduckgo-web-search): DuckDuckGo Web Search MCP Server - A simple web search implementation for Claude Desktop using DuckDuckGo API
 - [letsbuildagent/perplexity-tool](https://github.com/letsbuildagent/perplexity-tool): perplexity search tool for Claude MCP
 - [kagisearch/kagimcp](https://github.com/kagisearch/kagimcp): A Model Context Protocol (MCP) server for Kagi search.


### PR DESCRIPTION
## What is Tavily Hub?

Tavily Hub 是面向国内 AI 创作者的自建 Tavily 聚合网关 — 把多把 Tavily Key 合成一个动态号池，对外一个端点（thb- 开头），绕开官方免费档 1000 次/月的硬上限。

- 仓库：https://github.com/sharyuke/tavily-hub
- 官网：https://tavily.sharyuke.com

## 三大核心能力

1. **Credit 池 + 定时回充** — 池容量 + 每分钟回充，避开月度配额硬切
2. **多账号号池 + 自动负载均衡** — round_robin / weighted / least_used 在线热切换
3. **MCP streamableHTTP + SSE 双协议** — 一行配置接 Claude / Cursor / Cherry Studio 等 9 个客户端

## Connect

```json
{
  "mcpServers": {
    "tavily-hub": {
      "type": "streamable-http",
      "url": "https://tavily.sharyuke.com/api/mcp",
      "headers": { "Authorization": "thb-<your-hub-key>" }
    }
  }
}
```

老版本客户端（pre-MCP-2025-03-26）把 URL 末尾加 `/sse` 即可。

## Entry

- Transport: streamable-http + sse
- Auth: API key (Hub key, thb- prefix) in Authorization header
- Category: Search
- Tools: `tavily_search`, `tavily_extract`, `tavily_crawl`