### PR TITLE
Update Machine Library branding and primary domain

### DIFF
--- a/data/server-metadata/github-spacefrontiers-mcp-9eeddf65.json
+++ b/data/server-metadata/github-spacefrontiers-mcp-9eeddf65.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "../../schemas/server-metadata.schema.json",
+  "id": "github-spacefrontiers-mcp-9eeddf65",
+  "source": {
+    "projectUrl": "https://github.com/SpaceFrontiers/mcp"
+  },
+  "description": "Machine Library, the search and AI product by Space Frontiers, provides citable retrieval across papers, books, patents, Wikipedia, and public discussions.",
+  "links": {
+    "docs": "https://machinelibrary.ai/mcp",
+    "endpoint": "https://mcp.machinelibrary.ai/"
+  },
+  "transport": [
+    "streamable-http"
+  ],
+  "auth": {
+    "type": "oauth",
+    "notes": [
+      "OAuth 2.1 with PKCE or a bearer API key. Existing Space Frontiers accounts, API keys, and spacefrontiers_* tool names remain compatible."
+    ]
+  },
+  "license": "MIT",
+  "verification": {
+    "status": "self_reported",
+    "notes": [
+      "Branding and endpoint match the official repository and MCP Registry entry io.github.SpaceFrontiers/mcp version 0.3.2."
+    ]
+  }
+}

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -39,7 +39,7 @@ Servers or systems that deliver core runtime functionalities for MCP, such as pr
 - [tjun/terraform-doc-mcp](https://github.com/tjun/terraform-doc-mcp): Facilitates access to Terraform provider and resource documentation for integration with LLMs like Claude Desktop.
 - [jgarciaga/overseerr-mcp](https://github.com/jgarciaga/overseerr-mcp): Facilitates interaction with the Overseerr API for managing movie and TV show requests.
 - [joinbuildclub/buildclub-mcp-server](https://github.com/joinbuildclub/buildclub-mcp-server): BuildClub's official server facilitates seamless integration with Claude Desktop through MCP protocol.
-- [SpaceFrontiers/mcp](https://github.com/SpaceFrontiers/mcp): Facilitates interaction with Space Frontiers data sources via a Model Context Protocol server using FastAPI.
+- [Machine Library by Space Frontiers](https://github.com/SpaceFrontiers/mcp): Citable retrieval across papers, books, patents, Wikipedia, and public discussions. [Hosted MCP](https://mcp.machinelibrary.ai/) with OAuth or a bearer API key; [setup and documentation](https://machinelibrary.ai/mcp).
 - [adityaoberai/github-profile-mcp](https://github.com/adityaoberai/github-profile-mcp): Facilitates AI assistants in accessing and analyzing GitHub profile data and repositories through a simple API.
 - [jroyal/remote-mcp-server](https://github.com/jroyal/remote-mcp-server): Deploy a remote MCP server on Cloudflare Workers with OAuth login and connect it to Claude Desktop for seamless tool integration.
 - [BhagyaAmarasinghe/mcp-kubernetes](https://github.com/BhagyaAmarasinghe/mcp-kubernetes): Facilitates the execution of Kubernetes commands via Claude Desktop or any MCP-compatible client.


### PR DESCRIPTION
The search and AI product previously branded Space Frontiers is now **Machine Library**; **Space Frontiers** remains the company name. This updates the existing listing to reflect that split.

Primary website and setup: https://machinelibrary.ai/mcp
Hosted MCP: https://mcp.machinelibrary.ai/
Official source: https://github.com/SpaceFrontiers/mcp

Existing repository/registry identities and `spacefrontiers_*` tool names remain compatible. The old MCP endpoint still works.

Updates the category entry and adds an authored metadata sidecar with the current endpoint, setup URL, and authentication. Generated catalog/profile files are left to the normal build. Validation: JSON parses and the sidecar passes `schemas/server-metadata.schema.json`.