### PR TITLE
Add SandBase Harness to code execution servers

### DIFF
--- a/docs/code-execution.md
+++ b/docs/code-execution.md
@@ -2,6 +2,7 @@
 
 Servers designed to execute code snippets or scripts in various languages, often in sandboxed environments.
 
+- [SandBase Harness](https://github.com/sandbaseai/sandbase-harness): Self-hosted MCP runtime for running agent sessions with local, Docker, Kubernetes, or worker sandboxes, plus tool permissions, approvals, credentials, and audit/replay. Install: `docker pull ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.8`.
 - [rapidriskradar/RRR-MCP](https://github.com/rapidriskradar/RRR-MCP): Facilitates the execution of RRR scripts through a configurable MCP server interface.
 - [Quathor/CMD-Executor](https://github.com/Quathor/CMD-Executor): Facilitates remote execution of Windows CMD commands via the MCP protocol, ensuring secure and configurable command execution.
 - [JSFrouws/mcp-matlab-executor](https://github.com/JSFrouws/mcp-matlab-executor): Securely execute MATLAB functions and scripts with user-approved security prompts.

--- a/docs/code-execution.md
+++ b/docs/code-execution.md
@@ -2,7 +2,7 @@
 
 Servers designed to execute code snippets or scripts in various languages, often in sandboxed environments.
 
-- [SandBase Harness](https://github.com/sandbaseai/sandbase-harness): Self-hosted MCP runtime for running agent sessions with local, Docker, Kubernetes, or worker sandboxes, plus tool permissions, approvals, credentials, and audit/replay. Install: `docker pull ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.8`.
+- [SandBase Harness](https://github.com/sandbaseai/sandbase-harness): Local-first, self-hosted runtime for managed agent sessions with sandbox, approvals, audit, replay, and artifact inspection controls. Its stdio MCP bridge lets clients discover agents, create and stream runs, inspect state, list artifacts, and stop sessions. Install with `docker run -i --rm -e MANAGED_AGENTS_URL -e MANAGED_AGENTS_API_KEY ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.8`. Apache-2.0.
 - [rapidriskradar/RRR-MCP](https://github.com/rapidriskradar/RRR-MCP): Facilitates the execution of RRR scripts through a configurable MCP server interface.
 - [Quathor/CMD-Executor](https://github.com/Quathor/CMD-Executor): Facilitates remote execution of Windows CMD commands via the MCP protocol, ensuring secure and configurable command execution.
 - [JSFrouws/mcp-matlab-executor](https://github.com/JSFrouws/mcp-matlab-executor): Securely execute MATLAB functions and scripts with user-approved security prompts.


### PR DESCRIPTION
## Add SandBase Harness

SandBase Harness is an MCP runtime focused on agent session execution with local, Docker, Kubernetes, and self-hosted worker sandboxes. It also provides tool permissions, approvals, credentials, and audit/replay.

The entry includes the current OCI image install reference: ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.8

Source: https://github.com/sandbaseai/sandbase-harness

Disclosure: I maintain/contribute to SandBase Harness.