### PR TITLE
docs: add discord-mcp

### DIFF
--- a/docs/communication--messaging.md
+++ b/docs/communication--messaging.md
@@ -2,6 +2,7 @@
 
 Servers for interacting with email, chat platforms, SMS, or notification services.
 
+- [cappyeo/discord-mcp](https://github.com/cappyeo/discord-mcp): Caller-owned Discord operations for AI agents with 208 typed tools, explicit bot/guild boundaries, resumable builds, and Activity Evidence. Install: `npx -y @discord-mcp/cli@0.22.0`.
 - [anipotts/imessage-mcp](https://github.com/anipotts/imessage-mcp): iMessage MCP server for sending and reading Apple Messages on macOS. Install: `npx imessage-mcp`.
 - [nylas/cli](https://github.com/nylas/cli): MCP server for email, calendar, and contacts. 16 tools across Gmail, Outlook, Exchange, Yahoo, iCloud, and IMAP via a single auth flow. JSON output, install with `nylas mcp install`, works with Claude Code, Cursor, Codex, and Windsurf. Docs at https://cli.nylas.com.
 - [mailkite/mailkite-mcp](https://github.com/mailkite/mailkite-mcp): Gives an AI agent its own real email inbox — inbound mail arrives as structured tool calls and the agent sends from a domain you verify (SPF/DKIM), rather than wrapping a human's existing mailbox. Hosted remote server at `https://mcp.mailkite.dev/mcp` (Streamable HTTP, OAuth 2.0 with dynamic client registration and RFC 9728 protected-resource discovery — no local install). 60+ tools: transactional send and batch, attachments, inbound routes, webhook set/test, domain registration + DNS verification, templates, contact lists, broadcasts, and message search. MIT. Docs at https://mailkite.dev/docs/ai-agents.


### PR DESCRIPTION
Adds the caller-owned Discord operations MCP server to Communication & Messaging. The entry points to the canonical repository, documents the current public 0.22.0 install command and 208-tool surface, and was checked against the repository for duplicates.