### PR TITLE
Add plyo-dev/plyo-mcp (version control + build & deployment)

### DIFF
--- a/docs/build--deployment-tools.md
+++ b/docs/build--deployment-tools.md
@@ -2,6 +2,7 @@
 
 Servers interacting with build systems, containerization, CI/CD, or deployment platforms.
 
+- [plyo-dev/plyo-mcp](https://github.com/plyo-dev/plyo-mcp): Saves every AI work session as a restorable checkpoint on Plyo (plyo.dev), publishes the project to a live URL with a pre-publish secret-key scan, and backs up its database. Built for people who build with AI and don't read code. Install: `claude mcp add plyo -e PLYO_TOKEN=... -- npx plyo-mcp`. Stdio transport. MIT.
 - [friendlygeorge/docker-mcp-server](https://github.com/friendlygeorge/docker-mcp-server): Docker MCP server for container management, health checks, auto-restart, Compose lifecycle, log streaming, image, volume, network, and system diagnostics workflows. Install: `npx @supernova123/docker-mcp-server`. Stdio transport; no auth beyond local Docker socket access. MIT.
 - [zenoengine/msbuild-mcp-server](https://github.com/zenoengine/msbuild-mcp-server): Automates MSBuild project builds with dynamic discovery and customizable configurations, integrating seamlessly with various MCP clients.
 - [radostkali/gitlab-mcp-server](https://github.com/radostkali/gitlab-mcp-server): Facilitates GitLab integration using FastMCP for streamlined code review and repository management.

--- a/docs/version-control.md
+++ b/docs/version-control.md
@@ -2,7 +2,6 @@
 
 Servers interacting with version control systems and platforms for repository management, issues, pull requests, etc.
 
-- [plyo-dev/plyo-mcp](https://github.com/plyo-dev/plyo-mcp): Saves every AI work session as a restorable checkpoint on Plyo (plyo.dev), publishes the project to a live URL with a pre-publish secret-key scan, and backs up its database. Built for people who build with AI and don't read code. Install: `claude mcp add plyo -e PLYO_TOKEN=... -- npx plyo-mcp`. Stdio transport. MIT.
 - [rog0x/mcp-git-tools](https://github.com/rog0x/mcp-git-tools): Git MCP tools for repository logs, diffs, blame, branch statistics, and local version-control workflows. Install from the `@rog0x` npm package family. MIT.
 - [rog0x/mcp-github-tools](https://github.com/rog0x/mcp-github-tools): GitHub MCP tools for repository analytics, pull requests, issues, and project activity workflows. Install from the `@rog0x` npm package family. MIT.
 - [alvnavraii/MCPGithub](https://github.com/alvnavraii/MCPGithub): Facilitates efficient and secure GitHub repository management through MCP integration, offering comprehensive tools for repository, branch, and pull request operations.

--- a/docs/version-control.md
+++ b/docs/version-control.md
@@ -2,6 +2,7 @@
 
 Servers interacting with version control systems and platforms for repository management, issues, pull requests, etc.
 
+- [plyo-dev/plyo-mcp](https://github.com/plyo-dev/plyo-mcp): Saves every AI work session as a restorable checkpoint on Plyo (plyo.dev), publishes the project to a live URL with a pre-publish secret-key scan, and backs up its database. Built for people who build with AI and don't read code. Install: `claude mcp add plyo -e PLYO_TOKEN=... -- npx plyo-mcp`. Stdio transport. MIT.
 - [rog0x/mcp-git-tools](https://github.com/rog0x/mcp-git-tools): Git MCP tools for repository logs, diffs, blame, branch statistics, and local version-control workflows. Install from the `@rog0x` npm package family. MIT.
 - [rog0x/mcp-github-tools](https://github.com/rog0x/mcp-github-tools): GitHub MCP tools for repository analytics, pull requests, issues, and project activity workflows. Install from the `@rog0x` npm package family. MIT.
 - [alvnavraii/MCPGithub](https://github.com/alvnavraii/MCPGithub): Facilitates efficient and secure GitHub repository management through MCP integration, offering comprehensive tools for repository, branch, and pull request operations.


### PR DESCRIPTION
Adds [plyo-mcp](https://github.com/plyo-dev/plyo-mcp), the MCP server for [Plyo](https://plyo.dev).

Plyo is a hosting and versioning service aimed at people who build software with AI and don't code. Through the MCP server an agent can save each work session as a restorable checkpoint, publish the project to a live URL (with a secret-key scan before anything ships), start drafts with preview links, read build errors written for agents, and snapshot the project's database before risky changes.

- npm: `plyo-mcp` (v0.4.3), stdio transport
- Official MCP registry: `io.github.plyo-dev/plyo-mcp`
- License: MIT

Listed in both Version Control and Build & Deployment Tools since it spans saving versions and publishing; happy to drop either if you'd prefer a single category.