### PR TITLE
Add Busabase to Databases

### DIFF
--- a/docs/databases.md
+++ b/docs/databases.md
@@ -2,6 +2,7 @@
 
 Servers providing interfaces to various database types like SQL, NoSQL, Vector Databases, Graph Databases, Time-Series, etc.
 
+- [busabase/busabase](https://github.com/busabase/busabase): Open-source database and workspace for AI agents to manage typed tables, fields, views, records, docs, files, and search; important writes can become ChangeRequests for human review before merge. Hosted Streamable HTTP endpoint: `https://busabase.com/api/mcp` with OAuth, or self-host with `npx busabase server` or Docker. MIT. Official MCP Registry id: `com.busabase/busabase`.
 - [mcp-database-connector-lite](https://pypi.org/project/mcp-database-connector-lite/): Free SQLite MCP server for query execution, schema inspection, and data manipulation from AI assistants. Install: `pip install mcp-database-connector-lite`. MIT.
 - [rog0x/mcp-database-tools](https://github.com/rog0x/mcp-database-tools): Database MCP tools for SQL formatting, schema inspection, and migration workflows. Install from the `@rog0x` npm package family. MIT.
 - [tkz24589/mcp_mongodb](https://github.com/tkz24589/mcp_mongodb): Facilitates AI-driven interactions with MongoDB through natural language queries, supporting seamless data management and retrieval.


### PR DESCRIPTION
Adds Busabase to `docs/databases.md` as one catalog entry; no generated files are changed.

Busabase is an open-source database and workspace for AI agents. Its MCP server exposes typed tables, fields, views, records, docs, files, and search, while important writes can be submitted as ChangeRequests for human review before merge.

Verification:

- Source: https://github.com/busabase/busabase
- Hosted endpoint: `https://busabase.com/api/mcp` (Streamable HTTP + OAuth)
- Self-host: `npx busabase server` or Docker
- License: MIT
- Official MCP Registry: `com.busabase/busabase` v0.1.1, active/latest
- Duplicate search: no existing Busabase entry, issue, or PR
- Validation: catalog build reports zero errors; generated profile detects Databases, Streamable HTTP, OAuth, endpoint, install command, MIT, and `installReady: true`; 77 tests, typecheck, and build pass

Disclosure: I work on Busabase. This contribution was researched and drafted with AI assistance, then reviewed by me before submission.