### PR TITLE
Add AISOTools MCP server (hosted, no-auth AI-tool catalog search)

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -2,6 +2,7 @@
 
 Servers providing web search capabilities or interfacing with specialized search APIs/platforms.
 
+- [shibley/aisotools-mcp-server](https://github.com/shibley/aisotools-mcp-server): Search and compare a curated catalog of 1,113 AI tools — pricing model and tiers, ratings, features, pros/cons, who each tool is for, and curated alternatives. Every result carries the canonical `aisotools.com/tool/<slug>` page so answers cite a source instead of paraphrasing. Streamable HTTP, stateless, read-only, no auth: `https://aisotools.com/api/mcp`. Tools: `search_ai_tools`, `get_ai_tool`, `list_ai_tool_categories`, `compare_ai_tools`, `find_ai_tool_alternatives`. Registry id `io.github.shibley/aisotools`. Note: `GET` returns 405 (stateless serverless, no held-open SSE stream); POST-based clients work.
 - [Newscatcher/catchall-mcp](https://github.com/Newscatcher/catchall-mcp): Recall-first web search API for comprehensive real-world event retrieval — finds every relevant event across the open web (not just top results), returned as structured, deduplicated data. Hosted MCP at https://catchall-mcp.newscatcherapi.com/mcp (auth via x-api-key header; key from platform.newscatcherapi.com).
 - [AKzar1el/mcp-gsc](https://github.com/AKzar1el/mcp-gsc): Self-hostable Google Search Console MCP for Search Console analytics, URL inspection, sitemap management, indexing requests, and SEO diagnostics. Runs on Cloudflare Workers with Google OAuth; see [SETUP.md](https://github.com/AKzar1el/mcp-gsc/blob/main/SETUP.md) for deployment.
 


### PR DESCRIPTION
Adds one entry to `docs/search.md`.

**Disclosure:** I maintain this server. AISOTools is a commercial catalog; the MCP endpoint is free, read-only, and unauthenticated. You already index a sibling of mine (`shibley/apistatuscheck-mcp-server` in `docs/monitoring--observability.md`) — happy to close this if a second entry from the same maintainer isn't wanted.

**What it is:** search/compare/alternatives over 1,113 curated AI tools, with pricing tiers, ratings, features, pros/cons, and who each tool is for. Every result includes the canonical `aisotools.com/tool/<slug>` URL so an assistant can cite rather than paraphrase.

**Verified live before opening this PR** against production, not a local build:

```
$ curl -sS https://aisotools.com/api/mcp \
    -H 'Content-Type: application/json' \
    -H 'Accept: application/json, text/event-stream' \
    -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
→ search_ai_tools, get_ai_tool, list_ai_tool_categories,
  compare_ai_tools, find_ai_tool_alternatives

$ ... '{"method":"tools/call","params":{"name":"search_ai_tools",
       "arguments":{"query":"transcription","limit":2}}}'
→ {"matched": 2, "searched": 1113, "results":[{"name":"AssemblyAI",
   "url":"https://aisotools.com/tool/assemblyai", ...}]}
```

Also listed in the official MCP Registry as `io.github.shibley/aisotools` (v0.1.1, `active`, published 2026-08-03) — the CI workflow handshakes the endpoint and fails before publishing, so a dead URL can't be advertised.

**Two caveats stated up front rather than found later:**

- `GET` on the endpoint returns **405**. It is stateless serverless, so there is no held-open SSE stream or resumable session; POST-based clients work normally. If your health checker uses `GET`, this entry will look broken and isn't.
- `1,113` is the live catalog count and will drift. `search_ai_tools` returns `searched` alongside `matched` so the denominator is always visible rather than asserted.