### PR TITLE
Add SandBase Harness MCP server

### DIFF
--- a/data/server-metadata/github-sandbaseai-sandbase-harness-7a5986ca.json
+++ b/data/server-metadata/github-sandbaseai-sandbase-harness-7a5986ca.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "../../schemas/server-metadata.schema.json",
+  "id": "github-sandbaseai-sandbase-harness-7a5986ca",
+  "source": {
+    "projectUrl": "https://github.com/sandbaseai/sandbase-harness"
+  },
+  "links": {
+    "docs": "https://github.com/sandbaseai/sandbase-harness/tree/v0.3.0/examples/deepseek-harness"
+  },
+  "install": {
+    "commands": [
+      "git clone --branch v0.3.0 --depth 1 https://github.com/sandbaseai/sandbase-harness.git && cd sandbase-harness && npm ci && npm run build:runtime"
+    ],
+    "env": [
+      "MANAGED_AGENTS_URL",
+      "MANAGED_AGENTS_API_KEY"
+    ],
+    "confidence": "high"
+  },
+  "transport": [
+    "stdio"
+  ],
+  "auth": {
+    "type": "api-key",
+    "notes": [
+      "MANAGED_AGENTS_API_KEY is only required when authentication is enabled on the connected managed-agents runtime."
+    ]
+  },
+  "clients": [
+    "DeepSeek Harness"
+  ],
+  "license": "Apache-2.0",
+  "tools": {
+    "count": 6,
+    "names": [
+      "list_agents",
+      "create_session",
+      "run_session",
+      "get_session",
+      "list_artifacts",
+      "stop_session"
+    ],
+    "source": "self_reported"
+  },
+  "verification": {
+    "status": "self_reported",
+    "notes": [
+      "The v0.3.0 release gate passed 573 tests, production builds, package validation, and CLI/workspace smoke checks.",
+      "The stdio MCP handshake was verified against DeepSeek Harness commit 47f9438."
+    ]
+  }
+}

--- a/data/server-metadata/github-sandbaseai-sandbase-harness-7a5986ca.json
+++ b/data/server-metadata/github-sandbaseai-sandbase-harness-7a5986ca.json
@@ -5,11 +5,11 @@
     "projectUrl": "https://github.com/sandbaseai/sandbase-harness"
   },
   "links": {
-    "docs": "https://github.com/sandbaseai/sandbase-harness/tree/v0.3.0/examples/deepseek-harness"
+    "docs": "https://github.com/sandbaseai/sandbase-harness/tree/v0.3.1/examples/deepseek-harness"
   },
   "install": {
     "commands": [
-      "git clone --branch v0.3.0 --depth 1 https://github.com/sandbaseai/sandbase-harness.git && cd sandbase-harness && npm ci && npm run build:runtime"
+      "git clone --branch v0.3.1 --depth 1 https://github.com/sandbaseai/sandbase-harness.git && cd sandbase-harness && npm ci && npm run build:runtime"
     ],
     "env": [
       "MANAGED_AGENTS_URL",
@@ -45,7 +45,7 @@
   "verification": {
     "status": "self_reported",
     "notes": [
-      "The v0.3.0 release gate passed 573 tests, production builds, package validation, and CLI/workspace smoke checks.",
+      "The v0.3.1 release gate passed 572 tests (15 skipped), production builds, package validation, and CLI/workspace smoke checks.",
       "The stdio MCP handshake was verified against DeepSeek Harness commit 47f9438."
     ]
   }

--- a/docs/code-execution.md
+++ b/docs/code-execution.md
@@ -2,7 +2,7 @@
 
 Servers designed to execute code snippets or scripts in various languages, often in sandboxed environments.
 
-- [sandbaseai/sandbase-harness](https://github.com/sandbaseai/sandbase-harness): Model-agnostic managed agent runtime with a stdio MCP bridge for persistent sandboxed sessions, streamed runs, artifacts, cancellation, audit, and replay. Source release: [v0.3.0](https://github.com/sandbaseai/sandbase-harness/releases/tag/v0.3.0).
+- [sandbaseai/sandbase-harness](https://github.com/sandbaseai/sandbase-harness): Model-agnostic managed agent runtime with a stdio MCP bridge for persistent sandboxed sessions, streamed runs, artifacts, cancellation, audit, and replay. Source release: [v0.3.1](https://github.com/sandbaseai/sandbase-harness/releases/tag/v0.3.1).
 - [rapidriskradar/RRR-MCP](https://github.com/rapidriskradar/RRR-MCP): Facilitates the execution of RRR scripts through a configurable MCP server interface.
 - [Quathor/CMD-Executor](https://github.com/Quathor/CMD-Executor): Facilitates remote execution of Windows CMD commands via the MCP protocol, ensuring secure and configurable command execution.
 - [JSFrouws/mcp-matlab-executor](https://github.com/JSFrouws/mcp-matlab-executor): Securely execute MATLAB functions and scripts with user-approved security prompts.

--- a/docs/code-execution.md
+++ b/docs/code-execution.md
@@ -2,6 +2,7 @@
 
 Servers designed to execute code snippets or scripts in various languages, often in sandboxed environments.
 
+- [sandbaseai/sandbase-harness](https://github.com/sandbaseai/sandbase-harness): Model-agnostic managed agent runtime with a stdio MCP bridge for persistent sandboxed sessions, streamed runs, artifacts, cancellation, audit, and replay. Source release: [v0.3.0](https://github.com/sandbaseai/sandbase-harness/releases/tag/v0.3.0).
 - [rapidriskradar/RRR-MCP](https://github.com/rapidriskradar/RRR-MCP): Facilitates the execution of RRR scripts through a configurable MCP server interface.
 - [Quathor/CMD-Executor](https://github.com/Quathor/CMD-Executor): Facilitates remote execution of Windows CMD commands via the MCP protocol, ensuring secure and configurable command execution.
 - [JSFrouws/mcp-matlab-executor](https://github.com/JSFrouws/mcp-matlab-executor): Securely execute MATLAB functions and scripts with user-approved security prompts.
@@ -165,4 +166,3 @@ Servers designed to execute code snippets or scripts in various languages, often
 - [chrishayuk/mcp-cli](https://github.com/chrishayuk/mcp-cli): A command-line interface for interacting with Model Context Provider servers, enabling seamless communication with LLMs through a robust tool system and advanced conversation management.
 - [aviz85/my-first-mcp](https://github.com/aviz85/my-first-mcp): Facilitates natural language control of computer functions across macOS and Windows using Claude.
 - [MarkusPfundstein/cmd-line-executor-MCP](https://github.com/MarkusPfundstein/cmd-line-executor-MCP): Facilitates command line execution through an MCP server interface, returning execution results like stdout and status codes.
-


### PR DESCRIPTION
## Summary

Add SandBase Harness to the **Code Execution** category and provide a structured MCP Index metadata sidecar.

The entry describes the v0.3.1 stdio MCP bridge for persistent sandboxed agent sessions. The metadata enables TensorBlock to generate a searchable profile and install-config preview with:

- immutable source release and documentation
- source-build command and a repository-owned MCP Dockerfile
- stdio transport and optional runtime API-key boundary
- DeepSeek Harness client compatibility
- all six exposed MCP tools
- Apache-2.0 license and self-reported verification evidence

## Validation

- `npm run typecheck`
- `npm test` — 13 test files, 77 tests passed
- `npm run catalog:build` — 7,761 entries generated; the expected `github-sandbaseai-sandbase-harness-7a5986ca` profile resolved with `installReady: true`
- `git diff --check`

The v0.3.1 upstream release gate independently passed 572 tests (15 skipped), production builds, package validation, and CLI/workspace smoke coverage. The upstream Dockerfile was subsequently built successfully in GitHub CI as part of sandbaseai/sandbase-harness#35.

Disclosure: this contribution was prepared with AI assistance for the SandBase project.