### PR TITLE
metadata: enrich Nexus Shell Agent Bridge profile

### DIFF
--- a/data/server-metadata/github-viewer12-nexus-shell-releases-faa8c815.json
+++ b/data/server-metadata/github-viewer12-nexus-shell-releases-faa8c815.json
@@ -5,6 +5,9 @@
     "issue": 1637,
     "projectUrl": "https://github.com/viewer12/Nexus-Shell-Releases"
   },
+  "links": {
+    "docs": "https://nexusshell.app/agent-bridge"
+  },
   "transport": [
     "stdio"
   ],
@@ -18,5 +21,20 @@
     "Cursor",
     "and other local MCP clients that support stdio"
   ],
+  "tools": {
+    "count": 26,
+    "source": "self_reported"
+  },
+  "verification": {
+    "status": "self_reported",
+    "notes": [
+      "The bundled stdio launcher is created locally after the direct-download or Homebrew build starts with Agent Bridge enabled; saved passwords and private keys are not returned to MCP clients."
+    ]
+  },
+  "community": {
+    "maintainedBy": [
+      "viewer12"
+    ]
+  },
   "license": "Proprietary macOS app; Agent Bridge core is available on the Free tier."
 }


### PR DESCRIPTION
## Summary

- link the canonical Agent Bridge documentation
- record the 26-tool surface as self-reported metadata
- identify the project maintainer and document the local launcher prerequisite

I am the Nexus Shell developer. I intentionally left `install.commands` unset: the stdio launcher is created locally only after the direct-download or Homebrew app starts with Agent Bridge enabled, so a generic package command would be misleading.

## Validation

- `npm test` (77 tests)
- `npm run typecheck`
- `git diff --check`

The metadata uses only fields already defined in `schemas/server-metadata.schema.json`.