### PR TITLE
Add Orizn Visa MCP server to Travel & Transportation

### DIFF
--- a/docs/travel--transportation.md
+++ b/docs/travel--transportation.md
@@ -2,6 +2,7 @@
 
 Servers providing data or services related to flights, trains, transportation APIs, or travel planning.
 
+- [mattjeff/orizn-mcp-server](https://github.com/mattjeff/orizn-mcp-server): Visa and entry requirements for 199 passports across 232 destinations in 15 languages, from the Orizn Visa API. Each answer carries the date that passport/destination pair was last verified, and covers non-sovereign territories (Aruba, Curaçao, Cayman, Greenland, Guam, Gibraltar) that most visa datasets omit. Free tier, no card.
 - [MAQAMI Travel](https://github.com/negm17111995/mcp-server): Hosted hotel and flight search, prebooking, and booking tools with direct booking links and coverage across 249 countries. Streamable HTTP endpoint at `https://mcp.maqami.co`; no auth required.
 - [OctoTrip/rental-cars](https://github.com/OctoTrip/rental-cars): Free rental car search with real-time pricing from multiple providers worldwide. No API key or login required. Returns cars grouped by category (economy, compact, SUV, etc.) with per-day pricing, vendor details, and booking links. Remote Streamable HTTP endpoint at `https://mcp.octotrip.app/rental-cars/mcp`.
 - [drivly/auto-dev-skill](https://github.com/drivly/auto-dev-skill): Automotive data APIs for AI agents — VIN decode, vehicle listings, payments, recalls, and specs.


### PR DESCRIPTION
The Travel & Transportation list covers flights, hotels, rentals, rail and EV charging — but nothing for entry requirements, which is the check that decides whether a trip happens at all.

**[mattjeff/orizn-mcp-server](https://github.com/mattjeff/orizn-mcp-server)** exposes the Orizn Visa API to agents: 199 passports × 232 destinations, 15 languages, free tier without a card.

Two things that matter for an agent answering a travel question: every response carries the date that specific passport/destination pair was last verified, so a model can say how fresh the answer is instead of asserting it; and the dataset covers non-sovereign territories (Aruba, Curaçao, Cayman Islands, Greenland, Guam, Gibraltar, Falklands) that most visa datasets return as 404 — collected from the official government sources of each territory.