### PR TITLE
Add Ask Helena

### DIFF
--- a/docs/healthcare--life-sciences.md
+++ b/docs/healthcare--life-sciences.md
@@ -2,6 +2,7 @@
 
 Servers integrating with healthcare standards, medical literature databases, bioinformatics resources, or specific healthcare platforms.
 
+- [Ask Helena](https://github.com/helena-bioinformatics/ask-helena-mcp): Official public, read-only Helena Bioinformatics MCP for source-cited answers about the company and its published bioinformatics products. Remote Streamable HTTP at `https://api.helena.bio/ask/v1/mcp`; no authentication; Apache-2.0 integration bridge. Excludes private content and patient data and does not perform clinical variant interpretation. [Website](https://www.helena.bio/ask) · [Official Registry](https://registry.modelcontextprotocol.io/?q=io.github.helena-bioinformatics%2Fask-helena)
 - [Legal Fournier Spain Legal](https://legalfournier.com/en/mcp/spain-legal/): Read-only Streamable HTTP MCP server for Spain legal route screening, including visas, Beckham Law eligibility, NIE/TIE, residency, nationality, EU family routes, and handoff preparation.
 - [fastomop/omcp_a2a](https://github.com/fastomop/omcp_a2a): Facilitates LLM-driven analysis of healthcare data in OMOP format through modular MCP servers and A2A protocol integration.
 - [deak-ai/openehr-mcp-server](https://github.com/deak-ai/openehr-mcp-server): Facilitates seamless integration with openEHR REST APIs, enabling the creation and management of electronic health records and compositions.


### PR DESCRIPTION
## Summary

Adds **Ask Helena** to Healthcare & Life Sciences as the official public knowledge companion to Folklore Clinical Variant Interpretation MCP.

Ask Helena provides source-cited answers about Helena Bioinformatics and its published bioinformatics products through a public, read-only Streamable HTTP endpoint. It requires no authentication and exposes exactly `search_public_knowledge` and `ask_public_knowledge`.

The entry preserves the product boundary: Ask Helena excludes private Wiki content, backend details, credentials, patient data, clinical records and writes, and it does not perform live variant classification. Apache-2.0 applies only to the public integration bridge; the private backend and corpus are not published.

This is an additive maintainer submission. The Folklore entry remains unchanged.