### PR TITLE
Add kelvia-mcp to Project & Task Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ The README is now a lightweight entry point. Browse the full directory in the ca
 | Monitoring & Observability | 88 | [Browse](docs/monitoring--observability.md) |
 | Multimedia Processing | 212 | [Browse](docs/multimedia-processing.md) |
 | Operating System & Command Line | 107 | [Browse](docs/operating-system--command-line.md) |
-| Project & Task Management | 223 | [Browse](docs/project--task-management.md) |
+| Project & Task Management | 222 | [Browse](docs/project--task-management.md) |
 | Real Estate & Home Services | 3 | [Browse](docs/real-estate--home-services.md) |
 | Science & Research | 118 | [Browse](docs/science--research.md) |
 | Search | 172 | [Browse](docs/search.md) |

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ The README is now a lightweight entry point. Browse the full directory in the ca
 | Monitoring & Observability | 88 | [Browse](docs/monitoring--observability.md) |
 | Multimedia Processing | 212 | [Browse](docs/multimedia-processing.md) |
 | Operating System & Command Line | 107 | [Browse](docs/operating-system--command-line.md) |
-| Project & Task Management | 222 | [Browse](docs/project--task-management.md) |
+| Project & Task Management | 223 | [Browse](docs/project--task-management.md) |
 | Real Estate & Home Services | 3 | [Browse](docs/real-estate--home-services.md) |
 | Science & Research | 118 | [Browse](docs/science--research.md) |
 | Search | 172 | [Browse](docs/search.md) |

--- a/docs/project--task-management.md
+++ b/docs/project--task-management.md
@@ -2,6 +2,7 @@
 
 Servers integrating with project management and task tracking tools.
 
+- [gonnagetapower/kelvia-mcp](https://github.com/gonnagetapower/kelvia-mcp): Task manager an agent can fully operate, not just read: boards, tasks, sprints, member roles, worklogs and a time-blocking day planner across 58 tools. Hosted endpoint with OAuth 2.1 (one command, no token to paste) plus stdio; every tool carries MCP safety annotations, and toolsets let a client load only the part it needs.
 - [KyaniteLabs/Epoch](https://github.com/KyaniteLabs/Epoch): Software estimation MCP server — PERT, COCOMO II, Monte Carlo, sprint forecasting, and schedule-risk tools for AI agents.
 - [Claw Task Hub](https://github.com/Catfish-75/claw-task-hub): Local-first, SQLite-backed task hub with MCP-compatible tools for AI agent issue tracking, sessions, claims, comments, and acceptance trails.
 - [MadGapun/PBP](https://github.com/MadGapun/PBP): AI-powered MCP server for job application management in the German-speaking market (DACH). 73 tools, 18 guided workflows, 18 job portal scrapers, React dashboard with 8 tabs, email integration (.msg/.eml), calendar with .ics export, intelligent scoring, and AI coaching. Currently German language only. MIT licensed, runs locally, privacy-first.


### PR DESCRIPTION
Adds [kelvia-mcp](https://github.com/gonnagetapower/kelvia-mcp) to **Project & Task Management**, and bumps that category's count in the README table from 222 to 223 so the two stay in sync.

[Kelvia](https://kelvia.app) is a task manager built to be operated by an agent rather than just read from: 58 tools across boards, tasks, sprints, member roles, worklogs and a personal time-blocking day planner.

- Hosted endpoint with OAuth 2.1 (`https://mcp.kelvia.app/mcp`) — one command to connect, no token to paste. stdio is there for clients without remote MCP support, and for CI.
- Every tool carries MCP annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`); 22 of the 58 are read-only.
- Toolsets let a client publish one part of the product instead of the whole surface, which keeps the schema out of the context budget.
- On npm as [`kelvia-mcp`](https://www.npmjs.com/package/kelvia-mcp) and in the official MCP registry as `io.github.gonnagetapower/kelvia-mcp`. MIT licensed.