### PR TITLE
Stop reading the word 'URL' in a description as an env var

### DIFF
--- a/.github/scripts/create-add-server-pr.mjs
+++ b/.github/scripts/create-add-server-pr.mjs
@@ -716,7 +716,7 @@ function normalizeMetadataScalar(value) {
 
 function extractEnvVars(value) {
   const matches = value.match(/\b[A-Z][A-Z0-9_]{2,}\b/g) ?? [];
-  return unique(matches.filter((match) => /(KEY|TOKEN|SECRET|PASSWORD|ENDPOINT|URL)$/.test(match)));
+  return unique(matches.filter((match) => /^.+(?:KEY|TOKEN|SECRET|PASSWORD|ENDPOINT|URL)$/.test(match)));
 }
 
 function extractEndpoint(value) {

--- a/.github/scripts/create-improve-metadata-pr.mjs
+++ b/.github/scripts/create-improve-metadata-pr.mjs
@@ -457,7 +457,7 @@ function normalizeMetadataScalar(value) {
 
 function extractEnvVars(value) {
   const matches = value.match(/\b[A-Z][A-Z0-9_]{2,}\b/g) ?? [];
-  return unique(matches.filter((match) => /(KEY|TOKEN|SECRET|PASSWORD|ENDPOINT|URL)$/.test(match)));
+  return unique(matches.filter((match) => /^.+(?:KEY|TOKEN|SECRET|PASSWORD|ENDPOINT|URL)$/.test(match)));
 }
 
 function extractFirstUrl(value) {

--- a/packages/catalog-builder/src/buildCatalog.ts
+++ b/packages/catalog-builder/src/buildCatalog.ts
@@ -347,7 +347,7 @@ function extractInstallCommands(text: string): string[] {
 
 function extractEnvVars(text: string): string[] {
   const matches = text.match(/\b[A-Z][A-Z0-9_]{2,}\b/g) ?? [];
-  return unique(matches.filter((match) => /(KEY|TOKEN|SECRET|PASSWORD|ENDPOINT|URL)$/.test(match)));
+  return unique(matches.filter((match) => /^.+(?:KEY|TOKEN|SECRET|PASSWORD|ENDPOINT|URL)$/.test(match)));
 }
 
 function extractEndpoint(text: string): string | null {

--- a/packages/catalog-builder/test/buildCatalog.test.ts
+++ b/packages/catalog-builder/test/buildCatalog.test.ts
@@ -198,7 +198,7 @@ describe("buildCatalogFromMarkdown", () => {
       "## Experimental",
       [
         "- [Metadata MCP](https://example.com/metadata-mcp):",
-        "Run `npx metadata-mcp` with API_KEY for OAuth-enabled Claude usage.",
+        "Run `npx metadata-mcp` with API_KEY against any URL for OAuth-enabled Claude usage.",
         "Includes 13 tools under MIT license.",
       ].join(" "),
     ].join("\n");


### PR DESCRIPTION
The live index is currently handing out this config:

    curl -sS 'https://mcp-index.tensorblock.co/v1/servers/github-massanaroger-extracto-mcp-86988083/install-config?client=claude-desktop'

    "command": "npx",
    "args": ["-y", "extracto-mcp"],
    "env": { "URL": "<URL>" }

Checked 2026-09-11, with `/health` reporting the index on the same commit as main, so that's not a stale build. There is no `URL` variable. Its description says:

> Turns any URL plus a JSON schema into validated, typed JSON via the Extracto API. No CSS selectors; missing fields return null instead of guesses. Install: `npx -y extracto-mcp`.

Someone copying that config into Claude Desktop is told to set a variable the project doesn't have. They may ignore it, or waste time searching the README before assuming the listing is broken or theyve missed a setup step. The profile repeats the fictional name under install env, so it offers no correction.

The tokenizer extracts all-caps words, then a suffix regex decides which look like credentails. With no left anchor, the bare suffix `URL` matches itself. Real names including `API_KEY`, `GITHUB_TOKEN` and `LNURL` still match.

The made-up name only reaches install config when an entry has a lauch command, though it appears in `install.env` on profiles either way. This doesn't make the heuristic clever: `CURL` still passes. There aren't any in the catalog now, and that could be tightened later with a real word list.

With the three source copies reverted, the fixture fails with `expected [ 'API_KEY', 'URL' ] to deeply equal [ 'API_KEY' ]`. Put back, `npx vitest run` passes 13 files and 77 tests, `node --test '.github/scripts/*.test.mjs'` passes 74 with 0 failures, and `npm run typecheck` is clean. A full rebuild keeps the same entries, drops only `URL`, and adds nothing.

All three source copies need the fix. The scripts write metadata sidecars which overide catalog detection, so leaving either unchanged can write `URL` back and make it stick. Some sidecars under `data/server-metadata/` already carry `URL` in `install.env`, `github-octotrip-rental-cars-79f20a09` among them. Nothing here touches `data/`, so they keep it until the next regeneration.
