### PR TITLE
Update Scoutee listing with free alerts and AI CPV discovery

### DIFF
--- a/data/server-metadata/scoutee-org-en-mcp-public-tenders-1435db60.json
+++ b/data/server-metadata/scoutee-org-en-mcp-public-tenders-1435db60.json
@@ -5,7 +5,7 @@
     "issue": 2281,
     "projectUrl": "https://scoutee.org/en/mcp-public-tenders"
   },
-  "description": "Hosted read-only public tender search MCP for Europe and North America, exposing anonymous public notice previews with buyer, location, deadline, estimated value, and Scoutee notice links.",
+  "description": "Search public tenders across Europe and North America with free previews. Find your business's EU CPV codes free on Scoutee after sign-in: AI and Scoutee's knowledge base suggest relevant codes. CPV filters are optional in workspace search; the official catalogue is public.",
   "category": "Search",
   "links": {
     "docs": "https://scoutee.org/en/mcp-public-tenders",

--- a/data/server-metadata/scoutee-org-en-mcp-public-tenders-1435db60.json
+++ b/data/server-metadata/scoutee-org-en-mcp-public-tenders-1435db60.json
@@ -5,7 +5,7 @@
     "issue": 2281,
     "projectUrl": "https://scoutee.org/en/mcp-public-tenders"
   },
-  "description": "Search public tenders across Europe and North America with free previews. Find your business's EU CPV codes free on Scoutee after sign-in: AI and Scoutee's knowledge base suggest relevant codes. CPV filters are optional in workspace search; the official catalogue is public.",
+  "description": "Search public tenders across Europe and North America with free previews. Register free on Scoutee to enable one saved search's daily email alert, capped at 20 results/search. Get your EU CPV codes free with AI and Scoutee's knowledge base. Manage alerts and AI discovery on Scoutee; MCP searches and reads notices.",
   "category": "Search",
   "links": {
     "docs": "https://scoutee.org/en/mcp-public-tenders",


### PR DESCRIPTION
Update Scoutee's existing listing with free AI CPV discovery and the free saved-search email alert now available on Scoutee.

After registering, a free account can enable one daily email alert across its free workspaces. Results are capped at 20 per search, with a three-tender email preview and the usual free search allowance on the website. AI and Scoutee's knowledge base also identify company-specific EU CPV codes after sign-in; the official catalogue remains public.

MCP continues to provide read-only tender search and notice details. Assistants direct users to Scoutee to enable an alert or discover their CPVs; no subscription-writing MCP tool is advertised.

Verified live: public plan allowance, MCP 1.3.0 initialization, signup, pricing, API documentation, and the CPV catalogue/finder. The updated metadata passes the repository's server-metadata JSON schema.
