### PR TITLE
Add harvis.dev (remote MCP server) to Build & Deployment Tools

### DIFF
--- a/docs/build--deployment-tools.md
+++ b/docs/build--deployment-tools.md
@@ -91,3 +91,4 @@ Servers interacting with build systems, containerization, CI/CD, or deployment p
 - [Bigsy/maven-mcp-server](https://github.com/Bigsy/maven-mcp-server): Facilitates LLMs in verifying and retrieving Maven dependency versions from the Maven Central Repository.
 - [QuantGeekDev/docker-mcp](https://github.com/QuantGeekDev/docker-mcp): Facilitates Docker container and stack management through Claude AI with a Model Context Protocol server.
 - [solomon2773/nora](https://github.com/solomon2773/nora): Deploy, inspect, start, stop, restart, redeploy, and monitor self-hosted OpenClaw and Hermes agent fleets through a Nora control plane, including fleet health, metrics, events, versions, and per-agent cost.
+- [harvis.dev](https://harvis.dev): Publishes static sites from AI agents via a deploy_site tool that returns a live URL. Remote Streamable HTTP endpoint at https://harvis.dev/api/mcp; open access, no auth or account required.


### PR DESCRIPTION
Adds harvis.dev to `docs/build--deployment-tools.md`.

Metadata per the maintainer quick start:
- **Endpoint:** `https://harvis.dev/api/mcp` (remote, Streamable HTTP)
- **Transport:** Streamable HTTP
- **Auth:** none required — open access; anonymous deploys return a private claim link
- **Tools:** `deploy_site` — publishes a folder of static files, returns a live `slug.harvis.dev` URL
- **Supported clients:** any remote-MCP-capable client (Claude Desktop/Code, Cursor, VS Code, etc.)
- **Docs / website:** https://harvis.dev
- **Install:** paste the endpoint into your MCP client config; no package to install
- **Maintainer:** harvis.dev team (this submission) — happy to file the claim-profile form after merge

Disclosure: I built harvis.dev.
