### PR TITLE
Remove stale propzapi sports entry (repurposed to image/PDF)

### DIFF
--- a/docs/sport.md
+++ b/docs/sport.md
@@ -2,7 +2,6 @@
 
 Servers providing access to sports-related APIs and analysis.
 
-- [propzapi](https://github.com/paperandbeyond23-gif/propzapi-skills): Hosted Streamable HTTP MCP server for live sports odds and player props across US sportsbooks, with moneyline, spread, total, event, and sportsbook tools. Endpoint: `https://api.propzapi.com/mcp` with `PROPZAPI_KEY`; free tier available. MIT-0.
 - [dhrbtjr0331/nba-stats-predictor-mcp](https://github.com/dhrbtjr0331/nba-stats-predictor-mcp): Generates NBA player performance forecasts using real-time data analysis and advanced statistical modeling.
 - [JamsusMaximus/trainingpeaks-mcp](https://github.com/JamsusMaximus/trainingpeaks-mcp): Accesses TrainingPeaks training data including fitness metrics (CTL/ATL/TSB), workout history, and power/pace personal records for endurance athletes.
 - [henryco23/NBA](https://github.com/henryco23/NBA): A Python server utilizing MCP to provide comprehensive access to NBA statistics and live game data through the NBA API.


### PR DESCRIPTION
Removes the propzapi entry from the Sports category. propzapi was repurposed from a sports-odds API into an image + PDF render API with render-and-verify, so the current sports description is inaccurate. Its correct image/PDF listing lives in the Official MCP Registry (io.github.paperandbeyond23-gif/propzapi) and repo https://github.com/paperandbeyond23-gif/propzapi-skills.