### PR TITLE
fix(entia): profile JSON says 34 countries; live server reports 10 (+ toolCount 12)

### DIFF
--- a/data/profiles/github-entia-ia-entia-mcp-server-61e034a8.json
+++ b/data/profiles/github-entia-ia-entia-mcp-server-61e034a8.json
@@ -1,7 +1,7 @@
 {
   "id": "github-entia-ia-entia-mcp-server-61e034a8",
   "name": "ENTIA",
-  "description": "Verified business-identity intelligence for AI agents and MCP clients, covering company verification, VAT, BORME, GLEIF, ownership, and risk signals across 34 countries. Remote streamable HTTP endpoint at `https://mcp.entia.systems/mcp`; free tier available via `npx mcp-remote https://mcp.entia.systems/mcp`. MCP Registry id `io.github.entia-systems-core/entity-verification`. MIT.",
+  "description": "Verified business-identity intelligence for AI agents and MCP clients, covering company verification, VAT, BORME, GLEIF, ownership, and risk signals across 10 countries. Remote streamable HTTP endpoint at `https://mcp.entia.systems/mcp`; free tier available via `npx mcp-remote https://mcp.entia.systems/mcp`. MCP Registry id `io.github.entia-systems-core/entity-verification`. MIT.",
   "category": "Finance & Crypto",
   "profileUrl": "https://tensorblock.co/mcp/servers/github-entia-ia-entia-mcp-server-61e034a8",
   "badgeMarkdown": "[![Indexed on TensorBlock MCP Index](https://mcp-index.tensorblock.co/v1/servers/github-entia-ia-entia-mcp-server-61e034a8/badge.svg)](https://tensorblock.co/mcp/servers/github-entia-ia-entia-mcp-server-61e034a8)",
@@ -53,6 +53,6 @@
     "installConfidence": "medium",
     "installReady": true,
     "verification": "unknown",
-    "toolCount": null
+    "toolCount": 12
   }
 }


### PR DESCRIPTION
Maintainer of `ENTIA-IA/entia-mcp-server` here.

`data/profiles/github-entia-ia-entia-mcp-server-61e034a8.json` carries a stale claim: *"risk signals across 34 countries"*, and `summary.toolCount: null`. Both are verifiable against the live server.

Countries and entity count (measured today):

```
POST https://mcp.entia.systems/mcp
{"jsonrpc":"2.0","id":1,"method":"tools/call",
 "params":{"name":"get_platform_stats","arguments":{}}}

-> {"total_entities": 11330392, "countries_active": 10, "borme_acts": 40345410, ...}
```

Tool count:

```
POST https://mcp.entia.systems/mcp
{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}

-> 12 tools: entity_lookup, search_entities, verify_vat, zone_profile,
   get_competitors, get_showcase, professional_lookup, get_full_dossier,
   get_platform_stats, run_risk_audit, get_entia_home, get_entity_home_projection
```

Same figures in our official MCP Registry entry, `io.github.entia-systems-core/entity-verification` v4.4.0 (status `active`): *"11.3M entities, 10 countries, 12 tools. EU VAT (VIES), BORME, GLEIF, KYB. Free: 100 req/month."*
Check with: `curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=entia"`

This PR changes only that profile JSON: `34 countries` -> `10 countries`, `toolCount: null` -> `12`. `docs/finance--crypto.md` is already correct on `main` and is untouched here.

Overlap note: PR #1811 (also from us) targets the markdown entry only, and I flagged this JSON there as a heads-up for your indexer. This PR is the actual JSON fix; the two do not touch the same file, so they should not conflict. Close whichever is redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
