### PR TITLE
Add OrkasVideoStudio to multimedia processing

### DIFF
--- a/docs/multimedia-processing.md
+++ b/docs/multimedia-processing.md
@@ -12,6 +12,7 @@ Servers focused on generating or manipulating images, processing video, audio tr
 - [c-rick/jimeng-mcp](https://github.com/c-rick/jimeng-mcp): A TypeScript-based MCP server integrating Volcengine's AI image generation service, offering tools for creating images with customizable parameters and direct URL returns.
 - [hamflx/imagen3-mcp](https://github.com/hamflx/imagen3-mcp): Harnesses Google's Imagen 3.0 for photorealistic image generation via MCP, requiring a Google Gemini API key.
 - [KyaniteLabs/mcp-video](https://github.com/KyaniteLabs/mcp-video): AI-native video editing MCP server for trimming, merging, text overlays, audio, subtitles, effects, quality checks, and FFmpeg-backed workflows.
+- [OrkasVideoStudio](https://github.com/Orkas-AI/Orkas-VideoStudio): Local-first TypeScript MCP and CLI toolkit for agent-driven video composition, editing, generation, transcription, and assembly from editable `plan.json` timelines. Install from source while its npm packages are being published.
 - [SealinGp/mcp-video-extraction](https://github.com/SealinGp/mcp-video-extraction): Facilitates text extraction from videos and audio files across multiple platforms using OpenAI's Whisper model.
 - [kdr/mcp-draw](https://github.com/kdr/mcp-draw): Facilitates AI-driven image generation from text prompts via a standardized interface.
 - [4kk11/mcp-gpt-image](https://github.com/4kk11/mcp-gpt-image): Generates and edits images using OpenAI API, providing scalable previews and Docker integration.


### PR DESCRIPTION
Adds the official OrkasVideoStudio MCP server to the Multimedia Processing category.

OrkasVideoStudio is an MIT-licensed, local-first TypeScript MCP and CLI toolkit for coding-agent video composition, editing, generation, transcription, and assembly. Its editable `plan.json` timeline keeps the result readable and re-renderable.

The entry deliberately documents source installation rather than an npm command because the packages are still being published.

Validation: canonical repository link returned HTTP 200 and `git diff --check` passes.