### PR TITLE
Update ReadyAgents link to readyagentsdev/readyagents-core

### DIFF
--- a/docs/frameworks.md
+++ b/docs/frameworks.md
@@ -233,4 +233,4 @@ Toolkits, SDKs, starter templates, or code frameworks designed to help developer
 
 
 - [MervinPraison/praisonai-mcp](https://github.com/MervinPraison/praisonai-mcp): An AI Agents framework providing 64+ built-in MCP tools for search, memory management, workflow orchestration, code execution, and file operations. Install via uvx praisonai-mcp.
-- [ReadyAgents](https://github.com/readyagents/readyagents-core): Local one-shot YAML/JSON agent workflow CLI with tools, approvals, resume, and an optional stdio MCP server for built-in tools. Install: `pip install "readyagents[mcp]"`; run `readyagents mcp serve`. Apache-2.0, BYOK.
+- [ReadyAgents](https://github.com/readyagentsdev/readyagents-core): Local one-shot YAML/JSON agent workflow CLI with tools, approvals, resume, and an optional stdio MCP server for built-in tools. Install: `git clone https://github.com/readyagentsdev/readyagents-core && cd readyagents-core && pip install -e ".[mcp]"` (or see https://readyagents.dev); run `readyagents mcp serve`. Apache-2.0, BYOK.


### PR DESCRIPTION
## Summary
- Updates the existing ReadyAgents entry in `docs/frameworks.md` to point at the canonical repo: https://github.com/readyagentsdev/readyagents-core
- Replaces `pip install "readyagents[mcp]"` with clone + editable install (or see https://readyagents.dev), then `readyagents mcp serve`

## Notes
- Follow-up to the merged listing PR; does not re-add a duplicate entry.
- No other files changed.