### PR TITLE
Add Jacobian to science and research MCP servers

### DIFF
--- a/docs/science--research.md
+++ b/docs/science--research.md
@@ -2,7 +2,7 @@
 
 Servers accessing scientific databases, research platforms, or providing tools for scientific computation/simulation.
 
-- [morluto/jacobian](https://github.com/morluto/jacobian): Executable mathematics and independent verification for AI agents through a composable MCP server. Install: `npx -y jacobian mcp`.
+- [morluto/jacobian](https://github.com/morluto/jacobian): MCP server, CLI, and Python library for composable mathematics: exact computation and conjecture testing across polynomial maps, linear algebra, and graph algorithms. Install: `npx -y jacobian mcp`.
 
 - [xmpuspus/ph-civic-data-mcp](https://github.com/xmpuspus/ph-civic-data-mcp): Philippine civic data plus global Earth observation as MCP tools. Covers PSGC location resolver, PHIVOLCS earthquakes and volcano alerts, PAGASA weather and typhoons, PhilGEPS procurement with infra-spending accountability flags, PSA population, poverty, and economy (inflation, labor, health), NASA POWER solar/climate, Open-Meteo air quality, NASA MODIS NDVI, USGS earthquakes, NOAA IBTrACS typhoon tracks, and World Bank macro indicators. 29 tools across 12 sources, zero required API keys, with cross-source multi-hazard risk profiler and a `get_area_profile` auto-stitch that composes demographics, economy, procurement, hazard, and weather in one call. Install: `uvx ph-civic-data-mcp`.
 - [GreatApo/concrete-properties-mcp](https://github.com/GreatApo/concrete-properties-mcp): Facilitates AI-driven analysis of reinforced concrete sections by providing a unified API interface for calculating geometric and material properties.

--- a/docs/science--research.md
+++ b/docs/science--research.md
@@ -2,6 +2,8 @@
 
 Servers accessing scientific databases, research platforms, or providing tools for scientific computation/simulation.
 
+- [morluto/jacobian](https://github.com/morluto/jacobian): Executable mathematics and independent verification for AI agents through a composable MCP server. Install: `npx -y jacobian mcp`.
+
 - [xmpuspus/ph-civic-data-mcp](https://github.com/xmpuspus/ph-civic-data-mcp): Philippine civic data plus global Earth observation as MCP tools. Covers PSGC location resolver, PHIVOLCS earthquakes and volcano alerts, PAGASA weather and typhoons, PhilGEPS procurement with infra-spending accountability flags, PSA population, poverty, and economy (inflation, labor, health), NASA POWER solar/climate, Open-Meteo air quality, NASA MODIS NDVI, USGS earthquakes, NOAA IBTrACS typhoon tracks, and World Bank macro indicators. 29 tools across 12 sources, zero required API keys, with cross-source multi-hazard risk profiler and a `get_area_profile` auto-stitch that composes demographics, economy, procurement, hazard, and weather in one call. Install: `uvx ph-civic-data-mcp`.
 - [GreatApo/concrete-properties-mcp](https://github.com/GreatApo/concrete-properties-mcp): Facilitates AI-driven analysis of reinforced concrete sections by providing a unified API interface for calculating geometric and material properties.
 - [GooTec/NCBI-MCP](https://github.com/GooTec/NCBI-MCP): Facilitates access to NCBI Datasets through a modular MCP server with OpenAPI-driven endpoints for genome, gene, and taxonomy data.


### PR DESCRIPTION
Adds Jacobian to the Science & Research MCP server list. One entry added; nothing else touched.

What it is: an MCP server, CLI, and Python library for composable mathematics: exact computation and conjecture testing across polynomial maps, linear algebra, and graph algorithms.

Why it fits: the category already includes MCP servers for mathematical expressions, numerical computing, theorem proving, and scientific research.

Install: `npx -y jacobian mcp`

License: MIT

Validation:

- `git diff --check`
